### PR TITLE
Fix runtime panics from curl

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -22,10 +22,17 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
+
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+      - name: Run cargo clippy with no default features
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --no-default-features
+
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:

--- a/htsget-http-actix/Cargo.toml
+++ b/htsget-http-actix/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "htsget-http-actix"
 version = "0.1.0"
-authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>"]
+authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2018"
 
 [features]

--- a/htsget-http-actix/Cargo.toml
+++ b/htsget-http-actix/Cargo.toml
@@ -9,7 +9,7 @@ default = ["async", "htsget-search/default", "htsget-http-core/default"]
 async = ["tokio", "futures", "htsget-search/async", "htsget-http-core/async"]
 
 [dependencies]
-actix-web = "3"
+actix-web = { version = "4.0.0-beta.13" }
 envy = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/htsget-http-actix/Cargo.toml
+++ b/htsget-http-actix/Cargo.toml
@@ -9,7 +9,7 @@ default = ["async", "htsget-search/default", "htsget-http-core/default"]
 async = ["tokio", "futures", "htsget-search/async", "htsget-http-core/async"]
 
 [dependencies]
-actix-web = { version = "4.0.0-beta.13" }
+actix-web = { version = "4.0.0-beta.14" }
 envy = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/htsget-http-actix/src/handlers/blocking/get.rs
