### PR TITLE
Make service-info only show the formats available in that endpoint

### DIFF
--- a/htsget-http-core/src/service_info.rs
+++ b/htsget-http-core/src/service_info.rs
@@ -1,4 +1,4 @@
-use crate::Endpoint;
+use crate::{Endpoint, READS_FORMATS, VARIANTS_FORMATS};
 use htsget_search::htsget::HtsGet;
 use serde::{Deserialize, Serialize};
 
@@ -59,6 +59,10 @@ pub fn get_service_info_json(endpoint: Endpoint, searcher: &impl HtsGet) -> Serv
       .get_supported_formats()
       .iter()
       .map(|format| format.to_string())
+      .filter(|format| match endpoint {
+        Endpoint::Reads => READS_FORMATS.contains(&format.as_str()),
+        Endpoint::Variants => VARIANTS_FORMATS.contains(&format.as_str()),
+      })
       .collect(),
     fields_parameters_effective: searcher.are_field_parameters_effective(),
     tags_parameters_effective: searcher.are_tag_parameters_effective(),


### PR DESCRIPTION
This is how it works in the reference implementation and it also seems clearer. Reporting in both endpoints (reads and variants) the formats supported in the whole server can cause confusions. For example, if I got from 'reads/service-info' a response saying 'VCF' is a supported format, I could be really surprised when requesting a 'VCF' format to the reads endpoint ended in an unsupported format error.

Didn't notice this when I implemented it, but it seems better now.