### PR TITLE
Allow AwsS3Storage tests to be run in parallel

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -37,4 +37,3 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -- --test-threads=1


### PR DESCRIPTION
This PR changes the s3-server tests for `AwsS3Storage`, so that a test server is only initialized once. This allows tests to be run in parallel.