### PR TITLE
Refactor commonalities across all formats.

### DIFF
--- a/htsget-devtools/src/bam.rs
+++ b/htsget-devtools/src/bam.rs
@@ -7,6 +7,7 @@ use std::{collections::HashSet, path::Path};
 use bam::Record;
 use noodles_bam::{self as bam, bai};
 use noodles_bgzf::VirtualPosition;
+use noodles_csi::{BinningIndex, BinningIndexReferenceSequence};
 use noodles_sam::{self as sam};
 
 #[derive(Debug, Serialize)]

--- a/htsget-devtools/src/bcf.rs
+++ b/htsget-devtools/src/bcf.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use noodles_bcf::{self as bcf};
 use noodles_bgzf::VirtualPosition;
-use noodles_csi::{self as csi};
+use noodles_csi::{self as csi, BinningIndex, BinningIndexReferenceSequence};
 use noodles_vcf::{self as vcf};
 
 #[derive(Debug, Serialize)]

--- a/htsget-devtools/src/vcf.rs
+++ b/htsget-devtools/src/vcf.rs
@@ -4,6 +4,7 @@ use std::io::Result;
 use std::path::Path;
 
 use noodles_bgzf::{self as bgzf, VirtualPosition};
+use noodles_csi::{BinningIndex, BinningIndexReferenceSequence};
 use noodles_tabix::{self as tabix};
 use noodles_vcf::{self as vcf};
 

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -1,155 +1,54 @@
 //! Module providing the search capability using BAM/BAI files
 //!
 
-use std::{fs::File, path::Path};
+use std::path::PathBuf;
+use std::{fs::File, io};
 
-use noodles_bam::{self as bam, bai};
-use noodles_bgzf::index::{optimize_chunks, Chunk};
+use noodles_bam::bai::index::ReferenceSequence;
+use noodles_bam::bai::Index;
+use noodles_bam::{self as bam, bai, Reader};
 use noodles_bgzf::VirtualPosition;
-use noodles_sam::{self as sam};
+use noodles_csi::BinningIndex;
+use noodles_sam as sam;
+use noodles_sam::Header;
 
+use crate::htsget::search::{BgzfSearch, Search, SearchReads};
 use crate::{
-  htsget::{Class, Format, HtsGetError, Query, Response, Result, Url},
-  storage::{BytesRange, GetOptions, Storage, UrlOptions},
+  htsget::search::{BlockPosition, VirtualPositionExt},
+  htsget::{Format, Query, Result},
+  storage::{BytesRange, Storage},
 };
-
-trait VirtualPositionExt {
-  const MAX_BLOCK_SIZE: u64 = 65536;
-
-  /// Get the starting bytes for a compressed BGZF block.
-  fn bytes_range_start(&self) -> u64;
-  /// Get the ending bytes for a compressed BGZF block.
-  fn bytes_range_end(&self, reader: &mut bam::Reader<File>) -> u64;
-  fn to_string(&self) -> String;
-}
-
-impl VirtualPositionExt for VirtualPosition {
-  /// This is just an alias to compressed. Kept for consistency.
-  fn bytes_range_start(&self) -> u64 {
-    self.compressed()
-  }
-  /// The compressed part refers always to the beginning of a BGZF block.
-  /// But when we need to translate it into a byte range, we need to make sure
-  /// the reads falling inside that block are also included, which requires to know
-  /// where that block ends, which is not trivial nor possible for the last block.
-  /// The solution used here goes through reading the records starting at the compressed
-  /// virtual offset (coffset) of the end position (remember this will always be the
-  /// start of a BGZF block). If we read the records pointed by that coffset until we
-  /// reach a different coffset, we can find out where the current block ends.
-  /// Therefore this can be used to only add the required bytes in the query results.
-  /// If for some reason we can't read correctly the records we fall back
-  /// to adding the maximum BGZF block size.
-  fn bytes_range_end(&self, reader: &mut bam::Reader<File>) -> u64 {
-    if self.uncompressed() == 0 {
-      // If the uncompressed part is exactly zero, we don't need the next block
-      return self.compressed();
-    }
-    get_next_block_position(*self, reader).unwrap_or(self.compressed() + Self::MAX_BLOCK_SIZE)
-  }
-
-  fn to_string(&self) -> String {
-    format!("{}/{}", self.compressed(), self.uncompressed())
-  }
-}
-
-fn get_next_block_position(
-  block_position: VirtualPosition,
-  reader: &mut bam::Reader<File>,
-) -> Option<u64> {
-  reader.seek(block_position).ok()?;
-  let next_block_index = loop {
-    let mut record = bam::Record::default();
-    let bytes_read = reader.read_record(&mut record).ok()?;
-    let actual_block_index = reader.virtual_position().compressed();
-    if bytes_read == 0 || actual_block_index > block_position.compressed() {
-      break actual_block_index;
-    }
-  };
-  Some(next_block_index)
-}
 
 pub(crate) struct BamSearch<'a, S> {
   storage: &'a S,
 }
 
-impl<'a, S> BamSearch<'a, S>
+impl BlockPosition for bam::Reader<File> {
+  fn read_bytes(&mut self) -> Option<usize> {
+    self.read_record(&mut bam::Record::default()).ok()
+  }
+
+  fn seek(&mut self, pos: VirtualPosition) -> std::io::Result<VirtualPosition> {
+    self.seek(pos)
+  }
+
+  fn virtual_position(&self) -> VirtualPosition {
+    self.virtual_position()
+  }
+}
+
+impl<'a, S> BgzfSearch<'a, S, ReferenceSequence, bai::Index, bam::Reader<File>, sam::Header>
+  for BamSearch<'a, S>
 where
   S: Storage + 'a,
 {
-  const MIN_SEQ_POSITION: u32 = 1; // 1-based
+  type ReferenceSequenceHeader = sam::header::ReferenceSequence;
 
-  pub fn new(storage: &'a S) -> Self {
-    Self { storage }
+  fn max_seq_position(ref_seq: &Self::ReferenceSequenceHeader) -> i32 {
+    ref_seq.len()
   }
 
-  pub fn search(&self, query: Query) -> Result<Response> {
-    let (bam_key, bai_key) = self.get_keys_from_id(query.id.as_str());
-
-    match query.class {
-      Class::Body => {
-        let bai_path = self.storage.get(&bai_key, GetOptions::default())?;
-        let bai_index = bai::read(bai_path).map_err(|_| HtsGetError::io_error("Reading BAI"))?;
-
-        let byte_ranges = match query.reference_name.as_ref() {
-          None => self.get_byte_ranges_for_all_reads(bam_key.as_str(), &bai_index)?,
-          Some(reference_name) if reference_name.as_str() == "*" => {
-            self.get_byte_ranges_for_unmapped_reads(bam_key.as_str(), &bai_index)?
-          }
-          Some(reference_name) => self.get_byte_ranges_for_reference_name(
-            bam_key.as_str(),
-            reference_name,
-            &bai_index,
-            &query,
-          )?,
-        };
-        self.build_response(query, &bam_key, byte_ranges)
-      }
-      Class::Header => {
-        let byte_ranges = self.get_byte_ranges_for_header(&bam_key)?;
-        self.build_response(query, &bam_key, byte_ranges)
-      }
-    }
-  }
-
-  /// Generate a key for the storage object from an ID
-  /// This may involve a more complex transformation in the future,
-  /// or even require custom implementations depending on the organizational structure
-  /// For now there is a 1:1 mapping to the underlying files
-  fn get_keys_from_id(&self, id: &str) -> (String, String) {
-    let bam_key = format!("{}.bam", id);
-    let bai_key = format!("{}.bai", bam_key);
-    (bam_key, bai_key)
-  }
-
-  /// This returns mapped and placed unmapped ranges
-  fn get_byte_ranges_for_all_reads(
-    &self,
-    bam_key: &str,
-    bai_index: &bai::Index,
-  ) -> Result<Vec<BytesRange>> {
-    let mut byte_ranges: Vec<BytesRange> = Vec::new();
-    let get_options = GetOptions::default();
-    let bam_path = self.storage.get(bam_key, get_options)?;
-    let mut bam_reader = Self::get_bam_reader(bam_path)?;
-    for reference_sequence in bai_index.reference_sequences() {
-      if let Some(metadata) = reference_sequence.metadata() {
-        let start_vpos = metadata.start_position();
-        let end_vpos = metadata.end_position();
-        byte_ranges.push(
-          BytesRange::default()
-            .with_start(start_vpos.bytes_range_start())
-            .with_end(end_vpos.bytes_range_end(&mut bam_reader)),
-        );
-      }
-    }
-
-    let unmapped_byte_ranges = self.get_byte_ranges_for_unmapped_reads(bam_key, bai_index)?;
-    byte_ranges.extend(unmapped_byte_ranges.into_iter());
-    Ok(BytesRange::merge_all(byte_ranges))
-  }
-
-  /// This returns only unplaced unmapped ranges
-  fn get_byte_ranges_for_unmapped_reads(
+  fn get_byte_ranges_for_unmapped(
     &self,
     bam_key: &str,
     bai_index: &bai::Index,
@@ -163,9 +62,7 @@ where
     let start = match last_interval {
       Some(start) => start,
       None => {
-        let get_options = GetOptions::default();
-        let bam_path = self.storage.get(bam_key, get_options)?;
-        let (bam_reader, _) = Self::read_bam_header(&bam_path)?;
+        let (bam_reader, _) = self.create_reader(bam_key)?;
         bam_reader.virtual_position()
       }
     };
@@ -175,141 +72,102 @@ where
       BytesRange::default().with_start(start.bytes_range_start())
     ])
   }
+}
 