+++ b/htsget-http-actix/src/handlers/blocking/get.rs
@@ -23,11 +23,11 @@ use crate::AppState;
 #[cfg(not(feature = "async"))]
 pub async fn reads<H: HtsGet>(
   request: Query<HashMap<String, String>>,
-  Path(id): Path<String>,
+  path: Path<String>,
   app_state: Data<AppState<H>>,
 ) -> impl Responder {
   let mut query_information = request.into_inner();
-  query_information.insert("id".to_string(), id);
+  query_information.insert("id".to_string(), path.into_inner());
   handle_response(get_response_for_get_request(
     &app_state.get_ref().htsget,
     query_information,
@@ -39,11 +39,11 @@ pub async fn reads<H: HtsGet>(
 #[cfg(not(feature = "async"))]
 pub async fn variants<H: HtsGet>(
   request: Query<HashMap<String, String>>,
-  Path(id): Path<String>,
+  path: Path<String>,
   app_state: Data<AppState<H>>,
 ) -> impl Responder {
   let mut query_information = request.into_inner();
-  query_information.insert("id".to_string(), id);
+  query_information.insert("id".to_string(), path.into_inner());
   handle_response(get_response_for_get_request(
     &app_state.get_ref().htsget,
     query_information,

--- a/htsget-http-actix/src/handlers/blocking/mod.rs
+++ b/htsget-http-actix/src/handlers/blocking/mod.rs
@@ -14,8 +14,6 @@ use crate::handlers::fill_out_service_info_json;
 use crate::handlers::pretty_json::PrettyJson;
 #[cfg(not(feature = "async"))]
 use crate::AppState;
-#[cfg(not(feature = "async"))]
-use crate::Config;
 
 pub mod get;
 pub mod post;

--- a/htsget-http-actix/src/handlers/blocking/mod.rs
+++ b/htsget-http-actix/src/handlers/blocking/mod.rs
@@ -13,16 +13,12 @@ use crate::handlers::fill_out_service_info_json;
 #[cfg(not(feature = "async"))]
 use crate::handlers::pretty_json::PrettyJson;
 #[cfg(not(feature = "async"))]
+use crate::AppState;
+#[cfg(not(feature = "async"))]
 use crate::Config;
 
 pub mod get;
 pub mod post;
-
-#[cfg(not(feature = "async"))]
-pub struct AppState<H: HtsGet> {
-  pub htsget: H,
-  pub config: Config,
-}
 
 /// Gets the JSON to return for a service-info endpoint
 #[cfg(not(feature = "async"))]

--- a/htsget-http-actix/src/handlers/blocking/post.rs
+++ b/htsget-http-actix/src/handlers/blocking/post.rs
@@ -20,13 +20,13 @@ use crate::AppState;
 #[cfg(not(feature = "async"))]
 pub async fn reads<H: HtsGet>(
   request: Json<PostRequest>,
-  Path(id): Path<String>,
+  path: Path<String>,
   app_state: Data<AppState<H>>,
 ) -> impl Responder {
   handle_response(get_response_for_post_request(
     &app_state.get_ref().htsget,
     request.into_inner(),
-    id,
+    path.into_inner(),
     Endpoint::Reads,
   ))
 }
@@ -35,13 +35,13 @@ pub async fn reads<H: HtsGet>(
 #[cfg(not(feature = "async"))]
 pub async fn variants<H: HtsGet>(
   request: Json<PostRequest>,
-  Path(id): Path<String>,
+  path: Path<String>,
   app_state: Data<AppState<H>>,
 ) -> impl Responder {
   handle_response(get_response_for_post_request(
     &app_state.get_ref().htsget,
     request.into_inner(),
-    id,
+    path.into_inner(),
     Endpoint::Variants,
   ))
 }

--- a/htsget-http-actix/src/handlers/get.rs
+++ b/htsget-http-actix/src/handlers/get.rs
@@ -15,11 +15,11 @@ use super::handle_response;
 /// GET request reads endpoint
 pub async fn reads<H: HtsGet + Send + Sync + 'static>(
   request: Query<HashMap<String, String>>,
-  Path(id): Path<String>,
+  path: Path<String>,
   app_state: Data<AsyncAppState<H>>,
 ) -> impl Responder {
   let mut query_information = request.into_inner();
-  query_information.insert("id".to_string(), id);
+  query_information.insert("id".to_string(), path.into_inner());
   handle_response(
     get_response_for_get_request(
       app_state.get_ref().htsget.clone(),
@@ -33,11 +33,11 @@ pub async fn reads<H: HtsGet + Send + Sync + 'static>(
 /// GET request variants endpoint
 pub async fn variants<H: HtsGet + Send + Sync + 'static>(
   request: Query<HashMap<String, String>>,
-  Path(id): Path<String>,
+  path: Path<String>,
   app_state: Data<AsyncAppState<H>>,
 ) -> impl Responder {
   let mut query_information = request.into_inner();
-  query_information.insert("id".to_string(), id);
+  query_information.insert("id".to_string(), path.into_inner());
   handle_response(
     get_response_for_get_request(
       app_state.get_ref().htsget.clone(),

--- a/htsget-http-actix/src/handlers/mod.rs
+++ b/htsget-http-actix/src/handlers/mod.rs
@@ -25,9 +25,9 @@ fn handle_response(response: Result<JsonResponse>) -> Either<impl Responder, imp
   match response {
     Err(error) => {
       let (json, status_code) = error.to_json_representation();
-      Either::A(PrettyJson(json).with_status(StatusCode::from_u16(status_code).unwrap()))
+      Either::Left(PrettyJson(json).with_status(StatusCode::from_u16(status_code).unwrap()))
     }
-    Ok(json) => Either::B(PrettyJson(json).with_status(StatusCode::OK)),
+    Ok(json) => Either::Right(PrettyJson(json).with_status(StatusCode::OK)),
   }
 }
 

--- a/htsget-http-actix/src/handlers/post.rs
+++ b/htsget-http-actix/src/handlers/post.rs
@@ -13,14 +13,14 @@ use super::handle_response;
 /// POST request reads endpoint
 pub async fn reads<H: HtsGet + Send + Sync + 'static>(
   request: Json<PostRequest>,
-  Path(id): Path<String>,
+  path: Path<String>,
   app_state: Data<AsyncAppState<H>>,
 ) -> impl Responder {
   handle_response(
     get_response_for_post_request(
       app_state.get_ref().htsget.clone(),
       request.into_inner(),
-      id,
+      path.into_inner(),
       Endpoint::Reads,
     )
     .await,
@@ -30,14 +30,14 @@ pub async fn reads<H: HtsGet + Send + Sync + 'static>(
 /// POST request variants endpoint
 pub async fn variants<H: HtsGet + Send + Sync + 'static>(
   request: Json<PostRequest>,
-  Path(id): Path<String>,
+  path: Path<String>,
   app_state: Data<AsyncAppState<H>>,
 ) -> impl Responder {
   handle_response(
     get_response_for_post_request(
       app_state.get_ref().htsget.clone(),
       request.into_inner(),
-      id,
+      path.into_inner(),
       Endpoint::Variants,
     )
     .await,

--- a/htsget-http-actix/src/handlers/pretty_json.rs
+++ b/htsget-http-actix/src/handlers/pretty_json.rs
@@ -1,24 +1,18 @@
-use actix_web::{error::Error, http::StatusCode, HttpRequest, HttpResponse, Responder};
-use futures_util::future::{err, ok, Ready};
+use actix_web::{http::StatusCode, HttpRequest, HttpResponse, Responder};
 use serde::Serialize;
 
 pub struct PrettyJson<T>(pub T);
 
 impl<T: Serialize> Responder for PrettyJson<T> {
-  type Error = Error;
-  type Future = Ready<Result<HttpResponse, Error>>;
-
-  fn respond_to(self, _: &HttpRequest) -> Self::Future {
+  fn respond_to(self, _: &HttpRequest) -> HttpResponse {
     let mut body = match serde_json::to_string_pretty(&self.0) {
       Ok(body) => body,
-      Err(e) => return err(e.into()),
+      Err(e) => return HttpResponse::from_error(e),
     };
     body.push('\n');
 
-    ok(
-      HttpResponse::build(StatusCode::OK)
+    HttpResponse::build(StatusCode::OK)
         .content_type("application/json")
-        .body(body),
-    )
+        .body(body)
   }
 }

--- a/htsget-http-actix/src/handlers/pretty_json.rs
+++ b/htsget-http-actix/src/handlers/pretty_json.rs
@@ -1,9 +1,12 @@
+use actix_web::body::BoxBody;
 use actix_web::{http::StatusCode, HttpRequest, HttpResponse, Responder};
 use serde::Serialize;
 
 pub struct PrettyJson<T>(pub T);
 
 impl<T: Serialize> Responder for PrettyJson<T> {
+  type Body = BoxBody;
+
   fn respond_to(self, _: &HttpRequest) -> HttpResponse {
     let mut body = match serde_json::to_string_pretty(&self.0) {
       Ok(body) => body,

--- a/htsget-http-actix/src/handlers/pretty_json.rs
+++ b/htsget-http-actix/src/handlers/pretty_json.rs
@@ -12,7 +12,7 @@ impl<T: Serialize> Responder for PrettyJson<T> {
     body.push('\n');
 
     HttpResponse::build(StatusCode::OK)
-        .content_type("application/json")
-        .body(body)
+      .content_type("application/json")
+      .body(body)
   }
 }

--- a/htsget-http-actix/src/lib.rs
+++ b/htsget-http-actix/src/lib.rs
@@ -41,6 +41,7 @@ The next variables are used to configure the info for the service-info endpoints
 
 #[cfg(feature = "async")]
 pub type AsyncHtsGetStorage = HtsGetFromStorage<LocalStorage>;
+#[cfg(not(feature = "async"))]
 pub type HtsGetStorage = HtsGetFromStorage<LocalStorage>;
 
 #[cfg(feature = "async")]

--- a/htsget-http-actix/src/lib.rs
+++ b/htsget-http-actix/src/lib.rs
@@ -1,19 +1,29 @@
 #[cfg(feature = "async")]
 use std::sync::Arc;
 
-use config::Config;
+use actix_web::web;
 
+// Async
+#[cfg(feature = "async")]
+use crate::handlers::{get, post, reads_service_info, variants_service_info};
+#[cfg(feature = "async")]
+use htsget_search::htsget::from_storage::HtsGetFromStorage;
+#[cfg(feature = "async")]
+use htsget_search::htsget::HtsGet;
+
+// Blocking
+#[cfg(not(feature = "async"))]
+use crate::handlers::blocking::{get, post, reads_service_info, variants_service_info};
 #[cfg(not(feature = "async"))]
 use htsget_search::htsget::blocking::from_storage::HtsGetFromStorage;
 #[cfg(not(feature = "async"))]
 use htsget_search::htsget::blocking::HtsGet;
-#[cfg(not(feature = "async"))]
+
+use htsget_id_resolver::RegexResolver;
+
 use htsget_search::storage::blocking::local::LocalStorage;
-#[cfg(feature = "async")]
-use htsget_search::{
-  htsget::{from_storage::HtsGetFromStorage, HtsGet},
-  storage::blocking::local::LocalStorage,
-};
+
+use crate::config::Config;
 
 pub mod config;
 pub mod handlers;
@@ -54,4 +64,250 @@ pub struct AsyncAppState<H: HtsGet> {
 pub struct AppState<H: HtsGet> {
   pub htsget: H,
   pub config: Config,
+}
+
+#[cfg(feature = "async")]
+pub fn async_configure_server(service_config: &mut web::ServiceConfig, config: Config) {
+  let htsget_path = config.htsget_path.clone();
+  let regex_match = config.htsget_regex_match.clone();
+  let regex_substitution = config.htsget_regex_substitution.clone();
+  service_config
+    .app_data(web::Data::new(AsyncAppState {
+      htsget: Arc::new(AsyncHtsGetStorage::new(
+        LocalStorage::new(
+          htsget_path,
+          RegexResolver::new(&regex_match, &regex_substitution).unwrap(),
+        )
+        .expect("Couldn't create a Storage with the provided path"),
+      )),
+      config,
+    }))
+    .service(
+      web::scope("/reads")
+        .route(
+          "/service-info",
+          web::get().to(reads_service_info::<AsyncHtsGetStorage>),
+        )
+        .route(
+          "/service-info",
+          web::post().to(reads_service_info::<AsyncHtsGetStorage>),
+        )
+        .route("/{id:.+}", web::get().to(get::reads::<AsyncHtsGetStorage>))
+        .route(
+          "/{id:.+}",
+          web::post().to(post::reads::<AsyncHtsGetStorage>),
+        ),
+    )
+    .service(
+      web::scope("/variants")
+        .route(
+          "/service-info",
+          web::get().to(variants_service_info::<AsyncHtsGetStorage>),
+        )
+        .route(
+          "/service-info",
+          web::post().to(variants_service_info::<AsyncHtsGetStorage>),
+        )
+        .route(
+          "/{id:.+}",
+          web::get().to(get::variants::<AsyncHtsGetStorage>),
+        )
+        .route(
+          "/{id:.+}",
+          web::post().to(post::variants::<AsyncHtsGetStorage>),
+        ),
+    );
+}
+
+#[cfg(not(feature = "async"))]
+pub fn configure_server(service_config: &mut web::ServiceConfig, config: Config) {
+  let htsget_path = config.htsget_path.clone();
+  let regex_match = config.htsget_regex_match.clone();
+  let regex_substitution = config.htsget_regex_substitution.clone();
+  service_config
+    .app_data(web::Data::new(AppState {
+      htsget: HtsGetStorage::new(
+        LocalStorage::new(
+          htsget_path,
+          RegexResolver::new(&regex_match, &regex_substitution).unwrap(),
+        )
+        .expect("Couldn't create a Storage with the provided path"),
+      ),
+      config,
+    }))
+    .service(
+      web::scope("/reads")
+        .route(
+          "/service-info",
+          web::get().to(reads_service_info::<HtsGetStorage>),
+        )
+        .route(
+          "/service-info",
+          web::post().to(reads_service_info::<HtsGetStorage>),
+        )
+        .route("/{id:.+}", web::get().to(get::reads::<HtsGetStorage>))
+        .route("/{id:.+}", web::post().to(post::reads::<HtsGetStorage>)),
+    )
+    .service(
+      web::scope("/variants")
+        .route(
+          "/service-info",
+          web::get().to(variants_service_info::<HtsGetStorage>),
+        )
+        .route(
+          "/service-info",
+          web::post().to(variants_service_info::<HtsGetStorage>),
+        )
+        .route("/{id:.+}", web::get().to(get::variants::<HtsGetStorage>))
+        .route("/{id:.+}", web::post().to(post::variants::<HtsGetStorage>)),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+  #[cfg(feature = "async")]
+  use super::async_configure_server as configure_server;
+  #[cfg(not(feature = "async"))]
+  use super::configure_server;
+  use super::*;
+
+  use actix_web::http::StatusCode;
+  use actix_web::test::TestRequest;
+  use actix_web::{test, web, App};
+  use htsget_http_core::get_service_info_with;
+  use htsget_http_core::{Endpoint, JsonResponse, ServiceInfo};
+  use htsget_search::htsget::Class::Header;
+  use htsget_search::htsget::{Format, Headers, Response, Url};
+  use serde::Deserialize;
+  use std::collections::HashMap;
+  use std::path::{Path, PathBuf};
+
+  #[actix_web::test]
+  async fn test_get() {
+    let request = test::TestRequest::get().uri("/variants/data/vcf/sample1-bcbio-cancer");
+
+    with_response(request, |path, status, response: JsonResponse| {
+      assert!(status.is_success());
+      assert_eq!(example_response(&path), response);
+    })
+    .await;
+  }
+
+  #[actix_web::test]
+  async fn test_post() {
+    let request = test::TestRequest::post()
+      .insert_header(("content-type", "application/json"))
+      .set_payload("{}")
+      .uri("/variants/data/vcf/sample1-bcbio-cancer");
+
+    with_response(request, |path, status, response: JsonResponse| {
+      assert!(status.is_success());
+      assert_eq!(example_response(&path), response);
+    })
+    .await;
+  }
+
+  #[actix_web::test]
+  async fn test_parameterized_get() {
+    let request = test::TestRequest::get()
+      .uri("/variants/data/vcf/sample1-bcbio-cancer?format=VCF&class=header");
+
+    with_response(request, |path, status, response: JsonResponse| {
+      assert!(status.is_success());
+      assert_eq!(example_response_header(&path), response);
+    })
+    .await;
+  }
+
+  #[actix_web::test]
+  async fn test_parameterized_post() {
+    let request = test::TestRequest::post()
+      .insert_header(("content-type", "application/json"))
+      .set_payload("{\"format\": \"VCF\", \"regions\": [{\"referenceName\": \"chrM\"}]}")
+      .uri("/variants/data/vcf/sample1-bcbio-cancer");
+
+    with_response(request, |path, status, response: JsonResponse| {
+      assert!(status.is_success());
+      assert_eq!(example_response(&path), response);
+    })
+    .await;
+  }
+
+  #[actix_web::test]
+  async fn test_service_info() {
+    let request = test::TestRequest::get().uri("/variants/service-info");
+
+    with_response(request, |_, status, response: ServiceInfo| {
+      let expected = get_service_info_with(
+        Endpoint::Variants,
+        &[Format::Vcf, Format::Bcf],
+        false,
+        false,
+      );
+
+      assert!(status.is_success());
+      assert_eq!(expected, response);
+    })
+    .await;
+  }
+
+  fn example_response(path: &Path) -> JsonResponse {
+    let mut headers = HashMap::new();
+    headers.insert("Range".to_string(), "bytes=0-3367".to_string());
+    JsonResponse::from_response(Response::new(
+      Format::Vcf,
+      vec![Url::new(format!(
+        "file://{}",
+        path
+          .join("data")
+          .join("vcf")
+          .join("sample1-bcbio-cancer.vcf.gz")
+          .to_string_lossy()
+      ))
+      .with_headers(Headers::new(headers))],
+    ))
+  }
+
+  fn example_response_header(path: &Path) -> JsonResponse {
+    let mut headers = HashMap::new();
+    headers.insert("Range".to_string(), "bytes=0-3367".to_string());
+    JsonResponse::from_response(Response::new(
+      Format::Vcf,
+      vec![Url::new(format!(
+        "file://{}",
+        path
+          .join("data")
+          .join("vcf")
+          .join("sample1-bcbio-cancer.vcf.gz")
+          .to_string_lossy()
+      ))
+      .with_headers(Headers::new(headers))
+      .with_class(Header)],
+    ))
+  }
+
+  async fn with_response<F, T>(request: TestRequest, test: F)
+  where
+    T: for<'de> Deserialize<'de>,
+    F: FnOnce(PathBuf, StatusCode, T),
+  {
+    std::env::set_var(
+      "HTSGET_PATH",
+      PathBuf::from(env!("CARGO_MANIFEST_DIR")).parent().unwrap(),
+    );
+
+    let config =
+      envy::from_env::<Config>().expect("The environment variables weren't properly set!");
+    let app = test::init_service(App::new().configure(
+      |service_config: &mut web::ServiceConfig| {
+        configure_server(service_config, config.clone());
+      },
+    ))
+    .await;
+    let response = request.send_request(&app).await;
+    let status = response.status();
+    let response_json = test::read_body_json(response).await;
+
+    test(config.htsget_path, status, response_json);
+  }
 }

--- a/htsget-http-actix/src/main.rs
+++ b/htsget-http-actix/src/main.rs
@@ -113,7 +113,7 @@ async fn main() -> std::io::Result<()> {
   let regex_substitution = config.htsget_regex_substitution.clone();
   HttpServer::new(move || {
     App::new()
-      .data(AppState {
+      .app_data(web::Data::new(AppState {
         htsget: HtsGetFromStorage::new(
           LocalStorage::new(
             htsget_path.clone(),
@@ -122,7 +122,7 @@ async fn main() -> std::io::Result<()> {
           .expect("Couldn't create a Storage with the provided path"),
         ),
         config: config.clone(),
-      })
+      }))
       .service(
         web::scope("/reads")
           .route(

--- a/htsget-http-actix/src/main.rs
+++ b/htsget-http-actix/src/main.rs
@@ -2,7 +2,6 @@ use std::env::args;
 
 #[cfg(feature = "async")]
 use std::sync::Arc;
-use color_backtrace;
 
 use actix_web::{web, App, HttpServer};
 
@@ -48,7 +47,7 @@ async fn main() -> std::io::Result<()> {
   let regex_substitution = config.htsget_regex_substitution.clone();
   HttpServer::new(move || {
     App::new()
-      .data(AsyncAppState {
+      .app_data(web::Data::new(AsyncAppState {
         htsget: Arc::new(AsyncHtsGetStorage::new(
           LocalStorage::new(
             htsget_path.clone(),
@@ -57,7 +56,7 @@ async fn main() -> std::io::Result<()> {
           .expect("Couldn't create a Storage with the provided path"),
         )),
         config: config.clone(),
-      })
+      }))
       .service(
         web::scope("/reads")
           .route(

--- a/htsget-http-actix/src/main.rs
+++ b/htsget-http-actix/src/main.rs
@@ -1,36 +1,15 @@
 use std::env::args;
 
-#[cfg(feature = "async")]
-use std::sync::Arc;
-
 use actix_web::{web, App, HttpServer};
 
-// Async
 #[cfg(feature = "async")]
-use htsget_http_actix::handlers::{get, post, reads_service_info, variants_service_info};
-#[cfg(feature = "async")]
-use htsget_http_actix::AsyncAppState;
-#[cfg(feature = "async")]
-use htsget_http_actix::AsyncHtsGetStorage;
-
-// Blocking
+use htsget_http_actix::async_configure_server as configure_server;
 #[cfg(not(feature = "async"))]
-use htsget_http_actix::handlers::blocking::{get, post, reads_service_info, variants_service_info};
-#[cfg(not(feature = "async"))]
-use htsget_http_actix::AppState;
-#[cfg(not(feature = "async"))]
-use htsget_http_actix::HtsGetStorage;
-#[cfg(not(feature = "async"))]
-use htsget_search::htsget::blocking::from_storage::HtsGetFromStorage;
-
-use htsget_id_resolver::RegexResolver;
-
-use htsget_search::storage::blocking::local::LocalStorage;
+use htsget_http_actix::configure_server;
 
 use htsget_http_actix::config::Config;
 use htsget_http_actix::USAGE;
 
-#[cfg(feature = "async")]
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
   color_backtrace::install();
@@ -40,115 +19,13 @@ async fn main() -> std::io::Result<()> {
     println!("{}", USAGE);
     return Ok(());
   }
-  let config = envy::from_env::<Config>().expect("The environment variables weren't properly set!");
-  let address = format!("{}:{}", config.htsget_ip, config.htsget_port);
-  let htsget_path = config.htsget_path.clone();
-  let regex_match = config.htsget_regex_match.clone();
-  let regex_substitution = config.htsget_regex_substitution.clone();
-  HttpServer::new(move || {
-    App::new()
-      .app_data(web::Data::new(AsyncAppState {
-        htsget: Arc::new(AsyncHtsGetStorage::new(
-          LocalStorage::new(
-            htsget_path.clone(),
-            RegexResolver::new(&regex_match, &regex_substitution).unwrap(),
-          )
-          .expect("Couldn't create a Storage with the provided path"),
-        )),
-        config: config.clone(),
-      }))
-      .service(
-        web::scope("/reads")
-          .route(
-            "/service-info",
-            web::get().to(reads_service_info::<AsyncHtsGetStorage>),
-          )
-          .route(
-            "/service-info",
-            web::post().to(reads_service_info::<AsyncHtsGetStorage>),
-          )
-          .route("/{id:.+}", web::get().to(get::reads::<AsyncHtsGetStorage>))
-          .route(
-            "/{id:.+}",
-            web::post().to(post::reads::<AsyncHtsGetStorage>),
-          ),
-      )
-      .service(
-        web::scope("/variants")
-          .route(
-            "/service-info",
-            web::get().to(variants_service_info::<AsyncHtsGetStorage>),
-          )
-          .route(
-            "/service-info",
-            web::post().to(variants_service_info::<AsyncHtsGetStorage>),
-          )
-          .route(
-            "/{id:.+}",
-            web::get().to(get::variants::<AsyncHtsGetStorage>),
-          )
-          .route(
-            "/{id:.+}",
-            web::post().to(post::variants::<AsyncHtsGetStorage>),
-          ),
-      )
-  })
-  .bind(address)?
-  .run()
-  .await
-}
 
-#[cfg(not(feature = "async"))]
-#[actix_web::main]
-async fn main() -> std::io::Result<()> {
-  if args().len() > 1 {
-    // Show help if command line options are provided
-    println!("{}", USAGE);
-    return Ok(());
-  }
   let config = envy::from_env::<Config>().expect("The environment variables weren't properly set!");
   let address = format!("{}:{}", config.htsget_ip, config.htsget_port);
-  let htsget_path = config.htsget_path.clone();
-  let regex_match = config.htsget_regex_match.clone();
-  let regex_substitution = config.htsget_regex_substitution.clone();
   HttpServer::new(move || {
-    App::new()
-      .app_data(web::Data::new(AppState {
-        htsget: HtsGetFromStorage::new(
-          LocalStorage::new(
-            htsget_path.clone(),
-            RegexResolver::new(&regex_match, &regex_substitution).unwrap(),
-          )
-          .expect("Couldn't create a Storage with the provided path"),
-        ),
-        config: config.clone(),
-      }))
-      .service(
-        web::scope("/reads")
-          .route(
-            "/service-info",
-            web::get().to(reads_service_info::<HtsGetStorage>),
-          )
-          .route(
-            "/service-info",
-            web::post().to(reads_service_info::<HtsGetStorage>),
-          )
-          .route("/{id:.+}", web::get().to(get::reads::<HtsGetStorage>))
-          .route("/{id:.+}", web::post().to(post::reads::<HtsGetStorage>)),
-      )
-      .service(
-        web::scope("/variants")
-          .route(
-            "/service-info",
-            web::get().to(variants_service_info::<HtsGetStorage>),
-          )
-          .route(
-            "/service-info",
-            web::post().to(variants_service_info::<HtsGetStorage>),
-          )
-          .route("/{id:.+}", web::get().to(get::variants::<HtsGetStorage>))
-          .route("/{id:.+}", web::post().to(post::variants::<HtsGetStorage>)),
-      )
+    App::new().configure(|service_config: &mut web::ServiceConfig| {
+      configure_server(service_config, config.clone());
+    })
   })
   .bind(address)?
   .run()

--- a/htsget-http-core/Cargo.toml
+++ b/htsget-http-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "htsget-http-core"
 version = "0.1.0"
-authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>"]
+authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2018"
 
 [features]

--- a/htsget-http-core/src/json_response.rs
+++ b/htsget-http-core/src/json_response.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use htsget_search::htsget::{Class, Format, Response, Url};
 
 /// A helper struct to convert [Responses](Response) to JSON. It implements [serde's Serialize trait](Serialize),
 /// so it's trivial to convert to JSON.
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct JsonResponse {
   htsget: HtsGetResponse,
 }
@@ -21,7 +21,7 @@ impl JsonResponse {
 
 /// A helper struct to represent a JSON response. It shouldn't be used
 /// on its own, but with [JsonResponse]
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct HtsGetResponse {
   format: String,
   urls: Vec<JsonUrl>,
@@ -40,7 +40,7 @@ impl HtsGetResponse {
 
 /// A helper struct to convert [Urls](Url) to JSON. It shouldn't be used
 /// on its own, but with [JsonResponse]
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct JsonUrl {
   url: String,
   headers: HashMap<String, String>,

--- a/htsget-http-core/src/lib.rs
+++ b/htsget-http-core/src/lib.rs
@@ -9,6 +9,7 @@ pub use post_request::{PostRequest, Region};
 use query_builder::QueryBuilder;
 #[cfg(feature = "async")]
 pub use service_info::get_service_info_json;
+pub use service_info::get_service_info_with;
 pub use service_info::{ServiceInfo, ServiceInfoHtsget, ServiceInfoOrganization, ServiceInfoType};
 
 #[cfg(feature = "async")]

--- a/htsget-http-core/src/service_info.rs
+++ b/htsget-http-core/src/service_info.rs
@@ -7,7 +7,7 @@ use htsget_search::htsget::{Format, HtsGet};
 use crate::{Endpoint, READS_FORMATS, VARIANTS_FORMATS};
 
 /// A struct representing the information that should be present in a service-info response
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ServiceInfo {
   pub id: String,
   pub name: String,
@@ -29,20 +29,20 @@ pub struct ServiceInfo {
   pub environment: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ServiceInfoOrganization {
   pub name: String,
   pub url: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ServiceInfoType {
   pub group: String,
   pub artifact: String,
   pub version: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ServiceInfoHtsget {
   pub datatype: String,
   pub formats: Vec<String>,

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "htsget-search"
 version = "0.1.0"
-authors = ["Christian Perez Llamas <chrispz@gmail.com>", "Roman Valls Guimera <brainstorm@nopcode.org>"]
+authors = ["Christian Perez Llamas <chrispz@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>", "Roman Valls Guimera <brainstorm@nopcode.org>"]
 edition = "2018"
 
 [features]

--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -243,7 +243,7 @@ pub enum Tags {
 }
 
 /// The headers that need to be supplied when requesting data from a url.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Default, PartialEq)]
 pub struct Headers(HashMap<String, String>);
 
 impl Headers {
@@ -266,12 +266,6 @@ impl Headers {
 
   pub fn get_inner(self) -> HashMap<String, String> {
     self.0
-  }
-}
-
-impl Default for Headers {
-  fn default() -> Self {
-    Self(HashMap::new())
   }
 }
 

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -26,7 +26,7 @@ pub enum StorageError {
   NotFound(String),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct BytesRange {
   start: Option<u64>,
   end: Option<u64>,
@@ -116,15 +116,7 @@ impl BytesRange {
   }
 }
 
-impl Default for BytesRange {
-  fn default() -> Self {
-    Self {
-      start: None,
-      end: None,
-    }
-  }
-}
-
+#[derive(Default)]
 pub struct GetOptions {
   range: BytesRange,
 }
@@ -138,14 +130,6 @@ impl GetOptions {
   pub fn with_range(mut self, range: BytesRange) -> Self {
     self.range = range;
     self
-  }
-}
-
-impl Default for GetOptions {
-  fn default() -> Self {
-    Self {
-      range: BytesRange::default(),
-    }
   }
 }
 


### PR DESCRIPTION
Closes #67 

This was an issue with multiple conflicting versions of tokio. Actix-web v3 only supports tokio 0.2, however our project uses tokio 1.x. This PR updates to Actix-web v4, which is still in beta. This fixes the issues relating to the server not returning proper responses with curl examples. All the curl examples should now work, for both blocking and async code.