### PR TITLE
Enable choosing between storage types.

### DIFF
--- a/htsget-config/Cargo.toml
+++ b/htsget-config/Cargo.toml
@@ -10,4 +10,5 @@ default = ["s3-storage"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+serde_regex = "1.1"
 regex = "1.5"

--- a/htsget-config/Cargo.toml
+++ b/htsget-config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "htsget-config"
 version = "0.1.0"
-authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>"]
+authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"
 
 [features]
@@ -12,3 +12,4 @@ default = ["s3-storage"]
 serde = { version = "1.0", features = ["derive"] }
 serde_regex = "1.1"
 regex = "1.5"
+envy = "0.4"

--- a/htsget-config/src/config.rs
+++ b/htsget-config/src/config.rs
@@ -8,23 +8,27 @@ use serde::Deserialize;
 
 pub const USAGE: &str = r#"
 This executable doesn't use command line arguments, but there are some environment variables that can be set to configure the HtsGet server:
-* HTSGET_IP: The ip to use. Default: 127.0.0.1
-* HTSGET_PORT: The port to use. Default: 8080
-* HTSGET_PATH: The path to the directory where the server should be started. Default: Actual directory
-* HTSGET_REGEX: The regular expression that should match an ID. Default: ".*"
-* HTSGET_REPLACEMENT: The replacement expression. Default: "$0"
+* HTSGET_ADDR: The socket address to use for the server which creates response tickets. Default: "127.0.0.1:8080".
+* HTSGET_PATH: The path to the directory where the server should be started. Default: "."
+* HTSGET_REGEX: The regular expression that should match an ID. Default: ".*".
+* HTSGET_SUBSTITUTION_STRING: The replacement expression. Default: "$0".
 For more information about the regex options look in the documentation of the regex crate(https://docs.rs/regex/).
-The next variables are used to configure the info for the service-info endpoints
-* HTSGET_ID: The id of the service. Default: ""
-* HTSGET_NAME: The name of the service. Default: "HtsGet service"
-* HTSGET_VERSION: The version of the service. Default: ""
-* HTSGET_ORGANIZATION_NAME: The name of the organization. Default: "Snake oil"
-* HTSGET_ORGANIZATION_URL: The url of the organization. Default: "https://en.wikipedia.org/wiki/Snake_oil"
-* HTSGET_CONTACT_URL: A url to provide contact to the users. Default: "",
-* HTSGET_DOCUMENTATION_URL: A link to the documentation. Default: "https://github.com/umccr/htsget-rs/tree/main/htsget-http-actix",
-* HTSGET_CREATED_AT: Date of the creation of the service. Default: "",
-* HTSGET_UPDATED_AT: Date of the last update of the service. Default: "",
-* HTSGET_ENVIRONMENT: The environment in which the service is running. Default: "Testing",
+The next variables are used to configure the info for the service-info endpoints.
+* HTSGET_ID: The id of the service. Default: "None".
+* HTSGET_NAME: The name of the service. Default: "None".
+* HTSGET_VERSION: The version of the service. Default: "None".
+* HTSGET_ORGANIZATION_NAME: The name of the organization. Default: "None".
+* HTSGET_ORGANIZATION_URL: The url of the organization. Default: "None".
+* HTSGET_CONTACT_URL: A url to provide contact to the users. Default: "None".
+* HTSGET_DOCUMENTATION_URL: A link to the documentation. Default: "None".
+* HTSGET_CREATED_AT: Date of the creation of the service. Default: "None".
+* HTSGET_UPDATED_AT: Date of the last update of the service. Default: "None".
+* HTSGET_ENVIRONMENT: The environment in which the service is running. Default: "None".
+* HTSGET_STORAGE_TYPE: Either LocalStorage or AwsS3Storage. Default: "LocalStorage".
+* HTSGET_TICKET_SERVER_ADDR: The socket address to use for the server which responds to tickets. Default: "127.0.0.1:8081". Unused if HTSGET_STORAGE_TYPE is not "LocalStorage".
+* HTSGET_TICKET_SERVER_KEY: The path to the PEM formatted X.509 private key used by the ticket response server. Default: "${HTSGET_PATH}/key.pem". Unused if HTSGET_STORAGE_TYPE is not "LocalStorage".
+* HTSGET_TICKET_SERVER_CERT: The path to the PEM formatted X.509 certificate used by the ticket response server. Default: "${HTSGET_PATH}/cert.pem". Unused if HTSGET_STORAGE_TYPE is not "LocalStorage".
+* HTSGET_S3_BUCKET: The name of the AWS S3 bucket. Default: None. Unused if HTSGET_STORAGE_TYPE is not "AwsS3Storage". Must be specified if using AwsS3Storage.
 "#;
 
 fn default_localstorage_addr() -> SocketAddr {
@@ -39,20 +43,16 @@ fn default_path() -> PathBuf {
   PathBuf::from(".")
 }
 
-fn default_resolver() -> RegexResolver {
-  RegexResolver::new(".*", "$0").expect("Expected valid resolver.")
-}
-
 fn default_localstorage_cert() -> PathBuf {
-  default_path().join("certs/cert.pem")
+  default_path().join("cert.pem")
 }
 
 fn default_localstorage_key() -> PathBuf {
-  default_path().join("certs/key.pem")
+  default_path().join("key.pem")
 }
 
 /// Specify the storage type to use.
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, PartialEq)]
 pub enum StorageType {
   LocalStorage,
   #[cfg(feature = "s3-storage")]
@@ -64,19 +64,21 @@ pub enum StorageType {
 #[serde(default)]
 pub struct Config {
   pub htsget_addr: SocketAddr,
+  #[serde(flatten)]
   pub htsget_resolver: RegexResolver,
   pub htsget_path: PathBuf,
   #[serde(flatten)]
   pub htsget_config_service_info: ConfigServiceInfo,
-  pub htsget_localstorage_addr: SocketAddr,
-  pub htsget_localstorage_cert: PathBuf,
-  pub htsget_localstorage_key: PathBuf,
   pub htsget_storage_type: StorageType,
+  pub htsget_localstorage_addr: SocketAddr,
+  pub htsget_localstorage_key: PathBuf,
+  pub htsget_localstorage_cert: PathBuf,
   #[cfg(feature = "s3-storage")]
   pub htsget_s3_bucket: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]
+#[serde(default)]
 pub struct ConfigServiceInfo {
   pub htsget_id: Option<String>,
   pub htsget_name: Option<String>,
@@ -94,13 +96,13 @@ impl Default for Config {
   fn default() -> Self {
     Self {
       htsget_addr: default_addr(),
-      htsget_resolver: default_resolver(),
+      htsget_resolver: RegexResolver::default(),
       htsget_path: default_path(),
       htsget_config_service_info: ConfigServiceInfo::default(),
-      htsget_localstorage_addr: default_localstorage_addr(),
-      htsget_localstorage_cert: default_localstorage_cert(),
-      htsget_localstorage_key: default_localstorage_key(),
       htsget_storage_type: LocalStorage,
+      htsget_localstorage_addr: default_localstorage_addr(),
+      htsget_localstorage_key: default_localstorage_key(),
+      htsget_localstorage_cert: default_localstorage_cert(),
       #[cfg(feature = "s3-storage")]
       htsget_s3_bucket: None,
     }
@@ -115,5 +117,46 @@ impl Config {
         format!("Config not properly set: {}", err),
       )
     })
+  }
+}
+
+mod tests {
+  use crate::config::Config;
+  use crate::config::StorageType::AwsS3Storage;
+
+
+  #[test]
+  fn config_addr() {
+    std::env::set_var("HTSGET_ADDR", "127.0.0.1:8081");
+    let config = Config::from_env().unwrap();
+    assert_eq!(config.htsget_addr, "127.0.0.1:8081".parse().unwrap());
+  }
+
+  #[test]
+  fn config_regex() {
+    std::env::set_var("HTSGET_REGEX", ".+");
+    let config = Config::from_env().unwrap();
+    assert_eq!(config.htsget_resolver.htsget_regex.to_string(), ".+");
+  }
+
+  #[test]
+  fn config_substitution_string() {
+    std::env::set_var("HTSGET_SUBSTITUTION_STRING", "$0-test");
+    let config = Config::from_env().unwrap();
+    assert_eq!(config.htsget_resolver.htsget_substitution_string, "$0-test");
+  }
+
+  #[test]
+  fn config_service_info_id() {
+    std::env::set_var("HTSGET_ID", "id");
+    let config = Config::from_env().unwrap();
+    assert_eq!(config.htsget_config_service_info.htsget_id.unwrap(), "id");
+  }
+
+  #[test]
+  fn config_storage_type() {
+    std::env::set_var("HTSGET_STORAGE_TYPE", "AwsS3Storage");
+    let config = Config::from_env().unwrap();
+    assert_eq!(config.htsget_storage_type, AwsS3Storage);
   }
 }

--- a/htsget-config/src/config.rs
+++ b/htsget-config/src/config.rs
@@ -1,7 +1,9 @@
+use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use serde::Deserialize;
 use crate::config::StorageType::LocalStorage;
+use crate::regex_resolver::RegexResolver;
 
 pub const USAGE: &str = r#"
 This executable doesn't use command line arguments, but there are some environment variables that can be set to configure the HtsGet server:
@@ -24,28 +26,20 @@ The next variables are used to configure the info for the service-info endpoints
 * HTSGET_ENVIRONMENT: The environment in which the service is running. Default: "Testing",
 "#;
 
-fn default_port() -> String {
-  "8080".to_string()
+fn default_localstorage_addr() -> SocketAddr {
+  "127.0.0.1:8081".parse().expect("Expected valid address.")
 }
 
-fn default_localstorage_port() -> String {
-  "8081".to_string()
-}
-
-fn default_ip() -> String {
-  "127.0.0.1".to_string()
+fn default_addr() -> SocketAddr {
+  "127.0.0.1:8080".parse().expect("Expected valid address.")
 }
 
 fn default_path() -> PathBuf {
   PathBuf::from(".")
 }
 
-fn default_regex_match() -> String {
-  ".*".to_string()
-}
-
-fn default_regex_substitution() -> String {
-  "$0".to_string()
+fn default_resolver() -> RegexResolver {
+  RegexResolver::new(".*", "$0").expect("Expected valid resolver.")
 }
 
 fn default_localstorage_cert() -> PathBuf {
@@ -68,11 +62,8 @@ pub enum StorageType {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(default)]
 pub struct Config {
-  pub htsget_port: String,
-  pub htsget_ip: String,
-  pub htsget_path: PathBuf,
-  pub htsget_regex_match: String,
-  pub htsget_regex_substitution: String,
+  pub htsget_addr: SocketAddr,
+  pub htsget_resolver: RegexResolver,
   pub htsget_id: Option<String>,
   pub htsget_name: Option<String>,
   pub htsget_version: Option<String>,
@@ -83,8 +74,7 @@ pub struct Config {
   pub htsget_created_at: Option<String>,
   pub htsget_updated_at: Option<String>,
   pub htsget_environment: Option<String>,
-  pub htsget_localstorage_ip: String,
-  pub htsget_localstorage_port: String,
+  pub htsget_localstorage_addr: SocketAddr,
   pub htsget_localstorage_cert: PathBuf,
   pub htsget_localstorage_key: PathBuf,
   pub htsget_storage_type: StorageType,
@@ -95,11 +85,8 @@ pub struct Config {
 impl Default for Config {
   fn default() -> Self {
     Self {
-      htsget_port: default_port(),
-      htsget_ip: default_ip(),
-      htsget_path: default_path(),
-      htsget_regex_match: default_regex_match(),
-      htsget_regex_substitution: default_regex_substitution(),
+      htsget_addr: default_addr(),
+      htsget_resolver: default_resolver(),
       htsget_id: None,
       htsget_name: None,
       htsget_version: None,
@@ -110,8 +97,7 @@ impl Default for Config {
       htsget_created_at: None,
       htsget_updated_at: None,
       htsget_environment: None,
-      htsget_localstorage_ip: default_ip(),
-      htsget_localstorage_port: default_localstorage_port(),
+      htsget_localstorage_addr: default_localstorage_addr(),
       htsget_localstorage_cert: default_localstorage_cert(),
       htsget_localstorage_key: default_localstorage_key(),
       htsget_storage_type: LocalStorage,

--- a/htsget-config/src/config.rs
+++ b/htsget-config/src/config.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use serde::Deserialize;
+use crate::config::StorageType::LocalStorage;
 
 pub const USAGE: &str = r#"
 This executable doesn't use command line arguments, but there are some environment variables that can be set to configure the HtsGet server:
@@ -55,6 +56,14 @@ fn default_localstorage_key() -> PathBuf {
   default_path().join("certs/key.pem")
 }
 
+/// Specify the storage type to use.
+#[derive(Deserialize, Debug, Clone)]
+pub enum StorageType {
+  LocalStorage,
+  #[cfg(feature = "s3-storage")]
+  AwsS3Storage
+}
+
 /// Configuration for the server. Each field will be read from environment variables
 #[derive(Deserialize, Debug, Clone)]
 #[serde(default)]
@@ -74,11 +83,13 @@ pub struct Config {
   pub htsget_created_at: Option<String>,
   pub htsget_updated_at: Option<String>,
   pub htsget_environment: Option<String>,
-  pub htsget_s3_bucket: Option<String>,
   pub htsget_localstorage_ip: String,
   pub htsget_localstorage_port: String,
   pub htsget_localstorage_cert: PathBuf,
   pub htsget_localstorage_key: PathBuf,
+  pub htsget_storage_type: StorageType,
+  #[cfg(feature = "s3-storage")]
+  pub htsget_s3_bucket: Option<String>,
 }
 
 impl Default for Config {
@@ -99,11 +110,13 @@ impl Default for Config {
       htsget_created_at: None,
       htsget_updated_at: None,
       htsget_environment: None,
-      htsget_s3_bucket: None,
       htsget_localstorage_ip: default_ip(),
       htsget_localstorage_port: default_localstorage_port(),
       htsget_localstorage_cert: default_localstorage_cert(),
       htsget_localstorage_key: default_localstorage_key(),
+      htsget_storage_type: LocalStorage,
+      #[cfg(feature = "s3-storage")]
+      htsget_s3_bucket: None,
     }
   }
 }

--- a/htsget-config/src/config.rs
+++ b/htsget-config/src/config.rs
@@ -113,6 +113,7 @@ impl Default for Config {
 }
 
 impl Config {
+  /// Read the environment variables into a Config struct.
   pub fn from_env() -> std::io::Result<Self> {
     envy::prefixed(ENVIRONMENT_VARIABLE_PREFIX)
       .from_env()

--- a/htsget-config/src/config.rs
+++ b/htsget-config/src/config.rs
@@ -2,9 +2,9 @@ use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
-use serde::Deserialize;
 use crate::config::StorageType::LocalStorage;
 use crate::regex_resolver::RegexResolver;
+use serde::Deserialize;
 
 pub const USAGE: &str = r#"
 This executable doesn't use command line arguments, but there are some environment variables that can be set to configure the HtsGet server:
@@ -56,7 +56,7 @@ fn default_localstorage_key() -> PathBuf {
 pub enum StorageType {
   LocalStorage,
   #[cfg(feature = "s3-storage")]
-  AwsS3Storage
+  AwsS3Storage,
 }
 
 /// Configuration for the server. Each field will be read from environment variables
@@ -109,6 +109,11 @@ impl Default for Config {
 
 impl Config {
   pub fn from_env() -> std::io::Result<Self> {
-    envy::from_env().map_err(|err| std::io::Error::new(ErrorKind::Other, format!("Config not properly set: {}", err.to_string())))
+    envy::from_env().map_err(|err| {
+      std::io::Error::new(
+        ErrorKind::Other,
+        format!("Config not properly set: {}", err),
+      )
+    })
   }
 }

--- a/htsget-config/src/config.rs
+++ b/htsget-config/src/config.rs
@@ -64,6 +64,19 @@ pub enum StorageType {
 pub struct Config {
   pub htsget_addr: SocketAddr,
   pub htsget_resolver: RegexResolver,
+  pub htsget_path: PathBuf,
+  #[serde(flatten)]
+  pub htsget_config_service_info: ConfigServiceInfo,
+  pub htsget_localstorage_addr: SocketAddr,
+  pub htsget_localstorage_cert: PathBuf,
+  pub htsget_localstorage_key: PathBuf,
+  pub htsget_storage_type: StorageType,
+  #[cfg(feature = "s3-storage")]
+  pub htsget_s3_bucket: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct ConfigServiceInfo {
   pub htsget_id: Option<String>,
   pub htsget_name: Option<String>,
   pub htsget_version: Option<String>,
@@ -74,12 +87,6 @@ pub struct Config {
   pub htsget_created_at: Option<String>,
   pub htsget_updated_at: Option<String>,
   pub htsget_environment: Option<String>,
-  pub htsget_localstorage_addr: SocketAddr,
-  pub htsget_localstorage_cert: PathBuf,
-  pub htsget_localstorage_key: PathBuf,
-  pub htsget_storage_type: StorageType,
-  #[cfg(feature = "s3-storage")]
-  pub htsget_s3_bucket: Option<String>,
 }
 
 impl Default for Config {
@@ -87,16 +94,8 @@ impl Default for Config {
     Self {
       htsget_addr: default_addr(),
       htsget_resolver: default_resolver(),
-      htsget_id: None,
-      htsget_name: None,
-      htsget_version: None,
-      htsget_organization_name: None,
-      htsget_organization_url: None,
-      htsget_contact_url: None,
-      htsget_documentation_url: None,
-      htsget_created_at: None,
-      htsget_updated_at: None,
-      htsget_environment: None,
+      htsget_path: default_path(),
+      htsget_config_service_info: ConfigServiceInfo::default(),
       htsget_localstorage_addr: default_localstorage_addr(),
       htsget_localstorage_cert: default_localstorage_cert(),
       htsget_localstorage_key: default_localstorage_key(),

--- a/htsget-config/src/config.rs
+++ b/htsget-config/src/config.rs
@@ -1,3 +1,4 @@
+use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
@@ -103,5 +104,11 @@ impl Default for Config {
       #[cfg(feature = "s3-storage")]
       htsget_s3_bucket: None,
     }
+  }
+}
+
+impl Config {
+  pub fn from_env() -> std::io::Result<Self> {
+    envy::from_env().map_err(|err| std::io::Error::new(ErrorKind::Other, format!("Config not properly set: {}", err.to_string())))
   }
 }

--- a/htsget-config/src/regex_resolver.rs
+++ b/htsget-config/src/regex_resolver.rs
@@ -9,8 +9,8 @@ pub trait HtsGetIdResolver {
 #[serde(default)]
 pub struct RegexResolver {
   #[serde(with = "serde_regex")]
-  pub(crate) htsget_regex: Regex,
-  pub(crate) htsget_substitution_string: String,
+  pub(crate) regex: Regex,
+  pub(crate) substitution_string: String,
 }
 
 impl Default for RegexResolver {
@@ -22,19 +22,19 @@ impl Default for RegexResolver {
 impl RegexResolver {
   pub fn new(regex: &str, replacement_string: &str) -> Result<Self, Error> {
     Ok(RegexResolver {
-      htsget_regex: Regex::new(regex)?,
-      htsget_substitution_string: replacement_string.to_string(),
+      regex: Regex::new(regex)?,
+      substitution_string: replacement_string.to_string(),
     })
   }
 }
 
 impl HtsGetIdResolver for RegexResolver {
   fn resolve_id(&self, id: &str) -> Option<String> {
-    if self.htsget_regex.is_match(id) {
+    if self.regex.is_match(id) {
       Some(
         self
-          .htsget_regex
-          .replace(id, &self.htsget_substitution_string)
+          .regex
+          .replace(id, &self.substitution_string)
           .to_string(),
       )
     } else {
@@ -43,8 +43,9 @@ impl HtsGetIdResolver for RegexResolver {
   }
 }
 
+#[cfg(test)]
 pub mod tests {
-  use crate::regex_resolver::{HtsGetIdResolver, RegexResolver};
+  use super::*;
 
   #[test]
   fn resolver_resolve_id() {

--- a/htsget-config/src/regex_resolver.rs
+++ b/htsget-config/src/regex_resolver.rs
@@ -6,32 +6,49 @@ pub trait HtsGetIdResolver {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct RegexResolver {
   #[serde(with = "serde_regex")]
-  regex: Regex,
-  substitution_string: String,
+  pub(crate) htsget_regex: Regex,
+  pub(crate) htsget_substitution_string: String,
+}
+
+impl Default for RegexResolver {
+  fn default() -> Self {
+    Self::new(".*", "$0").expect("Expected valid resolver.")
+  }
 }
 
 impl RegexResolver {
   pub fn new(regex: &str, replacement_string: &str) -> Result<Self, Error> {
     Ok(RegexResolver {
-      regex: Regex::new(regex)?,
-      substitution_string: replacement_string.to_string(),
+      htsget_regex: Regex::new(regex)?,
+      htsget_substitution_string: replacement_string.to_string(),
     })
   }
 }
 
 impl HtsGetIdResolver for RegexResolver {
   fn resolve_id(&self, id: &str) -> Option<String> {
-    if self.regex.is_match(id) {
+    if self.htsget_regex.is_match(id) {
       Some(
         self
-          .regex
-          .replace(id, &self.substitution_string)
+          .htsget_regex
+          .replace(id, &self.htsget_substitution_string)
           .to_string(),
       )
     } else {
       None
     }
+  }
+}
+
+pub mod tests {
+  use crate::regex_resolver::{HtsGetIdResolver, RegexResolver};
+
+  #[test]
+  fn resolver_resolve_id() {
+    let resolver = RegexResolver::new(".*", "$0-test").unwrap();
+    assert_eq!(resolver.resolve_id("id").unwrap(), "id-test");
   }
 }

--- a/htsget-config/src/regex_resolver.rs
+++ b/htsget-config/src/regex_resolver.rs
@@ -1,10 +1,13 @@
 use regex::{Error, Regex};
 use serde::Deserialize;
 
+/// Represents an id resolver, which matches the id, replacing the match in the substitution text.
 pub trait HtsGetIdResolver {
+  /// Resolve the id, returning the substituted string if there is a match.
   fn resolve_id(&self, id: &str) -> Option<String>;
 }
 
+/// A regex resolver is a resolver that matches ids using Regex.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct RegexResolver {

--- a/htsget-config/src/regex_resolver.rs
+++ b/htsget-config/src/regex_resolver.rs
@@ -1,11 +1,13 @@
 use regex::{Error, Regex};
+use serde::Deserialize;
 
 pub trait HtsGetIdResolver {
   fn resolve_id(&self, id: &str) -> Option<String>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct RegexResolver {
+  #[serde(with = "serde_regex")]
   regex: Regex,
   substitution_string: String,
 }

--- a/htsget-http-actix/Cargo.toml
+++ b/htsget-http-actix/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>
 edition = "2021"
 
 [features]
-default = ["htsget-config/default", "htsget-search/default", "htsget-http-core/default"]
+s3-storage = []
+default = ["s3-storage", "htsget-config/default", "htsget-search/default", "htsget-http-core/default"]
 
 [dependencies]
 actix-web = "4.0"

--- a/htsget-http-actix/Cargo.toml
+++ b/htsget-http-actix/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>
 edition = "2021"
 
 [features]
-default = ["htsget-search/default", "htsget-http-core/default"]
+default = ["htsget-config/default", "htsget-search/default", "htsget-http-core/default"]
 
 [dependencies]
 actix-web = "4.0"

--- a/htsget-http-actix/Cargo.toml
+++ b/htsget-http-actix/Cargo.toml
@@ -9,7 +9,6 @@ default = ["htsget-config/default", "htsget-search/default", "htsget-http-core/d
 
 [dependencies]
 actix-web = "4.0"
-envy = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 futures-util = { version = "0.3", default-features = false }

--- a/htsget-http-actix/src/handlers/service_info.rs
+++ b/htsget-http-actix/src/handlers/service_info.rs
@@ -16,7 +16,7 @@ pub fn get_service_info_json<H: HtsGet + Send + Sync + 'static>(
   PrettyJson(get_base_service_info_json(
     endpoint,
     app_state.htsget.clone(),
-    &app_state.config,
+    &app_state.config_service_info,
   ))
 }
 

--- a/htsget-http-actix/src/lib.rs
+++ b/htsget-http-actix/src/lib.rs
@@ -127,14 +127,12 @@ mod tests {
         |service_config: &mut web::ServiceConfig| {
           configure_server(
             service_config,
-            HtsGetFromStorage::new(
-              LocalStorage::new(
-                self.config.path.clone(),
-                self.config.resolver.clone(),
-                HttpsFormatter::from(self.config.addr),
-              )
-              .unwrap(),
-            ),
+            HtsGetFromStorage::local_from(
+              self.config.path.clone(),
+              self.config.resolver.clone(),
+              HttpsFormatter::from(self.config.addr),
+            )
+            .unwrap(),
             self.config.service_info.clone(),
           );
         },

--- a/htsget-http-actix/src/lib.rs
+++ b/htsget-http-actix/src/lib.rs
@@ -129,13 +129,13 @@ mod tests {
             service_config,
             HtsGetFromStorage::new(
               LocalStorage::new(
-                self.config.htsget_path.clone(),
-                self.config.htsget_resolver.clone(),
-                HttpsFormatter::from(self.config.htsget_addr),
+                self.config.path.clone(),
+                self.config.resolver.clone(),
+                HttpsFormatter::from(self.config.addr),
               )
               .unwrap(),
             ),
-            self.config.htsget_config_service_info.clone(),
+            self.config.service_info.clone(),
           );
         },
       ))

--- a/htsget-http-actix/src/main.rs
+++ b/htsget-http-actix/src/main.rs
@@ -32,13 +32,10 @@ async fn main() -> std::io::Result<()> {
         formatter
     )?,
   );
-  let path = config.htsget_path;
-  let key = config.htsget_localstorage_key;
-  let cert = config.htsget_localstorage_cert;
 
   select! {
     local_server = tokio::spawn(async move {
-      local_server.serve(path, key, cert).await
+      local_server.serve(&config.htsget_path, &config.htsget_localstorage_key, &config.htsget_localstorage_cert).await
     }) => Ok(local_server??),
     actix_server = HttpServer::new(move || {
       App::new().configure(|service_config: &mut web::ServiceConfig| {

--- a/htsget-http-actix/src/main.rs
+++ b/htsget-http-actix/src/main.rs
@@ -5,9 +5,7 @@ use tokio::select;
 use htsget_config::config::{Config, StorageType, USAGE};
 use htsget_http_actix::run_server;
 use htsget_search::htsget::from_storage::HtsGetFromStorage;
-use htsget_search::storage::aws::AwsS3Storage;
 use htsget_search::storage::axum_server::HttpsFormatter;
-use htsget_search::storage::local::LocalStorage;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -30,7 +28,7 @@ async fn local_storage_server(config: Config) -> std::io::Result<()> {
   let formatter = HttpsFormatter::from(config.addr);
   let mut local_server = formatter.bind_axum_server().await?;
 
-  let searcher = HtsGetFromStorage::<LocalStorage<HttpsFormatter>>::from(
+  let searcher = HtsGetFromStorage::local_from(
     config.path.clone(),
     config.resolver.clone(),
     formatter.clone(),
@@ -53,6 +51,6 @@ async fn local_storage_server(config: Config) -> std::io::Result<()> {
 
 #[cfg(feature = "s3-storage")]
 async fn s3_storage_server(config: Config) -> std::io::Result<()> {
-  let searcher = HtsGetFromStorage::<AwsS3Storage>::from(config.s3_bucket, config.resolver).await?;
+  let searcher = HtsGetFromStorage::s3_from(config.s3_bucket, config.resolver).await;
   run_server(searcher, config.service_info, config.addr)?.await
 }

--- a/htsget-http-actix/src/main.rs
+++ b/htsget-http-actix/src/main.rs
@@ -1,14 +1,16 @@
 use std::env::args;
 use std::io::ErrorKind;
+use std::io::ErrorKind::Other;
 use std::sync::Arc;
 
 use actix_web::{web, App, HttpServer};
 use futures_util::future::err;
 use tokio::select;
 
-use htsget_config::config::{Config, USAGE};
-use htsget_http_actix::configure_server;
+use htsget_config::config::{Config, StorageType, USAGE};
+use htsget_http_actix::{configure_server, run_server};
 use htsget_search::htsget::from_storage::HtsGetFromStorage;
+use htsget_search::storage::aws::AwsS3Storage;
 use htsget_search::storage::axum_server::HttpsFormatter;
 use htsget_search::storage::local::LocalStorage;
 
@@ -22,27 +24,30 @@ async fn main() -> std::io::Result<()> {
 
   let config = Config::from_env()?;
 
+  match config.htsget_storage_type {
+    StorageType::LocalStorage => local_storage_server(config).await,
+    #[cfg(feature = "s3-storage")]
+    StorageType::AwsS3Storage => s3_storage_server(config).await
+  }
+}
+
+async fn local_storage_server(config: Config) -> std::io::Result<()> {
   let formatter = HttpsFormatter::from(config.htsget_addr);
   let mut local_server = formatter.bind_axum_server().await?;
 
-  let searcher = HtsGetFromStorage::new(
-    LocalStorage::new(
-      config.htsget_path.clone(),
-      config.htsget_resolver,
-        formatter
-    )?,
-  );
+  let searcher = HtsGetFromStorage::<LocalStorage<HttpsFormatter>>::from(config.htsget_path.clone(), config.htsget_resolver.clone(), formatter.clone())?;
+  let local_server = tokio::spawn(async move {
+    local_server.serve(&config.htsget_path, &config.htsget_localstorage_key, &config.htsget_localstorage_cert).await
+  });
 
   select! {
-    local_server = tokio::spawn(async move {
-      local_server.serve(&config.htsget_path, &config.htsget_localstorage_key, &config.htsget_localstorage_cert).await
-    }) => Ok(local_server??),
-    actix_server = HttpServer::new(move || {
-      App::new().configure(|service_config: &mut web::ServiceConfig| {
-        configure_server(service_config, searcher.clone(), config.htsget_config_service_info.clone());
-      })
-    })
-    .bind(config.htsget_addr)?
-    .run() => actix_server
+    local_server = local_server => Ok(local_server??),
+    actix_server = run_server(searcher, config.htsget_config_service_info, config.htsget_addr)? => actix_server
   }
+}
+
+#[cfg(feature = "s3-storage")]
+async fn s3_storage_server(config: Config) -> std::io::Result<()> {
+  let searcher = HtsGetFromStorage::<AwsS3Storage>::from(config.htsget_s3_bucket, config.htsget_resolver).await?;
+  run_server(searcher, config.htsget_config_service_info, config.htsget_addr)?.await
 }

--- a/htsget-http-core/src/lib.rs
+++ b/htsget-http-core/src/lib.rs
@@ -7,9 +7,9 @@ pub use http_core::{get_response_for_get_request, get_response_for_post_request}
 pub use json_response::{JsonResponse, JsonUrl};
 pub use post_request::{PostRequest, Region};
 use query_builder::QueryBuilder;
-pub use service_info::{ServiceInfo, ServiceInfoHtsget, ServiceInfoOrganization, ServiceInfoType};
 pub use service_info::get_service_info_json;
 pub use service_info::get_service_info_with;
+pub use service_info::{ServiceInfo, ServiceInfoHtsget, ServiceInfoOrganization, ServiceInfoType};
 
 mod error;
 mod http_core;
@@ -113,12 +113,12 @@ mod tests {
   use std::sync::Arc;
 
   use htsget_config::regex_resolver::RegexResolver;
-  use htsget_search::{
-    htsget::{Format, from_storage::HtsGetFromStorage, Headers, Url},
-    storage::local::LocalStorage,
-  };
   use htsget_search::htsget::HtsGet;
   use htsget_search::storage::axum_server::HttpsFormatter;
+  use htsget_search::{
+    htsget::{from_storage::HtsGetFromStorage, Format, Headers, Url},
+    storage::local::LocalStorage,
+  };
 
   use super::*;
 

--- a/htsget-http-core/src/service_info.rs
+++ b/htsget-http-core/src/service_info.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use htsget_config::config::Config;
+use htsget_config::config::{Config, ConfigServiceInfo};
 use htsget_search::htsget::{Format, HtsGet};
 
 use crate::{Endpoint, READS_FORMATS, VARIANTS_FORMATS};
@@ -95,7 +95,7 @@ pub fn get_service_info_with(
 pub fn get_service_info_json(
   endpoint: Endpoint,
   searcher: Arc<impl HtsGet + Send + Sync + 'static>,
-  config: &Config,
+  config: &ConfigServiceInfo,
 ) -> ServiceInfo {
   fill_out_service_info_json(
     get_service_info_with(
@@ -111,7 +111,7 @@ pub fn get_service_info_json(
 /// Fills the service-info json with the data from the server config
 pub(crate) fn fill_out_service_info_json(
   mut service_info_json: ServiceInfo,
-  config: &Config,
+  config: &ConfigServiceInfo,
 ) -> ServiceInfo {
   if let Some(id) = &config.htsget_id {
     service_info_json.id = id.clone();

--- a/htsget-http-core/src/service_info.rs
+++ b/htsget-http-core/src/service_info.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use htsget_config::config::{Config, ConfigServiceInfo};
+use htsget_config::config::ConfigServiceInfo;
 use htsget_search::htsget::{Format, HtsGet};
 
 use crate::{Endpoint, READS_FORMATS, VARIANTS_FORMATS};

--- a/htsget-http-core/src/service_info.rs
+++ b/htsget-http-core/src/service_info.rs
@@ -113,34 +113,34 @@ pub(crate) fn fill_out_service_info_json(
   mut service_info_json: ServiceInfo,
   config: &ConfigServiceInfo,
 ) -> ServiceInfo {
-  if let Some(id) = &config.htsget_id {
+  if let Some(id) = &config.id {
     service_info_json.id = id.clone();
   }
-  if let Some(name) = &config.htsget_name {
+  if let Some(name) = &config.name {
     service_info_json.name = name.clone();
   }
-  if let Some(version) = &config.htsget_version {
+  if let Some(version) = &config.version {
     service_info_json.version = version.clone();
   }
-  if let Some(organization_name) = &config.htsget_organization_name {
+  if let Some(organization_name) = &config.organization_name {
     service_info_json.organization.name = organization_name.clone();
   }
-  if let Some(organization_url) = &config.htsget_organization_url {
+  if let Some(organization_url) = &config.organization_url {
     service_info_json.organization.url = organization_url.clone();
   }
-  if let Some(contact_url) = &config.htsget_contact_url {
+  if let Some(contact_url) = &config.contact_url {
     service_info_json.contact_url = contact_url.clone();
   }
-  if let Some(documentation_url) = &config.htsget_documentation_url {
+  if let Some(documentation_url) = &config.documentation_url {
     service_info_json.documentation_url = documentation_url.clone();
   }
-  if let Some(created_at) = &config.htsget_created_at {
+  if let Some(created_at) = &config.created_at {
     service_info_json.created_at = created_at.clone();
   }
-  if let Some(updated_at) = &config.htsget_updated_at {
+  if let Some(updated_at) = &config.updated_at {
     service_info_json.updated_at = updated_at.clone();
   }
-  if let Some(environment) = &config.htsget_environment {
+  if let Some(environment) = &config.environment {
     service_info_json.environment = environment.clone();
   }
   service_info_json

--- a/htsget-http-lambda/Cargo.toml
+++ b/htsget-http-lambda/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [features]
 s3-storage = []
-default = ["s3-storage", "htsget-search/default", "htsget-http-core/default", "htsget-config/s3-storage"]
+default = ["s3-storage", "htsget-search/default", "htsget-http-core/default", "htsget-config/default"]
 
 [dependencies]
 envy = "0.4.2"

--- a/htsget-http-lambda/src/handlers/service_info.rs
+++ b/htsget-http-lambda/src/handlers/service_info.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use lambda_http::IntoResponse;
 
-use htsget_config::config::{Config, ConfigServiceInfo};
+use htsget_config::config::ConfigServiceInfo;
 use htsget_http_core::get_service_info_json as get_base_service_info_json;
 use htsget_http_core::Endpoint;
 use htsget_search::htsget::HtsGet;

--- a/htsget-http-lambda/src/handlers/service_info.rs
+++ b/htsget-http-lambda/src/handlers/service_info.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use lambda_http::IntoResponse;
 
-use htsget_config::config::Config;
+use htsget_config::config::{Config, ConfigServiceInfo};
 use htsget_http_core::get_service_info_json as get_base_service_info_json;
 use htsget_http_core::Endpoint;
 use htsget_search::htsget::HtsGet;
@@ -13,7 +13,7 @@ use crate::handlers::FormatJson;
 pub fn get_service_info_json<H: HtsGet + Send + Sync + 'static>(
   searcher: Arc<H>,
   endpoint: Endpoint,
-  config: &Config,
+  config: &ConfigServiceInfo,
 ) -> impl IntoResponse {
   FormatJson(get_base_service_info_json(endpoint, searcher, config))
 }

--- a/htsget-http-lambda/src/lib.rs
+++ b/htsget-http-lambda/src/lib.rs
@@ -251,14 +251,14 @@ mod tests {
 
     async fn test_server(&self, request: LambdaTestRequest<Request>) -> Response {
       let router = Router::new(
-        Arc::new(HtsGetFromStorage::new(
-          LocalStorage::new(
+        Arc::new(
+          HtsGetFromStorage::local_from(
             &self.config.path,
             self.config.resolver.clone(),
-            HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
+            HttpsFormatter::from(self.config.addr),
           )
           .expect("Couldn't create a Storage with the provided path"),
-        )),
+        ),
         &self.config.service_info,
       );
 
@@ -462,7 +462,7 @@ mod tests {
         LocalStorage::new(
           &config.path,
           config.resolver.clone(),
-          HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
+          HttpsFormatter::new("127.0.0.1", "8080").unwrap(),
         )
         .unwrap(),
       )),

--- a/htsget-http-lambda/src/lib.rs
+++ b/htsget-http-lambda/src/lib.rs
@@ -253,13 +253,13 @@ mod tests {
       let router = Router::new(
         Arc::new(HtsGetFromStorage::new(
           LocalStorage::new(
-            &self.config.htsget_path,
-            self.config.htsget_resolver.clone(),
+            &self.config.path,
+            self.config.resolver.clone(),
             HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
           )
           .expect("Couldn't create a Storage with the provided path"),
         )),
-        &self.config.htsget_config_service_info,
+        &self.config.service_info,
       );
 
       let response = router.route_request(request.0).await;
@@ -460,13 +460,13 @@ mod tests {
     let router = Router::new(
       Arc::new(HtsGetFromStorage::new(
         LocalStorage::new(
-          &config.htsget_path,
-          config.htsget_resolver.clone(),
+          &config.path,
+          config.resolver.clone(),
           HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
         )
         .unwrap(),
       )),
-      &config.htsget_config_service_info,
+      &config.service_info,
     );
     test(router).await
   }

--- a/htsget-http-lambda/src/lib.rs
+++ b/htsget-http-lambda/src/lib.rs
@@ -9,7 +9,7 @@ use lambda_http::ext::RequestExt;
 use lambda_http::http::{Method, StatusCode, Uri};
 use lambda_http::http::header::CONTENT_TYPE;
 
-use htsget_config::config::Config;
+use htsget_config::config::{Config, ConfigServiceInfo};
 use htsget_http_core::{Endpoint, PostRequest};
 use htsget_search::htsget::HtsGet;
 
@@ -54,12 +54,12 @@ impl Route {
 /// A Router is a struct which handles routing any htsget requests to the htsget search, using the config.
 pub struct Router<'a, H> {
   searcher: Arc<H>,
-  config: &'a Config,
+  config_service_info: &'a ConfigServiceInfo,
 }
 
 impl<'a, H: HtsGet + Send + Sync + 'static> Router<'a, H> {
-  pub fn new(searcher: Arc<H>, config: &'a Config) -> Self {
-    Self { searcher, config }
+  pub fn new(searcher: Arc<H>, config_service_info: &'a ConfigServiceInfo) -> Self {
+    Self { searcher, config_service_info }
   }
 
   /// Gets the Route if the request is valid, otherwise returns None.
@@ -101,7 +101,7 @@ impl<'a, H: HtsGet + Send + Sync + 'static> Router<'a, H> {
         method: _,
         endpoint,
         route_type: RouteType::ServiceInfo,
-      }) => get_service_info_json(self.searcher.clone(), endpoint, self.config).into_response(),
+      }) => get_service_info_json(self.searcher.clone(), endpoint, &self.config_service_info).into_response(),
       Some(Route {
         method: HtsgetMethod::Get,
         endpoint,
@@ -251,16 +251,12 @@ mod tests {
         Arc::new(HtsGetFromStorage::new(
           LocalStorage::new(
             &self.config.htsget_path,
-            RegexResolver::new(
-              &self.config.htsget_regex_match,
-              &self.config.htsget_regex_substitution,
-            )
-            .unwrap(),
+            self.config.htsget_resolver.clone(),
             HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
           )
           .expect("Couldn't create a Storage with the provided path"),
         )),
-        &self.config,
+        &self.config.htsget_config_service_info,
       );
 
       let response = router.route_request(request.0).await;
@@ -462,16 +458,12 @@ mod tests {
       Arc::new(HtsGetFromStorage::new(
         LocalStorage::new(
           &config.htsget_path,
-          RegexResolver::new(
-            &config.htsget_regex_match,
-            &config.htsget_regex_substitution,
-          )
-          .unwrap(),
+          config.htsget_resolver.clone(),
           HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
         )
         .unwrap(),
       )),
-      config,
+      &config.htsget_config_service_info,
     );
     test(router).await
   }

--- a/htsget-http-lambda/src/main.rs
+++ b/htsget-http-lambda/src/main.rs
@@ -1,11 +1,8 @@
-use std::io::ErrorKind::Other;
 use std::sync::Arc;
 
 use lambda_http::{service_fn, Error, Request};
-use tokio::select;
 
 use htsget_config::config::{Config, StorageType};
-use htsget_config::regex_resolver::RegexResolver;
 use htsget_http_lambda::Router;
 use htsget_search::htsget::from_storage::HtsGetFromStorage;
 use htsget_search::storage::aws::AwsS3Storage;
@@ -19,7 +16,7 @@ async fn main() -> Result<(), Error> {
   match config.htsget_storage_type {
     StorageType::LocalStorage => local_storage_server(config).await,
     #[cfg(feature = "s3-storage")]
-    StorageType::AwsS3Storage => s3_storage_server(config).await
+    StorageType::AwsS3Storage => s3_storage_server(config).await,
   }
 }
 
@@ -28,9 +25,9 @@ async fn local_storage_server(config: Config) -> Result<(), Error> {
     LocalStorage::new(
       config.htsget_path,
       config.htsget_resolver,
-      HttpsFormatter::from(config.htsget_addr)
+      HttpsFormatter::from(config.htsget_addr),
     )
-      .unwrap(),
+    .unwrap(),
   ));
   let router = &Router::new(searcher, &config.htsget_config_service_info);
 
@@ -42,7 +39,10 @@ async fn local_storage_server(config: Config) -> Result<(), Error> {
 
 #[cfg(feature = "s3-storage")]
 async fn s3_storage_server(config: Config) -> Result<(), Error> {
-  let searcher = Arc::new(HtsGetFromStorage::<AwsS3Storage>::from(config.htsget_s3_bucket, config.htsget_resolver).await?);
+  let searcher = Arc::new(
+    HtsGetFromStorage::<AwsS3Storage>::from(config.htsget_s3_bucket, config.htsget_resolver)
+      .await?,
+  );
   let router = &Router::new(searcher, &config.htsget_config_service_info);
 
   let handler = |event: Request| async move { Ok(router.route_request(event).await) };

--- a/htsget-http-lambda/src/main.rs
+++ b/htsget-http-lambda/src/main.rs
@@ -1,11 +1,14 @@
+use std::io::ErrorKind::Other;
 use std::sync::Arc;
 
 use lambda_http::{service_fn, Error, Request};
+use tokio::select;
 
-use htsget_config::config::Config;
+use htsget_config::config::{Config, StorageType};
 use htsget_config::regex_resolver::RegexResolver;
 use htsget_http_lambda::Router;
 use htsget_search::htsget::from_storage::HtsGetFromStorage;
+use htsget_search::storage::aws::AwsS3Storage;
 use htsget_search::storage::axum_server::HttpsFormatter;
 use htsget_search::storage::local::LocalStorage;
 
@@ -13,15 +16,33 @@ use htsget_search::storage::local::LocalStorage;
 async fn main() -> Result<(), Error> {
   let config = Config::from_env()?;
 
+  match config.htsget_storage_type {
+    StorageType::LocalStorage => local_storage_server(config).await,
+    #[cfg(feature = "s3-storage")]
+    StorageType::AwsS3Storage => s3_storage_server(config).await
+  }
+}
+
+async fn local_storage_server(config: Config) -> Result<(), Error> {
   let searcher = Arc::new(HtsGetFromStorage::new(
     LocalStorage::new(
       config.htsget_path,
       config.htsget_resolver,
       HttpsFormatter::from(config.htsget_addr)
     )
-    .unwrap(),
+      .unwrap(),
   ));
+  let router = &Router::new(searcher, &config.htsget_config_service_info);
 
+  let handler = |event: Request| async move { Ok(router.route_request(event).await) };
+  lambda_http::run(service_fn(handler)).await?;
+
+  Ok(())
+}
+
+#[cfg(feature = "s3-storage")]
+async fn s3_storage_server(config: Config) -> Result<(), Error> {
+  let searcher = Arc::new(HtsGetFromStorage::<AwsS3Storage>::from(config.htsget_s3_bucket, config.htsget_resolver).await?);
   let router = &Router::new(searcher, &config.htsget_config_service_info);
 
   let handler = |event: Request| async move { Ok(router.route_request(event).await) };

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [features]
 default = ["s3-storage"]
-s3-storage = ["aws-sdk-s3", "aws-config"]
+s3-storage = ["bytes", "aws-sdk-s3", "aws-config"]
 
 [dependencies]
 # Axum server dependencies.
@@ -14,7 +14,6 @@ hyper = "0.14"
 axum = "0.5.1"
 axum-extra = { version = "0.2.1", features = ["spa"] }
 rustls-pemfile = "0.3"
-tokio-tls = "0.3"
 tower = { version = "0.4", features = ["make"] }
 futures-util = "0.3"
 tokio-rustls = "0.23"
@@ -32,24 +31,18 @@ noodles-bcf = { version = "0.13", features = ["async"] }
 noodles-cram = { version = "0.14", features = ["async"] }
 noodles-vcf = { version = "0.15", features = ["async"] }
 
-#[cfg(feature = "aws")]
-bytes = "1.1"
-#[cfg(feature = "aws")]
+# Aws S3 storage dependencies.
+bytes = { version = "1.1", optional = true }
 aws-sdk-s3 = { version = "0.9", optional = true }
-#[cfg(feature = "aws")]
 aws-config = { version = "0.9", optional = true }
 
 [dev-dependencies]
 tempfile = "3.3"
-#[cfg(feature = "aws")]
-hyper = "0.14"
-#[cfg(feature = "aws")]
+
+# Aws S3 storage dependencies.
 anyhow = "1.0"
-#[cfg(feature = "aws")]
 s3-server = "0.2"
-#[cfg(feature = "aws")]
 http = "0.2"
-#[cfg(feature = "aws")]
 aws-types = { version = "0.9", features = ["hardcoded-credentials"] }
 
 # Axum server dependencies

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -3,25 +3,25 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use noodles::{bgzf, sam};
 use noodles::bam::bai;
-use noodles::bam::bai::Index;
 use noodles::bam::bai::index::ReferenceSequence;
+use noodles::bam::bai::Index;
 use noodles::bgzf::VirtualPosition;
 use noodles::csi::BinningIndex;
 use noodles::sam::Header;
+use noodles::{bgzf, sam};
 use noodles_bam as bam;
 use tokio::io;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncSeek;
 
+use crate::htsget::search::{BgzfSearch, Search, SearchReads, VirtualPositionExt};
+use crate::htsget::HtsGetError;
 use crate::{
-  htsget::{Format, Query, Result},
   htsget::search::BlockPosition,
+  htsget::{Format, Query, Result},
   storage::{BytesRange, Storage},
 };
-use crate::htsget::HtsGetError;
-use crate::htsget::search::{BgzfSearch, Search, SearchReads, VirtualPositionExt};
 
 type AsyncReader<ReaderType> = bam::AsyncReader<bgzf::AsyncReader<ReaderType>>;
 

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -13,11 +13,11 @@ use noodles::cram::crai::{Index, Record};
 use noodles::sam;
 use noodles::sam::Header;
 use noodles_cram::AsyncReader;
-use tokio::{io, select};
 use tokio::io::{AsyncRead, AsyncSeek};
+use tokio::{io, select};
 
-use crate::htsget::{Format, HtsGetError, Query, Result};
 use crate::htsget::search::{Search, SearchAll, SearchReads};
+use crate::htsget::{Format, HtsGetError, Query, Result};
 use crate::storage::{BytesRange, Storage};
 
 pub(crate) struct CramSearch<S> {

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -73,9 +73,11 @@ impl<S> HtsGetFromStorage<S> {
 
 #[cfg(feature = "s3-storage")]
 impl HtsGetFromStorage<AwsS3Storage> {
-  pub async fn from(bucket: String, resolver: RegexResolver) -> Result<Self> {
+  pub async fn from(bucket: Option<String>, resolver: RegexResolver) -> Result<Self> {
     Ok(HtsGetFromStorage::new(
-      AwsS3Storage::new_with_default_config(bucket, resolver).await
+      AwsS3Storage::new_with_default_config(bucket.ok_or_else(|| {
+        HtsGetError::io_error("Aws S3 Storage bucket not specified.")
+      })?, resolver).await
     ))
   }
 }

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 /// Implementation of the [HtsGet] trait using a [Storage].
+#[derive(Debug, Clone)]
 pub struct HtsGetFromStorage<S> {
   storage_ref: Arc<S>,
 }

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -71,15 +71,17 @@ impl<S> HtsGetFromStorage<S> {
 
 #[cfg(feature = "s3-storage")]
 impl HtsGetFromStorage<AwsS3Storage> {
-  pub async fn from(bucket: String, resolver: RegexResolver) -> Result<Self> {
-    Ok(HtsGetFromStorage::new(
-      AwsS3Storage::new_with_default_config(bucket, resolver).await,
-    ))
+  pub async fn s3_from(bucket: String, resolver: RegexResolver) -> Self {
+    HtsGetFromStorage::new(AwsS3Storage::new_with_default_config(bucket, resolver).await)
   }
 }
 
 impl<T: UrlFormatter + Send + Sync> HtsGetFromStorage<LocalStorage<T>> {
-  pub fn from<P: AsRef<Path>>(path: P, resolver: RegexResolver, formatter: T) -> Result<Self> {
+  pub fn local_from<P: AsRef<Path>>(
+    path: P,
+    resolver: RegexResolver,
+    formatter: T,
+  ) -> Result<Self> {
     Ok(HtsGetFromStorage::new(LocalStorage::new(
       path, resolver, formatter,
     )?))

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -10,7 +10,7 @@ use tokio::io::{AsyncRead, AsyncSeek};
 use htsget_config::regex_resolver::RegexResolver;
 
 use crate::htsget::search::Search;
-use crate::htsget::{Format, HtsGetError};
+use crate::htsget::Format;
 use crate::storage::aws::AwsS3Storage;
 use crate::storage::local::LocalStorage;
 use crate::storage::UrlFormatter;
@@ -71,13 +71,9 @@ impl<S> HtsGetFromStorage<S> {
 
 #[cfg(feature = "s3-storage")]
 impl HtsGetFromStorage<AwsS3Storage> {
-  pub async fn from(bucket: Option<String>, resolver: RegexResolver) -> Result<Self> {
+  pub async fn from(bucket: String, resolver: RegexResolver) -> Result<Self> {
     Ok(HtsGetFromStorage::new(
-      AwsS3Storage::new_with_default_config(
-        bucket.ok_or_else(|| HtsGetError::io_error("Aws S3 Storage bucket not specified."))?,
-        resolver,
-      )
-      .await,
+      AwsS3Storage::new_with_default_config(bucket, resolver).await,
     ))
   }
 }

--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -7,8 +7,10 @@ use core::fmt;
 use std::collections::HashMap;
 use std::fmt::Formatter;
 use std::io;
+use std::io::ErrorKind;
 
 use async_trait::async_trait;
+use futures_util::future::err;
 use thiserror::Error;
 use tokio::task::JoinError;
 
@@ -83,6 +85,12 @@ impl HtsGetError {
 
   pub fn concurrency_error<S: Into<String>>(message: S) -> Self {
     Self::InternalError(message.into())
+  }
+}
+
+impl From<HtsGetError> for std::io::Error {
+  fn from(error: HtsGetError) -> Self {
+    Self::new(ErrorKind::Other, error)
   }
 }
 

--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -10,7 +10,6 @@ use std::io;
 use std::io::ErrorKind;
 
 use async_trait::async_trait;
-use futures_util::future::err;
 use thiserror::Error;
 use tokio::task::JoinError;
 

--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -105,7 +105,7 @@ impl From<StorageError> for HtsGetError {
       StorageError::IoError(e) => Self::IoError(format!("Io error: {}", e)),
       #[cfg(feature = "s3-storage")]
       StorageError::AwsS3Error { .. } => Self::IoError(format!("AWS S3 error: {:?}", err)),
-      StorageError::ResponseServerError(e) => {
+      StorageError::TicketServerError(e) => {
         Self::InternalError(format!("Error using url response server: {}", e))
       }
       StorageError::InvalidInput(e) => Self::InvalidInput(format!("Invalid input: {}", e)),

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -9,19 +9,19 @@ use futures::prelude::stream::FuturesUnordered;
 use noodles::bgzf;
 use noodles::bgzf::VirtualPosition;
 use noodles::tabix;
-use noodles::tabix::Index;
 use noodles::tabix::index::ReferenceSequence;
+use noodles::tabix::Index;
 use noodles::vcf::Header;
 use noodles_vcf as vcf;
 use tokio::io;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncSeek;
 
+use crate::htsget::search::{find_first, BgzfSearch, BlockPosition, Search};
 use crate::{
   htsget::{Format, Query, Result},
   storage::{BytesRange, Storage},
 };
-use crate::htsget::search::{BgzfSearch, BlockPosition, find_first, Search};
 
 type AsyncReader<ReaderType> = vcf::AsyncReader<bgzf::AsyncReader<ReaderType>>;
 

--- a/htsget-search/src/storage/aws.rs
+++ b/htsget-search/src/storage/aws.rs
@@ -31,6 +31,7 @@ pub enum Retrieval {
 }
 
 /// Implementation for the [Storage] trait utilising data from an S3 bucket.
+#[derive(Debug, Clone)]
 pub struct AwsS3Storage {
   client: Client,
   bucket: String,

--- a/htsget-search/src/storage/axum_server.rs
+++ b/htsget-search/src/storage/axum_server.rs
@@ -192,7 +192,12 @@ mod tests {
     // Start server.
     let addr = SocketAddr::from_str(&format!("{}:{}", "127.0.0.1", "8080")).unwrap();
     let mut server = AxumStorageServer::bind_addr(&addr).await.unwrap();
-    tokio::spawn(async move { server.serve(base_path.path(), &key_path, &cert_path).await.unwrap() });
+    tokio::spawn(async move {
+      server
+        .serve(base_path.path(), &key_path, &cert_path)
+        .await
+        .unwrap()
+    });
 
     // Make request.
     let client = Client::builder().build::<_, hyper::Body>(https);
@@ -212,6 +217,9 @@ mod tests {
   #[test]
   fn https_formatter_format_authority() {
     let formatter = HttpsFormatter::new("127.0.0.1", "8080").unwrap();
-    assert_eq!(formatter.format_url("/path".to_string()).unwrap(), "https://127.0.0.1:8080/path")
+    assert_eq!(
+      formatter.format_url("/path".to_string()).unwrap(),
+      "https://127.0.0.1:8080/path"
+    )
   }
 }

--- a/htsget-search/src/storage/local.rs
+++ b/htsget-search/src/storage/local.rs
@@ -118,8 +118,8 @@ pub(crate) mod tests {
   use tokio::io::AsyncWriteExt;
 
   use crate::htsget::{Headers, Url};
-  use crate::storage::{BytesRange, GetOptions, StorageError, UrlOptions};
   use crate::storage::axum_server::HttpsFormatter;
+  use crate::storage::{BytesRange, GetOptions, StorageError, UrlOptions};
 
   use super::*;
 

--- a/htsget-search/src/storage/local.rs
+++ b/htsget-search/src/storage/local.rs
@@ -15,7 +15,7 @@ use super::{GetOptions, Result, StorageError, UrlOptions};
 
 /// Implementation for the [Storage] trait using the local file system. [T] is the type of the
 /// server struct, which is used for formatting urls.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LocalStorage<T> {
   base_path: PathBuf,
   id_resolver: RegexResolver,

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -60,8 +60,8 @@ pub enum StorageError {
   #[error("Aws error: {0}, with key: {1}")]
   AwsS3Error(String, String),
 
-  #[error("Url response server error: {0}")]
-  ResponseServerError(String),
+  #[error("Url response ticket server error: {0}")]
+  TicketServerError(String),
 
   #[error("Invalid input: {0}")]
   InvalidInput(String),

--- a/htsget-test-utils/src/server_tests.rs
+++ b/htsget-test-utils/src/server_tests.rs
@@ -19,7 +19,7 @@ pub async fn test_get<T: TestRequest>(tester: &impl TestServer<T>) {
   let url_path = expected_local_storage_path(tester.get_config());
   assert!(response.is_success());
   assert_eq!(
-    expected_response(&tester.get_config().htsget_path, Class::Body, url_path),
+    expected_response(&tester.get_config().path, Class::Body, url_path),
     response.deserialize_body().unwrap()
   );
 }
@@ -42,7 +42,7 @@ pub async fn test_post<T: TestRequest>(tester: &impl TestServer<T>) {
   let url_path = expected_local_storage_path(tester.get_config());
   assert!(response.is_success());
   assert_eq!(
-    expected_response(&tester.get_config().htsget_path, Class::Body, url_path),
+    expected_response(&tester.get_config().path, Class::Body, url_path),
     response.deserialize_body().unwrap()
   );
 }
@@ -57,7 +57,7 @@ pub async fn test_parameterized_get<T: TestRequest>(tester: &impl TestServer<T>)
   let url_path = expected_local_storage_path(tester.get_config());
   assert!(response.is_success());
   assert_eq!(
-    expected_response(&tester.get_config().htsget_path, Class::Header, url_path),
+    expected_response(&tester.get_config().path, Class::Header, url_path),
     response.deserialize_body().unwrap()
   );
 }
@@ -70,7 +70,7 @@ pub async fn test_parameterized_post<T: TestRequest>(tester: &impl TestServer<T>
   let url_path = expected_local_storage_path(tester.get_config());
   assert!(response.is_success());
   assert_eq!(
-    expected_response(&tester.get_config().htsget_path, Class::Body, url_path),
+    expected_response(&tester.get_config().path, Class::Body, url_path),
     response.deserialize_body().unwrap()
   );
 }
@@ -93,7 +93,7 @@ pub async fn test_service_info<T: TestRequest>(tester: &impl TestServer<T>) {
 }
 
 fn expected_local_storage_path(config: &Config) -> String {
-  format!("https://{}", config.htsget_addr)
+  format!("https://{}", config.addr)
 }
 
 /// An example VCF search response.

--- a/htsget-test-utils/src/server_tests.rs
+++ b/htsget-test-utils/src/server_tests.rs
@@ -94,8 +94,8 @@ pub async fn test_service_info<T: TestRequest>(tester: &impl TestServer<T>) {
 
 fn expected_local_storage_path(config: &Config) -> String {
   format!(
-    "https://{}:{}",
-    config.htsget_localstorage_ip, config.htsget_localstorage_port
+    "https://{}",
+    config.htsget_addr
   )
 }
 

--- a/htsget-test-utils/src/server_tests.rs
+++ b/htsget-test-utils/src/server_tests.rs
@@ -124,5 +124,5 @@ pub fn default_test_config() -> Config {
     "HTSGET_PATH",
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).parent().unwrap(),
   );
-  envy::from_env::<Config>().expect("Expected valid environment variables.")
+  Config::from_env().expect("Expected valid environment variables.")
 }

--- a/htsget-test-utils/src/server_tests.rs
+++ b/htsget-test-utils/src/server_tests.rs
@@ -93,10 +93,7 @@ pub async fn test_service_info<T: TestRequest>(tester: &impl TestServer<T>) {
 }
 
 fn expected_local_storage_path(config: &Config) -> String {
-  format!(
-    "https://{}",
-    config.htsget_addr
-  )
+  format!("https://{}", config.htsget_addr)
 }
 
 /// An example VCF search response.


### PR DESCRIPTION
This PR enables choosing between using `LocalStorage` and `AwsS3Storage`. It also refactors a bit of code in the some of the crates.

Changes:
* Add `StorageType` config option which allows choosing between `LocalStorage` and `AwsS3Storage`.
* Refactor some config options.
* Update usage text.
* Add a few tests for the config options.

Further improvements may involve adding the ability to setup multiple resolvers, that map to arbitrary storage types. For example, an id starting with "aws-{id}" could map to an `AwsS3Storage`, whereas an id starting with "local-{id}" could map to `LocalStorage`.