### PR TITLE
Add hstget container to response

### DIFF
--- a/htsget-http-core/src/json_response.rs
+++ b/htsget-http-core/src/json_response.rs
@@ -7,19 +7,33 @@ use serde::Serialize;
 /// so it's trivial to convert to JSON.
 #[derive(Debug, PartialEq, Serialize)]
 pub struct JsonResponse {
-  format: String,
-  urls: Vec<JsonUrl>,
+  htsget: HtsGetResponse,
 }
 
 impl JsonResponse {
   /// Converts a [Response] to JSON
   pub fn from_response(response: Response) -> Self {
+    let htsget = HtsGetResponse::new(response);
+    JsonResponse { htsget }
+  }
+}
+
+/// A helper struct to represent a JSON response. It shouldn't be used
+/// on its own, but with [JsonResponse]
+#[derive(Debug, PartialEq, Serialize)]
+pub struct HtsGetResponse {
+  format: String,
+  urls: Vec<JsonUrl>,
+}
+
+impl HtsGetResponse {
+  fn new(response: Response) -> Self {
     let format = match response.format {
       Format::Unsupported(_) => panic!("Response with an unsupported format"),
       format => format.to_string(),
     };
     let urls = response.urls.into_iter().map(JsonUrl::new).collect();
-    JsonResponse { format, urls }
+    HtsGetResponse { format, urls }
   }
 }
 


### PR DESCRIPTION
Another little fix to something I noticed comparing with the reference implementation. 
The JSON response is supposed to be wrapped in a htsget object.