-  /// This returns reads for a given reference name and an optional sequence range
+impl<'a, S> Search<'a, S, ReferenceSequence, bai::Index, bam::Reader<File>, sam::Header>
+  for BamSearch<'a, S>
+where
+  S: Storage + 'a,
+{
+  const READER_FN: fn(File) -> Reader<File> = bam::Reader::new;
+  const HEADER_FN: fn(&mut Reader<File>) -> io::Result<String> = |reader| {
+    let header = reader.read_header();
+    reader.read_reference_sequences()?;
+    header
+  };
+  const INDEX_FN: fn(PathBuf) -> io::Result<Index> = bai::read;
+
   fn get_byte_ranges_for_reference_name(
     &self,
-    bam_key: &str,
+    key: &str,
     reference_name: &str,
-    bai_index: &bai::Index,
+    index: &Index,
     query: &Query,
   ) -> Result<Vec<BytesRange>> {
-    let get_options = GetOptions::default();
-    let bam_path = self.storage.get(bam_key, get_options)?;
-    let (mut bam_reader, bam_header) = Self::read_bam_header(&bam_path)?;
-    let maybe_bam_ref_seq = bam_header.reference_sequences().get_full(reference_name);
-
-    let byte_ranges = match maybe_bam_ref_seq {
-      None => Err(HtsGetError::not_found(format!(
-        "Reference name not found: {}",
-        reference_name
-      ))),
-      Some((bam_ref_seq_idx, _, bam_ref_seq)) => {
-        let seq_start = query.start.map(|start| start as i32);
-        let seq_end = query.end.map(|end| end as i32);
-        Self::get_byte_ranges_for_reference_sequence(
-          bam_ref_seq,
-          bam_ref_seq_idx,
-          bai_index,
-          seq_start,
-          seq_end,
-          &mut bam_reader,
-        )
-      }
-    }?;
-    Ok(byte_ranges)
+    self.get_byte_ranges_for_reference_name_reads(key, reference_name, index, query)
   }
 
-  fn read_bam_header<P: AsRef<Path>>(path: P) -> Result<(bam::Reader<File>, sam::Header)> {
-    let mut bam_reader = Self::get_bam_reader(path)?;
-
-    let bam_header = bam_reader
-      .read_header()
-      .map_err(|_| HtsGetError::io_error("Reading BAM header"))?
-      .parse()
-      .map_err(|_| HtsGetError::io_error("Parsing BAM header"))?;
-
-    Ok((bam_reader, bam_header))
+  fn get_keys_from_id(&self, id: &str) -> (String, String) {
+    let bam_key = format!("{}.bam", id);
+    let bai_key = format!("{}.bai", bam_key);
+    (bam_key, bai_key)
   }
 
-  fn get_bam_reader<P: AsRef<Path>>(path: P) -> Result<bam::Reader<File>> {
-    File::open(path.as_ref())
-      .map(bam::Reader::new)
-      .map_err(|_| HtsGetError::io_error("Reading BAM"))
+  fn get_storage(&self) -> &S {
+    self.storage
+  }
+
+  fn get_format(&self) -> Format {
+    Format::Bam
+  }
+}
+
+impl<'a, S> SearchReads<'a, S, ReferenceSequence, bai::Index, bam::Reader<File>, sam::Header>
+  for BamSearch<'a, S>
+where
+  S: Storage + 'a,
+{
+  fn get_reference_sequence_from_name<'b>(
+    &self,
+    header: &'b Header,
+    name: &str,
+  ) -> Option<(
+    usize,
+    &'b String,
+    &'b noodles_sam::header::ReferenceSequence,
+  )> {
+    header.reference_sequences().get_full(name)
+  }
+
+  fn get_byte_ranges_for_unmapped_reads(
+    &self,
+    bam_key: &str,
+    bai_index: &Index,
+  ) -> Result<Vec<BytesRange>> {
+    self.get_byte_ranges_for_unmapped(bam_key, bai_index)
   }
 
   fn get_byte_ranges_for_reference_sequence(
-    bam_ref_seq: &sam::header::ReferenceSequence,
-    bam_ref_seq_idx: usize,
-    bai_index: &bai::Index,
-    seq_start: Option<i32>,
-    seq_end: Option<i32>,
-    bam_reader: &mut bam::Reader<File>,
-  ) -> Result<Vec<BytesRange>> {
-    let seq_start = seq_start.unwrap_or(Self::MIN_SEQ_POSITION as i32);
-    let seq_end = seq_end.unwrap_or_else(|| bam_ref_seq.len());
-    let bai_ref_seq = bai_index
-      .reference_sequences()
-      .get(bam_ref_seq_idx)
-      .ok_or_else(|| {
-        HtsGetError::not_found(format!(
-          "Reference not found in the BAI file: {} ({})",
-          bam_ref_seq.name(),
-          bam_ref_seq_idx
-        ))
-      })?;
-
-    let chunks: Vec<Chunk> = bai_ref_seq
-      .query(seq_start..=seq_end)
-      .map_err(|_| HtsGetError::InvalidRange(format!("{}-{}", seq_start, seq_end)))?
-      .into_iter()
-      .flat_map(|bin| bin.chunks())
-      .cloned()
-      .collect();
-
-    let min_offset = bai_ref_seq.min_offset(seq_start);
-
-    let byte_ranges = optimize_chunks(&chunks, min_offset)
-      .into_iter()
-      .map(|chunk| {
-        BytesRange::default()
-          .with_start(chunk.start().bytes_range_start())
-          .with_end(chunk.end().bytes_range_end(bam_reader))
-      })
-      .collect();
-
-    Ok(BytesRange::merge_all(byte_ranges))
-  }
-
-  /// Returns the header bytes range.
-  fn get_byte_ranges_for_header(&self, bam_key: &str) -> Result<Vec<BytesRange>> {
-    let get_options = GetOptions::default();
-    let bam_path = self.storage.get(bam_key, get_options)?;
-    let (mut reader, _) = Self::read_bam_header(&bam_path)?;
-    reader.read_reference_sequences()?;
-    Ok(vec![BytesRange::default().with_start(0).with_end(
-      reader.virtual_position().bytes_range_end(&mut reader),
-    )])
-  }
-
-  /// Build the response from the query using urls.
-  fn build_response(
     &self,
-    query: Query,
-    bam_key: &str,
-    byte_ranges: Vec<BytesRange>,
-  ) -> Result<Response> {
-    let urls = byte_ranges
-      .into_iter()
-      .map(|range| {
-        let options = UrlOptions::default()
-          .with_range(range)
-          .with_class(query.class.clone());
-        self
-          .storage
-          .url(&bam_key, options)
-          .map_err(HtsGetError::from)
-      })
-      .collect::<Result<Vec<Url>>>()?;
+    ref_seq: &sam::header::ReferenceSequence,
+    ref_seq_id: usize,
+    query: &Query,
+    index: &Index,
+    reader: &mut Reader<File>,
+  ) -> Result<Vec<BytesRange>> {
+    self.get_byte_ranges_for_reference_sequence_bgzf(
+      ref_seq,
+      ref_seq_id,
+      &index,
+      query.start.map(|start| start as i32),
+      query.end.map(|end| end as i32),
+      reader,
+    )
+  }
+}
 
-    let format = query.format.unwrap_or(Format::Bam);
-    Ok(Response::new(format, urls))
+impl<'a, S> BamSearch<'a, S>
+where
+  S: Storage + 'a,
+{
+  pub fn new(storage: &'a S) -> Self {
+    Self { storage }
   }
 }
 
 #[cfg(test)]
 pub mod tests {
-  use crate::htsget::Headers;
+  use crate::htsget::{Class, Headers, Response, Url};
   use crate::storage::local::LocalStorage;
 
   use super::*;

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -1,164 +1,73 @@
 //! Module providing the search capability using BCF files
 //!
 
-use std::{fs::File, path::Path};
+use std::marker::PhantomData;
+use std::path::PathBuf;
+use std::{fs::File, io};
 
-use noodles_bcf::{self as bcf};
-use noodles_bgzf::{
-  index::{optimize_chunks, Chunk},
-  VirtualPosition,
-};
-use noodles_csi::{self as csi};
-use noodles_vcf::{self as vcf};
+use noodles_bcf as bcf;
+use noodles_bcf::Reader;
+use noodles_bgzf::VirtualPosition;
+use noodles_csi::index::ReferenceSequence;
+use noodles_csi::{self as csi, Index};
+use noodles_vcf as vcf;
 
+use crate::htsget::search::{BgzfSearch, BlockPosition, Search};
 use crate::{
-  htsget::{Class, Format, HtsGetError, Query, Response, Result, Url},
-  storage::{BytesRange, GetOptions, Storage, UrlOptions},
+  htsget::{Format, HtsGetError, Query, Result},
+  storage::{BytesRange, Storage},
 };
-
-// TODO: This trait is clearly common across, **at least**, VCF, BCF and BAM
-trait VirtualPositionExt {
-  const MAX_BLOCK_SIZE: u64 = 65536;
-
-  /// Get the starting bytes for a compressed BGZF block.
-  fn bytes_range_start(&self) -> u64;
-  /// Get the ending bytes for a compressed BGZF block.
-  fn bytes_range_end(&self, reader: &mut bcf::Reader<File>) -> u64;
-  fn to_string(&self) -> String;
-}
-
-impl VirtualPositionExt for VirtualPosition {
-  /// This is just an alias to compressed. Kept for consistency.
-  fn bytes_range_start(&self) -> u64 {
-    self.compressed()
-  }
-  /// The compressed part refers always to the beginning of a BGZF block.
-  /// But when we need to translate it into a byte range, we need to make sure
-  /// the reads falling inside that block are also included, which requires to know
-  /// where that block ends, which is not trivial nor possible for the last block.
-  /// The solution used here goes through reading the records starting at the compressed
-  /// virtual offset (coffset) of the end position (remember this will always be the
-  /// start of a BGZF block). If we read the records pointed by that coffset until we
-  /// reach a different coffset, we can find out where the current block ends.
-  /// Therefore this can be used to only add the required bytes in the query results.
-  /// If for some reason we can't read correctly the records we fall back
-  /// to adding the maximum BGZF block size.
-  fn bytes_range_end(&self, reader: &mut bcf::Reader<File>) -> u64 {
-    if self.uncompressed() == 0 {
-      // If the uncompressed part is exactly zero, we don't need the next block
-      return self.compressed();
-    }
-    get_next_block_position(*self, reader).unwrap_or(self.compressed() + Self::MAX_BLOCK_SIZE)
-  }
-
-  fn to_string(&self) -> String {
-    format!("{}/{}", self.compressed(), self.uncompressed())
-  }
-}
-
-fn get_next_block_position(
-  block_position: VirtualPosition,
-  reader: &mut bcf::Reader<File>,
-) -> Option<u64> {
-  reader.seek(block_position).ok()?.compressed();
-  let next_block_index = loop {
-    let bytes_read = reader.read_record(&mut bcf::Record::default()).ok()?;
-    let actual_block_index = reader.virtual_position().compressed();
-    if bytes_read == 0 || actual_block_index > block_position.compressed() {
-      break actual_block_index;
-    }
-  };
-  Some(next_block_index)
-}
 
 pub(crate) struct BcfSearch<'a, S> {
   storage: &'a S,
 }
 
-impl<'a, S> BcfSearch<'a, S>
+impl BlockPosition for bcf::Reader<File> {
+  fn read_bytes(&mut self) -> Option<usize> {
+    self.read_record(&mut bcf::Record::default()).ok()
+  }
+
+  fn seek(&mut self, pos: VirtualPosition) -> std::io::Result<VirtualPosition> {
+    self.seek(pos)
+  }
+
+  fn virtual_position(&self) -> VirtualPosition {
+    self.virtual_position()
+  }
+}
+
+impl<'a, S> BgzfSearch<'a, S, ReferenceSequence, csi::Index, bcf::Reader<File>, vcf::Header>
+  for BcfSearch<'a, S>
 where
   S: Storage + 'a,
 {
-  const MIN_SEQ_POSITION: i32 = 1; // 1-based
-  const MAX_SEQ_POSITION: i32 = (1 << 29) - 1; // see https://github.com/zaeleus/noodles/issues/25#issuecomment-868871298
+  type ReferenceSequenceHeader = PhantomData<Self>;
 
-  pub fn new(storage: &'a S) -> Self {
-    Self { storage }
+  fn max_seq_position(_ref_seq: &Self::ReferenceSequenceHeader) -> i32 {
+    Self::MAX_SEQ_POSITION
   }
+}
 
-  pub fn search(&self, query: Query) -> Result<Response> {
-    let (bcf_key, csi_key) = self.get_keys_from_id(query.id.as_str());
+impl<'a, S> Search<'a, S, ReferenceSequence, csi::Index, bcf::Reader<File>, vcf::Header>
+  for BcfSearch<'a, S>
+where
+  S: Storage + 'a,
+{
+  const READER_FN: fn(File) -> Reader<File> = bcf::Reader::new;
+  const HEADER_FN: fn(&mut Reader<File>) -> io::Result<String> = |reader| {
+    reader.read_file_format()?;
+    reader.read_header()
+  };
+  const INDEX_FN: fn(PathBuf) -> io::Result<Index> = csi::read;
 
-    match query.class {
-      Class::Body => {
-        let csi_path = self.storage.get(&csi_key, GetOptions::default())?;
-        let bcf_index = csi::read(csi_path).map_err(|_| HtsGetError::io_error("Reading CSI"))?;
-
-        let byte_ranges = match query.reference_name.as_ref() {
-          None => self.get_byte_ranges_for_all_variants(&bcf_index, &bcf_key)?,
-          Some(reference_name) => self.get_byte_ranges_for_reference_name(
-            bcf_key.as_str(),
-            reference_name,
-            &bcf_index,
-            &query,
-          )?,
-        };
-        self.build_response(query, &bcf_key, byte_ranges)
-      }
-      Class::Header => {
-        let byte_ranges = self.get_byte_ranges_for_header(bcf_key.as_str())?;
-        self.build_response(query, &bcf_key, byte_ranges)
-      }
-    }
-  }
-
-  /// Generate a key for the storage object from an ID
-  /// This may involve a more complex transformation in the future,
-  /// or even require custom implementations depending on the organizational structure
-  /// For now there is a 1:1 mapping to the underlying files
-  fn get_keys_from_id(&self, id: &str) -> (String, String) {
-    let bcf_key = format!("{}.bcf", id);
-    let csi_key = format!("{}.bcf.csi", id);
-    (bcf_key, csi_key)
-  }
-
-  /// Returns [byte ranges](BytesRange) that cover all the variants
-  fn get_byte_ranges_for_all_variants(
-    &self,
-    csi_index: &csi::Index,
-    bcf_key: &str,
-  ) -> Result<Vec<BytesRange>> {
-    let get_options = GetOptions::default();
-    let bcf_path = self.storage.get(bcf_key, get_options)?;
-    let (mut bcf_reader, _) = self.read_bcf(bcf_path)?;
-
-    let mut byte_ranges: Vec<BytesRange> = Vec::new();
-    for reference_sequence in csi_index.reference_sequences() {
-      if let Some(metadata) = reference_sequence.metadata() {
-        let start_vpos = metadata.start_position();
-        let end_vpos = metadata.end_position();
-        byte_ranges.push(
-          BytesRange::default()
-            .with_start(start_vpos.bytes_range_start())
-            .with_end(end_vpos.bytes_range_end(&mut bcf_reader)),
-        );
-      }
-    }
-    Ok(BytesRange::merge_all(byte_ranges))
-  }
-
-  /// Returns [byte ranges](BytesRange) containing an specific reference sequence.
-  /// Needs a Query
   fn get_byte_ranges_for_reference_name(
     &self,
-    bcf_key: &str,
+    key: &str,
     reference_name: &str,
-    csi_index: &csi::Index,
+    index: &Index,
     query: &Query,
   ) -> Result<Vec<BytesRange>> {
-    let get_options = GetOptions::default();
-    let bcf_path = self.storage.get(bcf_key, get_options)?;
-    let (mut bcf_reader, header) = Self::read_bcf(self, &bcf_path)?;
+    let (mut bcf_reader, header) = self.create_reader(key)?;
     // We are assuming the order of the contigs in the header and the references sequences
     // in the index is the same
     let (ref_seq_index, (_, contig)) = header
@@ -176,115 +85,46 @@ where
 
     let seq_start = query.start.map(|start| start as i32);
     let seq_end = query.end.map(|end| end as i32).or(maybe_len);
-    let byte_ranges = Self::get_byte_ranges_for_reference_sequence(
-      &mut bcf_reader,
+    let byte_ranges = self.get_byte_ranges_for_reference_sequence_bgzf(
+      &PhantomData,
       ref_seq_index,
-      csi_index,
+      index,
       seq_start,
       seq_end,
+      &mut bcf_reader,
     )?;
     Ok(byte_ranges)
   }
 
-  /// Creates a BCF reader and reads its header
-  fn read_bcf<P: AsRef<Path>>(&self, path: P) -> Result<(bcf::Reader<File>, vcf::Header)> {
-    let mut bcf_reader = File::open(&path)
-      .map(bcf::Reader::new)
-      .map_err(|_| HtsGetError::io_error("Reading BCF"))?;
-    let _ = bcf_reader.read_file_format()?;
-
-    let header = bcf_reader
-      .read_header()
-      .map_err(|_| HtsGetError::io_error("Reading BCF header"))?
-      .parse::<vcf::Header>()
-      .map_err(|_| HtsGetError::io_error("Parsing BCF header"))?;
-
-    Ok((bcf_reader, header))
+  fn get_keys_from_id(&self, id: &str) -> (String, String) {
+    let bcf_key = format!("{}.bcf", id);
+    let csi_key = format!("{}.bcf.csi", id);
+    (bcf_key, csi_key)
   }
 
-  /// Returns [byte ranges](BytesRange) that cover an specific reference sequence.
-  /// Needs the index of the sequence in the CSI index
-  fn get_byte_ranges_for_reference_sequence(
-    bcf_reader: &mut bcf::Reader<File>,
-    ref_seq_index: usize,
-    csi_index: &csi::Index,
-    seq_start: Option<i32>,
-    seq_end: Option<i32>,
-  ) -> Result<Vec<BytesRange>> {
-    let seq_start = seq_start.unwrap_or(Self::MIN_SEQ_POSITION);
-    let seq_end = seq_end.unwrap_or(Self::MAX_SEQ_POSITION);
-    let csi_ref_seq = csi_index
-      .reference_sequences()
-      .get(ref_seq_index)
-      .ok_or_else(|| HtsGetError::ParseError(String::from("Parsing CSI file")))?;
-
-    let chunks: Vec<Chunk> = csi_ref_seq
-      .query(
-        csi_index.min_shift(),
-        csi_index.depth(),
-        seq_start as i64..=seq_end as i64,
-      )
-      .map_err(|_| HtsGetError::InvalidRange(format!("{}-{}", seq_start, seq_end)))?
-      .into_iter()
-      .flat_map(|bin| bin.chunks())
-      .cloned()
-      .collect();
-
-    let min_offset = csi_ref_seq
-      .metadata()
-      .map(|metadata| metadata.start_position())
-      .unwrap_or_else(|| VirtualPosition::from(0));
-    let byte_ranges = optimize_chunks(&chunks, min_offset)
-      .into_iter()
-      .map(|chunk| {
-        BytesRange::default()
-          .with_start(chunk.start().bytes_range_start())
-          .with_end(chunk.end().bytes_range_end(bcf_reader))
-      })
-      .collect();
-
-    Ok(BytesRange::merge_all(byte_ranges))
+  fn get_storage(&self) -> &S {
+    self.storage
   }
 
-  /// Returns a [byte range](BytesRange) that covers the header
-  fn get_byte_ranges_for_header(&self, bcf_key: &str) -> Result<Vec<BytesRange>> {
-    let get_options = GetOptions::default();
-    let bcf_path = self.storage.get(bcf_key, get_options)?;
-    let (mut bcf_reader, _) = self.read_bcf(bcf_path)?;
-    let end = bcf_reader
-      .virtual_position()
-      .bytes_range_end(&mut bcf_reader);
-    Ok(vec![BytesRange::default().with_start(0).with_end(end)])
+  fn get_format(&self) -> Format {
+    Format::Bcf
   }
+}
 
-  /// Builts a [response](Response)
-  fn build_response(
-    &self,
-    query: Query,
-    bcf_key: &str,
-    byte_ranges: Vec<BytesRange>,
-  ) -> Result<Response> {
-    let urls = byte_ranges
-      .into_iter()
-      .map(|range| {
-        let options = UrlOptions::default()
-          .with_range(range)
-          .with_class(query.class.clone());
-        self
-          .storage
-          .url(&bcf_key, options)
-          .map_err(HtsGetError::from)
-      })
-      .collect::<Result<Vec<Url>>>()?;
+impl<'a, S> BcfSearch<'a, S>
+where
+  S: Storage + 'a,
+{
+  const MAX_SEQ_POSITION: i32 = (1 << 29) - 1; // see https://github.com/zaeleus/noodles/issues/25#issuecomment-868871298
 
-    let format = query.format.unwrap_or(Format::Bcf);
-    Ok(Response::new(format, urls))
+  pub fn new(storage: &'a S) -> Self {
+    Self { storage }
   }
 }
 
 #[cfg(test)]
 pub mod tests {
-  use crate::htsget::Headers;
+  use crate::htsget::{Class, Headers, Response, Url};
   use crate::storage::local::LocalStorage;
 
   use super::*;

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -1,211 +1,177 @@
+//! This module provides search capabilities for CRAM files.
+//!
+
 use std::convert::TryFrom;
 use std::fs::File;
-use std::io::BufReader;
+use std::io;
+use std::marker::PhantomData;
+use std::path::PathBuf;
 
 use noodles_bam::record::ReferenceSequenceId;
-use noodles_cram::{crai, Reader};
 use noodles_cram::crai::{Index, Record};
-use noodles_sam::Header;
+use noodles_cram::{self as cram, crai, Reader};
+use noodles_sam::{self as sam, Header};
 
-use crate::htsget::{Class, Format, HtsGetError, Query, Response, Result, Url};
-use crate::storage::{BytesRange, GetOptions, Storage, UrlOptions};
+use crate::htsget::search::{Search, SearchAll, SearchReads};
+use crate::htsget::{Format, HtsGetError, Query, Result};
+use crate::storage::{BytesRange, Storage};
 
 pub(crate) struct CramSearch<'a, S> {
   storage: &'a S,
 }
 
-impl<'a, S> CramSearch<'a, S>
-  where
-    S: Storage + 'a
+impl<'a, S> SearchAll<'a, S, PhantomData<Self>, Index, Reader<File>, Header> for CramSearch<'a, S>
+where
+  S: Storage + 'a,
 {
-  const FILE_DEFINITION_LENGTH: u64 = 26;
-  const EOF_CONTAINER_LENGTH: u64 = 38;
-  const MIN_SEQ_POSITION: u32 = 1; // 1-based
-
-  pub fn new(storage: &'a S) -> Self {
-    Self { storage }
+  fn get_byte_ranges_for_all(&self, key: &str, index: &Index) -> Result<Vec<BytesRange>> {
+    Self::bytes_ranges_from_index(self, key, None, None, None, index, |_| true)
   }
 
-  /// Build response from a query.
-  pub fn search(&self, query: Query) -> Result<Response> {
-    let (cram_key, crai_key) = self.get_keys_from_id(query.id.as_str());
-    let crai_index = self.read_index(&crai_key)?;
-    let header_bytes = self.get_byte_ranges_for_header(&crai_index)?;
-
-    // Currently this ignores the start and end part of the query.
-    match query.class {
-      Class::Body => {
-        let (mut cram_reader, cram_header) = self.read_header(&cram_key, header_bytes)?;
-        let byte_ranges = match query.reference_name.as_ref() {
-          None => self.get_byte_ranges_for_all_reads(&crai_index, &mut cram_reader)?,
-          Some(reference_name) if reference_name.as_str() == "*" => {
-            self.get_byte_ranges_for_unmapped_reads(&crai_index, &mut cram_reader)?
-          }
-          Some(reference_name) => self.get_byte_ranges_for_reference_name(
-              reference_name,
-              &crai_index,
-              &mut cram_reader,
-              cram_header,
-              &query,
-          )?,
-        };
-        self.build_response(query, &cram_key, byte_ranges)
-      }
-      Class::Header => {
-        self.build_response(query, &cram_key, vec![header_bytes])
-      }
-    }
-  }
-
-  /// Read index from key
-  fn read_index(&self, crai_key: &str) -> Result<Index> {
-    let crai_path = self.storage.get(&crai_key, GetOptions::default())?;
-
-    crai::read(crai_path).map_err(|_| HtsGetError::io_error("Reading CRAI"))
-  }
-
-  /// Returns the header bytes range.
-  fn get_byte_ranges_for_header(
-    &self,
-    crai_index: &[crai::Record],
-  ) -> Result<BytesRange> {
-    // Assuming that the first index represents the first data container.
-    let first_record = crai_index.first().ok_or_else(|| HtsGetError::not_found("No entries in CRAI"))?;
-    Ok(BytesRange::default()
+  fn get_byte_ranges_for_header(&self, key: &str) -> Result<Vec<BytesRange>> {
+    let (mut reader, _) = self.create_reader(key)?;
+    Ok(vec![BytesRange::default()
       .with_start(Self::FILE_DEFINITION_LENGTH)
-      .with_end(first_record.offset())
-    )
+      .with_end(reader.position()?)])
+  }
+}
+
+impl<'a, S> SearchReads<'a, S, PhantomData<Self>, Index, Reader<File>, Header> for CramSearch<'a, S>
+where
+  S: Storage + 'a,
+{
+  fn get_reference_sequence_from_name<'b>(
+    &self,
+    header: &'b Header,
+    name: &str,
+  ) -> Option<(
+    usize,
+    &'b String,
+    &'b noodles_sam::header::ReferenceSequence,
+  )> {
+    header.reference_sequences().get_full(name)
   }
 
-  /// Read header using storage options.
-  fn read_header(
+  fn get_byte_ranges_for_unmapped_reads(
     &self,
     key: &str,
-    header_bytes: BytesRange,
-  ) -> Result<(Reader<BufReader<File>>, Header)> {
-    let get_options = GetOptions::default().with_range(header_bytes);
-    let cram_path = self.storage.get(key, get_options)?;
-
-    let mut reader = File::open(cram_path)
-      .map(BufReader::new)
-      .map(noodles_cram::Reader::new)
-      .map_err(|_| HtsGetError::io_error("Reading CRAM"))?;
-
-    reader.read_file_definition().map_err(|_| HtsGetError::io_error("Reading CRAM file definition"))?;
-
-    let header = reader
-      .read_file_header()
-      .map_err(|_| HtsGetError::io_error("Reading CRAM header"))?
-      .parse()
-      .map_err(|_| HtsGetError::io_error("Parsing CRAM header"))?;
-
-    Ok((reader, header))
+    index: &Index,
+  ) -> Result<Vec<BytesRange>> {
+    Self::bytes_ranges_from_index(self, key, None, None, None, index, |record| {
+      record.reference_sequence_id().is_none()
+    })
   }
 
-  /// Get key for storage object.
+  fn get_byte_ranges_for_reference_sequence(
+    &self,
+    key: &str,
+    ref_seq: &sam::header::ReferenceSequence,
+    ref_seq_id: usize,
+    query: &Query,
+    index: &Index,
+    _reader: &mut Reader<File>,
+  ) -> Result<Vec<BytesRange>> {
+    let ref_seq_id = ReferenceSequenceId::try_from(ref_seq_id as i32)
+      .map_err(|_| HtsGetError::invalid_input("Invalid reference sequence id"))?;
+    Self::bytes_ranges_from_index(
+      self,
+      key,
+      Some(&ref_seq),
+      query.start.map(|start| start as i32),
+      query.end.map(|end| end as i32),
+      index,
+      |record| record.reference_sequence_id() == Some(ref_seq_id),
+    )
+  }
+}
+
+impl<'a, S> Search<'a, S, PhantomData<Self>, Index, Reader<File>, Header> for CramSearch<'a, S>
+where
+  S: Storage + 'a,
+{
+  const READER_FN: fn(File) -> Reader<File> = cram::Reader::new;
+  const HEADER_FN: fn(&mut Reader<File>) -> io::Result<String> = |reader| {
+    reader.read_file_definition()?;
+    reader.read_file_header()
+  };
+  const INDEX_FN: fn(PathBuf) -> io::Result<Index> = crai::read;
+
+  fn get_byte_ranges_for_reference_name(
+    &self,
+    key: &str,
+    reference_name: &str,
+    index: &Index,
+    query: &Query,
+  ) -> Result<Vec<BytesRange>> {
+    self.get_byte_ranges_for_reference_name_reads(key, reference_name, index, query)
+  }
+
   fn get_keys_from_id(&self, id: &str) -> (String, String) {
     let cram_key = format!("{}.cram", id);
     let crai_key = format!("{}.crai", cram_key);
     (cram_key, crai_key)
   }
 
-  /// Returns mapped and placed unmapped ranges
-  fn get_byte_ranges_for_all_reads(
-    &self,
-    crai_index: &[crai::Record],
-    cram_reader: &mut Reader<BufReader<File>>,
-  ) -> Result<Vec<BytesRange>> {
-    Self::bytes_ranges_from_index(
-      None,
-      None,
-      None,
-      crai_index,
-      cram_reader,
-      |_| true,
-    )
+  fn get_storage(&self) -> &S {
+    self.storage
   }
 
-  /// Returns only unplaced unmapped ranges
-  fn get_byte_ranges_for_unmapped_reads(
-    &self,
-    crai_index: &[crai::Record],
-    cram_reader: &mut Reader<BufReader<File>>,
-  ) -> Result<Vec<BytesRange>> {
-    Self::bytes_ranges_from_index(
-      None,
-      None,
-      None,
-      crai_index,
-      cram_reader,
-      |record| {
-        record.reference_sequence_id().is_none()
-      },
-    )
+  fn get_format(&self) -> Format {
+    Format::Cram
   }
+}
 
-  /// Returns reads for a given reference name and an optional sequence range
-  fn get_byte_ranges_for_reference_name(
-    &self,
-    reference_name: &str,
-    crai_index: &[crai::Record],
-    cram_reader: &mut Reader<BufReader<File>>,
-    cram_header: Header,
-    query: &Query,
-  ) -> Result<Vec<BytesRange>> {
-    let maybe_cram_ref_seq = cram_header.reference_sequences().get_full(reference_name);
+impl<'a, S> CramSearch<'a, S>
+where
+  S: Storage + 'a,
+{
+  const FILE_DEFINITION_LENGTH: u64 = 26;
+  const EOF_CONTAINER_LENGTH: u64 = 38;
 
-    let byte_ranges = match maybe_cram_ref_seq {
-      None => Err(HtsGetError::not_found(format!(
-        "Reference name not found: {}",
-        reference_name
-      ))),
-      Some((ref_seq_id, _, ref_seq)) => {
-        let cram_ref_seq_idx = ReferenceSequenceId::try_from(ref_seq_id as i32)
-          .map_err(|_| HtsGetError::invalid_input("Invalid reference sequence id"))?;
-        let seq_start = query.start.map(|start| start as i32);
-        let seq_end = query.end.map(|end| end as i32);
-        Self::bytes_ranges_from_index(
-          Some(ref_seq),
-          seq_start,
-          seq_end,
-          crai_index,
-          cram_reader,
-          |record| record.reference_sequence_id() == Some(cram_ref_seq_idx),
-        )
-      }
-    }?;
-    Ok(byte_ranges)
+  pub fn new(storage: &'a S) -> Self {
+    Self { storage }
   }
 
   /// Get bytes ranges using the index.
   fn bytes_ranges_from_index<F>(
+    &self,
+    key: &str,
     ref_seq: Option<&noodles_sam::header::ReferenceSequence>,
     seq_start: Option<i32>,
     seq_end: Option<i32>,
     crai_index: &[crai::Record],
-    cram_reader: &mut noodles_cram::Reader<BufReader<File>>,
     predicate: F,
   ) -> Result<Vec<BytesRange>>
-    where F: Fn(&Record) -> bool
+  where
+    F: Fn(&Record) -> bool,
   {
     // This could be improved by using some sort of index mapping.
-    let mut byte_ranges: Vec<BytesRange> = crai_index.iter().zip(crai_index.iter().skip(1))
+    let mut byte_ranges: Vec<BytesRange> = crai_index
+      .iter()
+      .zip(crai_index.iter().skip(1))
       .filter_map(|(record, next)| {
         if predicate(record) {
           Self::bytes_ranges_for_record(ref_seq, seq_start, seq_end, record, next)
         } else {
           None
         }
-      }).collect();
+      })
+      .collect();
 
-    let last = crai_index.last().ok_or_else(|| HtsGetError::invalid_input("No entries in CRAI"))?;
+    let last = crai_index
+      .last()
+      .ok_or_else(|| HtsGetError::invalid_input("No entries in CRAI"))?;
     if predicate(last) {
-      // An implementation based on file size might be better.
-      cram_reader.seek(std::io::SeekFrom::Start(last.offset()))?;
-      cram_reader.records().last();
-      let eof_position = cram_reader.position().map_err(|_| HtsGetError::io_error("Reading CRAM eof"))?;
-      let eof_position = eof_position - Self::EOF_CONTAINER_LENGTH;
-      byte_ranges.push(BytesRange::default().with_start(last.offset()).with_end(eof_position));
+      let file_size = self
+        .storage
+        .head(key)
+        .map_err(|_| HtsGetError::io_error("Reading CRAM file size."))?;
+      let eof_position = file_size - Self::EOF_CONTAINER_LENGTH;
+      byte_ranges.push(
+        BytesRange::default()
+          .with_start(last.offset())
+          .with_end(eof_position),
+      );
     }
 
     Ok(BytesRange::merge_all(byte_ranges))
@@ -213,62 +179,46 @@ impl<'a, S> CramSearch<'a, S>
 
   /// Gets bytes ranges for a specific index entry.
   fn bytes_ranges_for_record(
-      ref_seq: Option<&noodles_sam::header::ReferenceSequence>,
-      seq_start: Option<i32>,
-      seq_end: Option<i32>,
-      record: &Record,
-      next: &Record,
+    ref_seq: Option<&noodles_sam::header::ReferenceSequence>,
+    seq_start: Option<i32>,
+    seq_end: Option<i32>,
+    record: &Record,
+    next: &Record,
   ) -> Option<BytesRange> {
     match ref_seq {
-      None => {
-        Some(BytesRange::default().with_start(record.offset()).with_end(next.offset()))
-      }
+      None => Some(
+        BytesRange::default()
+          .with_start(record.offset())
+          .with_end(next.offset()),
+      ),
       Some(ref_seq) => {
         let seq_start = seq_start.unwrap_or(Self::MIN_SEQ_POSITION as i32);
         let seq_end = seq_end.unwrap_or_else(|| ref_seq.len());
 
-        if seq_start <= record.alignment_start() + record.alignment_span() && seq_end >= record.alignment_start() {
-          Some(BytesRange::default().with_start(record.offset()).with_end(next.offset()))
+        if seq_start <= record.alignment_start() + record.alignment_span()
+          && seq_end >= record.alignment_start()
+        {
+          Some(
+            BytesRange::default()
+              .with_start(record.offset())
+              .with_end(next.offset()),
+          )
         } else {
           None
         }
       }
     }
   }
-
-  /// Build the response from the query using urls.
-  fn build_response(
-    &self,
-    query: Query,
-    cram_key: &str,
-    byte_ranges: Vec<BytesRange>,
-  ) -> Result<Response> {
-    let urls = byte_ranges
-      .into_iter()
-      .map(|range| {
-        let options = UrlOptions::default()
-          .with_range(range)
-          .with_class(query.class.clone());
-        self
-          .storage
-          .url(&cram_key, options)
-          .map_err(HtsGetError::from)
-      })
-      .collect::<Result<Vec<Url>>>()?;
-
-    let format = query.format.unwrap_or(Format::Cram);
-    Ok(Response::new(format, urls))
-  }
 }
 
 #[cfg(test)]
 pub mod tests {
-    use crate::htsget::Headers;
-    use crate::storage::local::LocalStorage;
+  use crate::htsget::{Class, Headers, Response, Url};
+  use crate::storage::local::LocalStorage;
 
-    use super::*;
+  use super::*;
 
-    #[test]
+  #[test]
   fn search_all_reads() {
     with_local_storage(|storage| {
       let search = CramSearch::new(&storage);

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -65,7 +65,7 @@ mod tests {
       let expected_response = Ok(Response::new(
         Format::Bam,
         vec![Url::new(bam_expected_url(htsget.storage()))
-          .with_headers(Headers::default().with_header("Range", "bytes=4668-"))],
+          .with_headers(Headers::default().with_header("Range", "bytes=4668-2596799"))],
       ));
       assert_eq!(response, expected_response)
     })

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -1,6 +1,7 @@
 //! Module providing an implementation of the [HtsGet] trait using a [Storage].
 //!
 
+use crate::htsget::search::Search;
 use crate::{
   htsget::bam_search::BamSearch,
   htsget::bcf_search::BcfSearch,
@@ -25,7 +26,7 @@ where
       Some(Format::Cram) => CramSearch::new(&self.storage).search(query),
       Some(Format::Vcf) => VcfSearch::new(&self.storage).search(query),
       Some(Format::Bcf) => BcfSearch::new(&self.storage).search(query),
-      Some(Format::Unsupported(format)) => Err(HtsGetError::unsupported_format(format))
+      Some(Format::Unsupported(format)) => Err(HtsGetError::unsupported_format(format)),
     }
   }
 }
@@ -63,7 +64,7 @@ mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bam,
-        vec![Url::new(bam_expected_url(&htsget.storage()))
+        vec![Url::new(bam_expected_url(htsget.storage()))
           .with_headers(Headers::default().with_header("Range", "bytes=4668-"))],
       ));
       assert_eq!(response, expected_response)
@@ -81,7 +82,7 @@ mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Vcf,
-        vec![Url::new(vcf_expected_url(&htsget.storage(), filename))
+        vec![Url::new(vcf_expected_url(htsget.storage(), filename))
           .with_headers(Headers::default().with_header("Range", "bytes=0-823"))],
       ));
       assert_eq!(response, expected_response)

--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -3,18 +3,21 @@
 //! Based on the [HtsGet Specification](https://samtools.github.io/hts-specs/htsget.html).
 //!
 
+use std::collections::HashMap;
+use std::io;
+
+use thiserror::Error;
+
+use crate::storage::StorageError;
+use core::fmt;
+use std::fmt::Formatter;
+
 pub mod bam_search;
 pub mod bcf_search;
 pub mod cram_search;
 pub mod from_storage;
 pub mod vcf_search;
-
-use std::collections::HashMap;
-
-use thiserror::Error;
-
-use crate::storage::StorageError;
-use std::io;
+mod search;
 
 type Result<T> = core::result::Result<T, HtsGetError>;
 
@@ -175,6 +178,18 @@ impl From<Format> for String {
       Format::Vcf => "VCF".to_string(),
       Format::Bcf => "BCF".to_string(),
       Format::Unsupported(format) => format
+    }
+  }
+}
+
+impl fmt::Display for Format {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    match self {
+      Format::Bam => write!(f, "BAM"),
+      Format::Cram => write!(f, "CRAM"),
+      Format::Vcf => write!(f, "VCF"),
+      Format::Bcf => write!(f, "BCF"),
+      Format::Unsupported(format) => write!(f, "{}", format)
     }
   }
 }

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -1,0 +1,386 @@
+//! The following file defines commonalities between all the file formats. While each format has
+//! its own particularities, there are many shared components that can be abstracted.
+//!
+//! The generic types represent the specifics of the formats, and allow the abstractions to be made,
+//! where the names of the types indicate their purpose.
+//!
+
+use std::fs::File;
+use std::io;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use noodles_bgzf::VirtualPosition;
+use noodles_csi::binning_index::merge_chunks;
+use noodles_csi::{BinningIndex, BinningIndexReferenceSequence};
+use noodles_sam as sam;
+
+use crate::storage::GetOptions;
+use crate::{
+  htsget::{Class, Format, HtsGetError, Query, Response, Result, Url},
+  storage::{BytesRange, Storage, UrlOptions},
+};
+
+/// [SearchAll] represents searching bytes ranges that are applicable to all formats. Specifically,
+/// range for the whole file, and the header.
+///
+/// [ReferenceSequence] is the reference sequence type of the format's index.
+/// [Index] is the format's index type.
+/// [Reader] is the format's reader type.
+/// [Header] is the format's header type.
+pub(crate) trait SearchAll<'a, S, ReferenceSequence, Index, Reader, Header> {
+  /// This returns mapped and placed unmapped ranges.
+  fn get_byte_ranges_for_all(&self, key: &str, index: &Index) -> Result<Vec<BytesRange>>;
+
+  /// Returns the header bytes range.
+  fn get_byte_ranges_for_header(&self, key: &str) -> Result<Vec<BytesRange>>;
+}
+
+/// [SearchReads] represents searching bytes ranges for the reads endpoint.
+///
+/// [ReferenceSequence] is the reference sequence type of the format's index.
+/// [Index] is the format's index type.
+/// [Reader] is the format's reader type.
+/// [Header] is the format's header type.
+pub(crate) trait SearchReads<'a, S, ReferenceSequence, Index, Reader, Header>:
+  Search<'a, S, ReferenceSequence, Index, Reader, Header>
+where
+  S: Storage + 'a,
+  Header: FromStr,
+{
+  /// Get reference sequence from name.
+  fn get_reference_sequence_from_name<'b>(
+    &self,
+    header: &'b Header,
+    name: &str,
+  ) -> Option<(usize, &'b String, &'b sam::header::ReferenceSequence)>;
+
+  /// Get unplaced unmapped ranges.
+  fn get_byte_ranges_for_unmapped_reads(&self, key: &str, index: &Index)
+    -> Result<Vec<BytesRange>>;
+
+  /// Get reads ranges for a reference sequence implementation.
+  fn get_byte_ranges_for_reference_sequence(
+    &self,
+    key: &str,
+    reference_sequence: &sam::header::ReferenceSequence,
+    ref_seq_id: usize,
+    query: &Query,
+    index: &Index,
+    reader: &mut Reader,
+  ) -> Result<Vec<BytesRange>>;
+
+  ///Get reads for a given reference name and an optional sequence range.
+  fn get_byte_ranges_for_reference_name_reads(
+    &self,
+    key: &str,
+    reference_name: &str,
+    index: &Index,
+    query: &Query,
+  ) -> Result<Vec<BytesRange>> {
+    if reference_name == "*" {
+      return self.get_byte_ranges_for_unmapped_reads(key, &index);
+    }
+
+    let (mut reader, header) = self.create_reader(key)?;
+    let maybe_ref_seq = self.get_reference_sequence_from_name(&header, reference_name);
+
+    let byte_ranges = match maybe_ref_seq {
+      None => Err(HtsGetError::not_found(format!(
+        "Reference name not found: {}",
+        reference_name
+      ))),
+      Some((bam_ref_seq_idx, _, bam_ref_seq)) => Self::get_byte_ranges_for_reference_sequence(
+        self,
+        key,
+        bam_ref_seq,
+        bam_ref_seq_idx,
+        query,
+        index,
+        &mut reader,
+      ),
+    }?;
+    Ok(byte_ranges)
+  }
+}
+
+/// [Search] is the general trait that all formats implement, including functions from [SearchAll].
+///
+/// [ReferenceSequence] is the reference sequence type of the format's index.
+/// [Index] is the format's index type.
+/// [Reader] is the format's reader type.
+/// [Header] is the format's header type.
+pub(crate) trait Search<'a, S, ReferenceSequence, Index, Reader, Header>:
+  SearchAll<'a, S, ReferenceSequence, Index, Reader, Header>
+where
+  S: Storage + 'a,
+  Header: FromStr,
+{
+  const MIN_SEQ_POSITION: u32 = 1; // 1-based
+
+  const READER_FN: fn(File) -> Reader;
+  const HEADER_FN: fn(&mut Reader) -> io::Result<String>;
+  const INDEX_FN: fn(PathBuf) -> io::Result<Index>;
+
+  /// Get ranges for a given reference name and an optional sequence range.
+  fn get_byte_ranges_for_reference_name(
+    &self,
+    key: &str,
+    reference_name: &str,
+    index: &Index,
+    query: &Query,
+  ) -> Result<Vec<BytesRange>>;
+
+  /// Generate a key for the storage object from an ID
+  /// This may involve a more complex transformation in the future,
+  /// or even require custom implementations depending on the organizational structure
+  /// For now there is a 1:1 mapping to the underlying files
+  fn get_keys_from_id(&self, id: &str) -> (String, String);
+
+  /// Get the storage of this trait.
+  fn get_storage(&self) -> &S;
+
+  /// Get the format of this trait.
+  fn get_format(&self) -> Format;
+
+  /// Read the index from the key.
+  fn read_index(&self, key: &str) -> Result<Index> {
+    let path = self.get_storage().get(&key, GetOptions::default())?;
+    Self::INDEX_FN(path)
+      .map_err(|_| HtsGetError::io_error(format!("Reading {} index file", self.get_format())))
+  }
+
+  /// Search based on the query.
+  fn search(&self, query: Query) -> Result<Response> {
+    let (file_key, index_key) = self.get_keys_from_id(query.id.as_str());
+
+    match query.class {
+      Class::Body => {
+        let index = self.read_index(&index_key)?;
+
+        let byte_ranges = match query.reference_name.as_ref() {
+          None => self.get_byte_ranges_for_all(file_key.as_str(), &index)?,
+          Some(reference_name) => self.get_byte_ranges_for_reference_name(
+            file_key.as_str(),
+            reference_name,
+            &index,
+            &query,
+          )?,
+        };
+        self.build_response(query, &file_key, byte_ranges)
+      }
+      Class::Header => {
+        let byte_ranges = self.get_byte_ranges_for_header(&file_key)?;
+        self.build_response(query, &file_key, byte_ranges)
+      }
+    }
+  }
+
+  /// Build the response from the query using urls.
+  fn build_response(
+    &self,
+    query: Query,
+    key: &str,
+    byte_ranges: Vec<BytesRange>,
+  ) -> Result<Response> {
+    let urls = byte_ranges
+      .into_iter()
+      .map(|range| {
+        let options = UrlOptions::default()
+          .with_range(range)
+          .with_class(query.class.clone());
+        self
+          .get_storage()
+          .url(&key, options)
+          .map_err(HtsGetError::from)
+      })
+      .collect::<Result<Vec<Url>>>()?;
+
+    let format = query.format.unwrap_or_else(|| self.get_format());
+    Ok(Response::new(format, urls))
+  }
+
+  /// Get the reader from the key.
+  fn get_reader<U: Into<String>>(&self, key: &str, msg: U) -> Result<Reader> {
+    let get_options = GetOptions::default();
+    let path = self.get_storage().get(key, get_options)?;
+
+    File::open(path)
+      .map(Self::READER_FN)
+      .map_err(|_| HtsGetError::io_error(msg))
+  }
+
+  /// Get the reader and header using the key.
+  fn create_reader(&self, key: &str) -> Result<(Reader, Header)> {
+    let mut reader = self.get_reader(key, format!("Reading {}", self.get_format()))?;
+
+    let header = Self::HEADER_FN(&mut reader)
+      .map_err(|_| HtsGetError::io_error(format!("Reading {} header", self.get_format())))?
+      .parse::<Header>()
+      .map_err(|_| HtsGetError::io_error(format!("Parsing {} header", self.get_format())))?;
+
+    Ok((reader, header))
+  }
+}
+
+/// The [BgzfSearch] trait defines commonalities for the formats that use a binning index, specifically
+/// BAM, BCF, and VCF.
+///
+/// [ReferenceSequence] is the reference sequence type of the format's index.
+/// [Index] is the format's index type.
+/// [Reader] is the format's reader type.
+/// [Header] is the format's header type.
+pub(crate) trait BgzfSearch<'a, S, ReferenceSequence, Index, Reader, Header>:
+  Search<'a, S, ReferenceSequence, Index, Reader, Header>
+where
+  S: Storage + 'a,
+  Reader: BlockPosition,
+  ReferenceSequence: 'a + BinningIndexReferenceSequence,
+  Index: BinningIndex<ReferenceSequence>,
+  Header: FromStr,
+{
+  type ReferenceSequenceHeader;
+
+  /// Get the max sequence position.
+  fn max_seq_position(ref_seq: &Self::ReferenceSequenceHeader) -> i32;
+
+  /// Get ranges for a reference sequence for the bgzf format.
+  fn get_byte_ranges_for_reference_sequence_bgzf(
+    &self,
+    reference_sequence: &Self::ReferenceSequenceHeader,
+    ref_seq_id: usize,
+    index: &'a Index,
+    seq_start: Option<i32>,
+    seq_end: Option<i32>,
+    reader: &mut Reader,
+  ) -> Result<Vec<BytesRange>> {
+    let seq_start = seq_start.unwrap_or(Self::MIN_SEQ_POSITION as i32);
+    let seq_end = seq_end.unwrap_or_else(|| Self::max_seq_position(reference_sequence));
+
+    let chunks = index
+      .query(ref_seq_id, seq_start..=seq_end)
+      .map_err(|_| HtsGetError::InvalidRange(format!("{}-{}", seq_start, seq_end)))?;
+
+    let byte_ranges = merge_chunks(&chunks)
+      .into_iter()
+      .map(|chunk| {
+        BytesRange::default()
+          .with_start(chunk.start().bytes_range_start())
+          .with_end(chunk.end().bytes_range_end(reader))
+      })
+      .collect();
+
+    Ok(BytesRange::merge_all(byte_ranges))
+  }
+
+  /// Get unmapped bytes ranges.
+  fn get_byte_ranges_for_unmapped(&self, _key: &str, _index: &Index) -> Result<Vec<BytesRange>> {
+    Ok(Vec::new())
+  }
+}
+
+impl<'a, S, ReferenceSequence, Index, Reader, Header, T>
+  SearchAll<'a, S, ReferenceSequence, Index, Reader, Header> for T
+where
+  S: Storage + 'a,
+  Reader: BlockPosition,
+  Header: FromStr,
+  ReferenceSequence: 'a + BinningIndexReferenceSequence,
+  Index: BinningIndex<ReferenceSequence>,
+  T: BgzfSearch<'a, S, ReferenceSequence, Index, Reader, Header>,
+{
+  fn get_byte_ranges_for_all(&self, key: &str, index: &Index) -> Result<Vec<BytesRange>> {
+    let (mut reader, _) = self.create_reader(key)?;
+
+    let mut byte_ranges: Vec<BytesRange> = Vec::new();
+    for ref_sequences in index.reference_sequences() {
+      if let Some(metadata) = ref_sequences.metadata() {
+        let start_vpos = metadata.start_position();
+        let end_vpos = metadata.end_position();
+        byte_ranges.push(
+          BytesRange::default()
+            .with_start(start_vpos.bytes_range_start())
+            .with_end(end_vpos.bytes_range_end(&mut reader)),
+        );
+      }
+    }
+
+    let unmapped_byte_ranges = self.get_byte_ranges_for_unmapped(key, index)?;
+    byte_ranges.extend(unmapped_byte_ranges.into_iter());
+    Ok(BytesRange::merge_all(byte_ranges))
+  }
+
+  fn get_byte_ranges_for_header(&self, key: &str) -> Result<Vec<BytesRange>> {
+    let (mut reader, _) = self.create_reader(key)?;
+    Ok(vec![BytesRange::default().with_start(0).with_end(
+      reader.virtual_position().bytes_range_end(&mut reader),
+    )])
+  }
+}
+
+/// A block position extends the concept of a virtual position for readers.
+pub(crate) trait BlockPosition {
+  /// Read bytes of record.
+  fn read_bytes(&mut self) -> Option<usize>;
+  /// Seek using VirtualPosition.
+  fn seek(&mut self, pos: VirtualPosition) -> io::Result<VirtualPosition>;
+  /// Read the virtual position.
+  fn virtual_position(&self) -> VirtualPosition;
+}
+
+/// An extension trait for VirtualPosition, which defines some common functions for the Bgzf formats.
+pub(crate) trait VirtualPositionExt {
+  const MAX_BLOCK_SIZE: u64 = 65536;
+
+  /// Get the starting bytes for a compressed BGZF block.
+  fn bytes_range_start(&self) -> u64;
+  /// Get the ending bytes for a compressed BGZF block.
+  fn bytes_range_end(&self, reader: &mut dyn BlockPosition) -> u64;
+  fn to_string(&self) -> String;
+  fn get_next_block_position(&self, reader: &mut dyn BlockPosition) -> Option<u64>;
+}
+
+impl VirtualPositionExt for VirtualPosition {
+  /// This is just an alias to compressed. Kept for consistency.
+  fn bytes_range_start(&self) -> u64 {
+    self.compressed()
+  }
+  /// The compressed part refers always to the beginning of a BGZF block.
+  /// But when we need to translate it into a byte range, we need to make sure
+  /// the reads falling inside that block are also included, which requires to know
+  /// where that block ends, which is not trivial nor possible for the last block.
+  /// The solution used here goes through reading the records starting at the compressed
+  /// virtual offset (coffset) of the end position (remember this will always be the
+  /// start of a BGZF block). If we read the records pointed by that coffset until we
+  /// reach a different coffset, we can find out where the current block ends.
+  /// Therefore this can be used to only add the required bytes in the query results.
+  /// If for some reason we can't read correctly the records we fall back
+  /// to adding the maximum BGZF block size.
+  fn bytes_range_end(&self, reader: &mut dyn BlockPosition) -> u64 {
+    if self.uncompressed() == 0 {
+      // If the uncompressed part is exactly zero, we don't need the next block
+      return self.compressed();
+    }
+    self
+      .get_next_block_position(reader)
+      .unwrap_or(self.compressed() + Self::MAX_BLOCK_SIZE)
+  }
+
+  /// Convert to string.
+  fn to_string(&self) -> String {
+    format!("{}/{}", self.compressed(), self.uncompressed())
+  }
+
+  /// Get the next block position from the reader.
+  fn get_next_block_position(&self, reader: &mut dyn BlockPosition) -> Option<u64> {
+    reader.seek(*self).ok()?;
+    let next_block_index = loop {
+      let bytes_read = reader.read_bytes()?;
+      let actual_block_index = reader.virtual_position().compressed();
+      if bytes_read == 0 || actual_block_index > self.compressed() {
+        break actual_block_index;
+      }
+    };
+    Some(next_block_index)
+  }
+}

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -1,164 +1,73 @@
 //! Module providing the search capability using VCF files
 //!
 
-use std::{fs::File, path::Path};
+use std::marker::PhantomData;
+use std::path::PathBuf;
+use std::{fs::File, io};
 
-use noodles_bgzf::{
-  self as bgzf,
-  index::{optimize_chunks, Chunk},
-  VirtualPosition,
-};
-use noodles_tabix::{self as tabix};
-use noodles_vcf::{self as vcf};
+use noodles_bgzf::{self as bgzf, VirtualPosition};
+use noodles_tabix::index::ReferenceSequence;
+use noodles_tabix::{self as tabix, Index};
+use noodles_vcf as vcf;
+use noodles_vcf::Reader;
 
+use crate::htsget::search::{BgzfSearch, BlockPosition, Search};
 use crate::{
-  htsget::{Class, Format, HtsGetError, Query, Response, Result, Url},
-  storage::{BytesRange, GetOptions, Storage, UrlOptions},
+  htsget::{Format, HtsGetError, Query, Result},
+  storage::{BytesRange, Storage},
 };
-
-// TODO: This trait is clearly common across, **at least**, VCF and BAM
-trait VirtualPositionExt {
-  const MAX_BLOCK_SIZE: u64 = 65536;
-
-  /// Get the starting bytes for a compressed BGZF block.
-  fn bytes_range_start(&self) -> u64;
-  /// Get the ending bytes for a compressed BGZF block.
-  fn bytes_range_end(&self, reader: &mut vcf::Reader<bgzf::Reader<File>>) -> u64;
-  fn to_string(&self) -> String;
-}
-
-impl VirtualPositionExt for VirtualPosition {
-  /// This is just an alias to compressed. Kept for consistency.
-  fn bytes_range_start(&self) -> u64 {
-    self.compressed()
-  }
-  /// The compressed part refers always to the beginning of a BGZF block.
-  /// But when we need to translate it into a byte range, we need to make sure
-  /// the reads falling inside that block are also included, which requires to know
-  /// where that block ends, which is not trivial nor possible for the last block.
-  /// The solution used here goes through reading the records starting at the compressed
-  /// virtual offset (coffset) of the end position (remember this will always be the
-  /// start of a BGZF block). If we read the records pointed by that coffset until we
-  /// reach a different coffset, we can find out where the current block ends.
-  /// Therefore this can be used to only add the required bytes in the query results.
-  /// If for some reason we can't read correctly the records we fall back
-  /// to adding the maximum BGZF block size.
-  fn bytes_range_end(&self, reader: &mut vcf::Reader<bgzf::Reader<File>>) -> u64 {
-    if self.uncompressed() == 0 {
-      // If the uncompressed part is exactly zero, we don't need the next block
-      return self.compressed();
-    }
-    get_next_block_position(*self, reader).unwrap_or(self.compressed() + Self::MAX_BLOCK_SIZE)
-  }
-
-  fn to_string(&self) -> String {
-    format!("{}/{}", self.compressed(), self.uncompressed())
-  }
-}
-
-fn get_next_block_position(
-  block_position: VirtualPosition,
-  reader: &mut vcf::Reader<bgzf::Reader<File>>,
-) -> Option<u64> {
-  reader.seek(block_position).ok()?.compressed();
-  let next_block_index = loop {
-    let bytes_read = reader.read_record(&mut String::new()).ok()?;
-    let actual_block_index = reader.virtual_position().compressed();
-    if bytes_read == 0 || actual_block_index > block_position.compressed() {
-      break actual_block_index;
-    }
-  };
-  Some(next_block_index)
-}
 
 pub(crate) struct VcfSearch<'a, S> {
   storage: &'a S,
 }
 
-impl<'a, S> VcfSearch<'a, S>
+impl BlockPosition for vcf::Reader<bgzf::Reader<File>> {
+  fn read_bytes(&mut self) -> Option<usize> {
+    self.read_record(&mut String::new()).ok()
+  }
+
+  fn seek(&mut self, pos: VirtualPosition) -> std::io::Result<VirtualPosition> {
+    self.seek(pos)
+  }
+
+  fn virtual_position(&self) -> VirtualPosition {
+    self.virtual_position()
+  }
+}
+
+impl<'a, S>
+  BgzfSearch<'a, S, ReferenceSequence, tabix::Index, vcf::Reader<bgzf::Reader<File>>, vcf::Header>
+  for VcfSearch<'a, S>
 where
   S: Storage + 'a,
 {
-  const MIN_SEQ_POSITION: i32 = 1; // 1-based
-  const MAX_SEQ_POSITION: i32 = (1 << 29) - 1; // see https://github.com/zaeleus/noodles/issues/25#issuecomment-868871298
+  type ReferenceSequenceHeader = PhantomData<Self>;
 
-  pub fn new(storage: &'a S) -> Self {
-    Self { storage }
+  fn max_seq_position(_ref_seq: &Self::ReferenceSequenceHeader) -> i32 {
+    Self::MAX_SEQ_POSITION
   }
+}
 
-  pub fn search(&self, query: Query) -> Result<Response> {
-    let (vcf_key, tbi_key) = self.get_keys_from_id(query.id.as_str());
+impl<'a, S>
+  Search<'a, S, ReferenceSequence, tabix::Index, vcf::Reader<bgzf::Reader<File>>, vcf::Header>
+  for VcfSearch<'a, S>
+where
+  S: Storage + 'a,
+{
+  const READER_FN: fn(File) -> Reader<noodles_bgzf::Reader<File>> =
+    |file| vcf::Reader::new(bgzf::Reader::new(file));
+  const HEADER_FN: fn(&mut Reader<noodles_bgzf::Reader<File>>) -> io::Result<String> =
+    vcf::Reader::read_header;
+  const INDEX_FN: fn(PathBuf) -> io::Result<Index> = tabix::read;
 
-    match query.class {
-      Class::Body => {
-        let tbi_path = self.storage.get(&tbi_key, GetOptions::default())?;
-        let vcf_index = tabix::read(tbi_path).map_err(|_| HtsGetError::io_error("Reading TBI"))?;
-
-        let byte_ranges = match query.reference_name.as_ref() {
-          None => self.get_byte_ranges_for_all_variants(&vcf_index, &vcf_key)?,
-          Some(reference_name) => self.get_byte_ranges_for_reference_name(
-            vcf_key.as_str(),
-            reference_name,
-            &vcf_index,
-            &query,
-          )?,
-        };
-        self.build_response(query, &vcf_key, byte_ranges)
-      }
-      Class::Header => {
-        let byte_ranges = self.get_byte_ranges_for_header(vcf_key.as_str())?;
-        self.build_response(query, &vcf_key, byte_ranges)
-      }
-    }
-  }
-
-  /// Generate a key for the storage object from an ID
-  /// This may involve a more complex transformation in the future,
-  /// or even require custom implementations depending on the organizational structure
-  /// For now there is a 1:1 mapping to the underlying files
-  fn get_keys_from_id(&self, id: &str) -> (String, String) {
-    let vcf_key = format!("{}.vcf.gz", id);
-    let tbi_key = format!("{}.vcf.gz.tbi", id);
-    (vcf_key, tbi_key)
-  }
-
-  /// Returns [byte ranges](BytesRange) that cover all the variants
-  fn get_byte_ranges_for_all_variants(
-    &self,
-    tbi_index: &tabix::Index,
-    vcf_key: &str,
-  ) -> Result<Vec<BytesRange>> {
-    let get_options = GetOptions::default();
-    let vcf_path = self.storage.get(vcf_key, get_options)?;
-    let (mut vcf_reader, _) = self.read_vcf(vcf_path)?;
-
-    let mut byte_ranges: Vec<BytesRange> = Vec::new();
-    for reference_sequence in tbi_index.reference_sequences() {
-      if let Some(metadata) = reference_sequence.metadata() {
-        let start_vpos = metadata.start_position();
-        let end_vpos = metadata.end_position();
-        byte_ranges.push(
-          BytesRange::default()
-            .with_start(start_vpos.bytes_range_start())
-            .with_end(end_vpos.bytes_range_end(&mut vcf_reader)),
-        );
-      }
-    }
-    Ok(BytesRange::merge_all(byte_ranges))
-  }
-
-  /// Returns [byte ranges](BytesRange) containing an specific reference sequence.
-  /// Needs a Query
   fn get_byte_ranges_for_reference_name(
     &self,
-    vcf_key: &str,
+    key: &str,
     reference_name: &str,
-    tbi_index: &tabix::Index,
+    index: &Index,
     query: &Query,
   ) -> Result<Vec<BytesRange>> {
-    let get_options = GetOptions::default();
-    let vcf_path = self.storage.get(vcf_key, get_options)?;
-    let (mut vcf_reader, vcf_header) = Self::read_vcf(self, &vcf_path)?;
+    let (mut vcf_reader, vcf_header) = self.create_reader(key)?;
     let maybe_len = vcf_header
       .contigs()
       .get(reference_name)
@@ -166,7 +75,7 @@ where
 
     // We are assuming the order of the names and the references sequences
     // in the index is the same
-    let ref_seq_index = tbi_index
+    let ref_seq_index = index
       .reference_sequence_names()
       .iter()
       .enumerate()
@@ -181,114 +90,47 @@ where
 
     let seq_start = query.start.map(|start| start as i32);
     let seq_end = query.end.map(|end| end as i32).or(maybe_len);
-    let byte_ranges = Self::get_byte_ranges_for_reference_sequence(
-      &mut vcf_reader,
+    let byte_ranges = self.get_byte_ranges_for_reference_sequence_bgzf(
+      &PhantomData,
       ref_seq_index,
-      tbi_index,
+      index,
       seq_start,
       seq_end,
+      &mut vcf_reader,
     )?;
     Ok(byte_ranges)
   }
 
-  /// Creates a VCF reader and reads its header
-  fn read_vcf<P: AsRef<Path>>(
-    &self,
-    path: P,
-  ) -> Result<(
-    vcf::Reader<noodles_bgzf::Reader<std::fs::File>>,
-    vcf::Header,
-  )> {
-    let mut vcf_reader = File::open(&path)
-      .map(bgzf::Reader::new)
-      .map(vcf::Reader::new)
-      .map_err(|_| HtsGetError::io_error("Reading VCF"))?;
-
-    let vcf_header = vcf_reader
-      .read_header()
-      .map_err(|_| HtsGetError::io_error("Reading VCF header"))?
-      .parse()
-      .map_err(|_| HtsGetError::io_error("Parsing VCF header"))?;
-
-    Ok((vcf_reader, vcf_header))
+  fn get_keys_from_id(&self, id: &str) -> (String, String) {
+    let vcf_key = format!("{}.vcf.gz", id);
+    let tbi_key = format!("{}.vcf.gz.tbi", id);
+    (vcf_key, tbi_key)
   }
 
-  /// Returns [byte ranges](BytesRange) that cover an specific reference sequence.
-  /// Needs the index of the sequence in the Tabix index
-  fn get_byte_ranges_for_reference_sequence(
-    vcf_reader: &mut vcf::Reader<bgzf::Reader<File>>,
-    ref_seq_index: usize,
-    tbi_index: &tabix::Index,
-    seq_start: Option<i32>,
-    seq_end: Option<i32>,
-  ) -> Result<Vec<BytesRange>> {
-    let seq_start = seq_start.unwrap_or(Self::MIN_SEQ_POSITION);
-    let seq_end = seq_end.unwrap_or(Self::MAX_SEQ_POSITION);
-    let tbi_ref_seq = tbi_index
-      .reference_sequences()
-      .get(ref_seq_index)
-      .ok_or_else(|| HtsGetError::ParseError(String::from("Parsing TBI file")))?;
-
-    let chunks: Vec<Chunk> = tbi_ref_seq
-      .query(seq_start..=seq_end)
-      .map_err(|_| HtsGetError::InvalidRange(format!("{}-{}", seq_start, seq_end)))?
-      .into_iter()
-      .flat_map(|bin| bin.chunks())
-      .cloned()
-      .collect();
-
-    let min_offset = tbi_ref_seq.min_offset(seq_start);
-    let byte_ranges = optimize_chunks(&chunks, min_offset)
-      .into_iter()
-      .map(|chunk| {
-        BytesRange::default()
-          .with_start(chunk.start().bytes_range_start())
-          .with_end(chunk.end().bytes_range_end(vcf_reader))
-      })
-      .collect();
-
-    Ok(BytesRange::merge_all(byte_ranges))
+  fn get_storage(&self) -> &S {
+    self.storage
   }
 
-  /// Returns a [byte range](BytesRange) that covers the header
-  fn get_byte_ranges_for_header(&self, vcf_key: &str) -> Result<Vec<BytesRange>> {
-    let get_options = GetOptions::default();
-    let vcf_path = self.storage.get(vcf_key, get_options)?;
-    let (mut vcf_reader, _) = self.read_vcf(vcf_path)?;
-    let end = vcf_reader
-      .virtual_position()
-      .bytes_range_end(&mut vcf_reader);
-    Ok(vec![BytesRange::default().with_start(0).with_end(end)])
+  fn get_format(&self) -> Format {
+    Format::Vcf
   }
+}
 
-  /// Builts a [response](Response)
-  fn build_response(
-    &self,
-    query: Query,
-    vcf_key: &str,
-    byte_ranges: Vec<BytesRange>,
-  ) -> Result<Response> {
-    let urls = byte_ranges
-      .into_iter()
-      .map(|range| {
-        let options = UrlOptions::default()
-          .with_range(range)
-          .with_class(query.class.clone());
-        self
-          .storage
-          .url(&vcf_key, options)
-          .map_err(HtsGetError::from)
-      })
-      .collect::<Result<Vec<Url>>>()?;
+impl<'a, S> VcfSearch<'a, S>
+where
+  S: Storage + 'a,
+{
+  // 1-based
+  const MAX_SEQ_POSITION: i32 = (1 << 29) - 1; // see https://github.com/zaeleus/noodles/issues/25#issuecomment-868871298
 
-    let format = query.format.unwrap_or(Format::Vcf);
-    Ok(Response::new(format, urls))
+  pub fn new(storage: &'a S) -> Self {
+    Self { storage }
   }
 }
 
 #[cfg(test)]
 pub mod tests {
-  use crate::htsget::Headers;
+  use crate::htsget::{Class, Headers, Response, Url};
   use crate::storage::local::LocalStorage;
 
   use super::*;


### PR DESCRIPTION
This refactors some commonalities across the formats, by creating a trait. Currently there is further duplicate code, however this will be removed upon completing this pull request.

Closes #48.