### PR TITLE
Fix localstorage path

### DIFF
--- a/data/events/event_get.json
+++ b/data/events/event_get.json
@@ -1,6 +1,6 @@
 {
   "httpMethod": "GET",
-  "path": "/variants/data/vcf/sample1-bcbio-cancer",
+  "path": "/variants/vcf/sample1-bcbio-cancer",
   "body": null,
 
   "resource": "/{proxy+}",

--- a/data/events/event_parameterized_get.json
+++ b/data/events/event_parameterized_get.json
@@ -1,6 +1,6 @@
 {
   "httpMethod": "GET",
-  "path": "/variants/data/vcf/sample1-bcbio-cancer",
+  "path": "/variants/vcf/sample1-bcbio-cancer",
   "body": null,
 
   "resource": "/{proxy+}",

--- a/data/events/event_parameterized_post.json
+++ b/data/events/event_parameterized_post.json
@@ -1,6 +1,6 @@
 {
   "httpMethod": "POST",
-  "path": "/variants/data/vcf/sample1-bcbio-cancer",
+  "path": "/variants/vcf/sample1-bcbio-cancer",
   "body": "{\"format\": \"VCF\", \"regions\": [{\"referenceName\": \"chrM\"}]}",
 
   "resource": "/{proxy+}",

--- a/data/events/event_parameterized_post_class_header.json
+++ b/data/events/event_parameterized_post_class_header.json
@@ -1,6 +1,6 @@
 {
   "httpMethod": "POST",
-  "path": "/variants/data/vcf/sample1-bcbio-cancer",
+  "path": "/variants/vcf/sample1-bcbio-cancer",
   "body": "{\"format\": \"VCF\", \"class\": \"header\", \"regions\": [{\"referenceName\": \"chrM\"}]}",
 
   "resource": "/{proxy+}",

--- a/data/events/event_post.json
+++ b/data/events/event_post.json
@@ -1,6 +1,6 @@
 {
   "httpMethod": "POST",
-  "path": "/variants/data/vcf/sample1-bcbio-cancer",
+  "path": "/variants/vcf/sample1-bcbio-cancer",
   "body": null,
 
   "resource": "/{proxy+}",

--- a/htsget-config/src/config.rs
+++ b/htsget-config/src/config.rs
@@ -9,13 +9,13 @@ use crate::config::StorageType::LocalStorage;
 use crate::regex_resolver::RegexResolver;
 
 pub const USAGE: &str = r#"
-This executable doesn't use command line arguments, but there are some environment variables that can be set to configure the HtsGet server:
-* HTSGET_ADDR: The socket address to use for the server which creates response tickets. Default: "127.0.0.1:8080".
+The HtsGet server executables don't use command line arguments, but there are some environment variables that can be set to configure them:
+* HTSGET_ADDR: The socket address for the server which creates response tickets. Default: "127.0.0.1:8080".
 * HTSGET_PATH: The path to the directory where the server should be started. Default: ".". Unused if HTSGET_STORAGE_TYPE is "AwsS3Storage".
 * HTSGET_REGEX: The regular expression that should match an ID. Default: ".*".
 For more information about the regex options look in the documentation of the regex crate(https://docs.rs/regex/).
 * HTSGET_SUBSTITUTION_STRING: The replacement expression. Default: "$0".
-* HTSGET_STORAGE_TYPE: Either LocalStorage or AwsS3Storage. Default: "LocalStorage".
+* HTSGET_STORAGE_TYPE: Either "LocalStorage" or "AwsS3Storage", representing which storage type to use. Default: "LocalStorage".
 
 The following options are used for the ticket server.
 * HTSGET_TICKET_SERVER_ADDR: The socket address to use for the server which responds to tickets. Default: "127.0.0.1:8081". Unused if HTSGET_STORAGE_TYPE is not "LocalStorage".

--- a/htsget-http-actix/README.md
+++ b/htsget-http-actix/README.md
@@ -55,25 +55,25 @@ As mentioned above, please keep in mind that the server will take the path where
 ### GET
 
 ```shell
-$ curl '127.0.0.1:8080/variants/data/vcf/sample1-bcbio-cancer'
+$ curl '127.0.0.1:8080/variants/vcf/sample1-bcbio-cancer'
 ```
 
 ### POST
 
 ```shell
-$ curl --header "Content-Type: application/json" -d '{}' '127.0.0.1:8080/variants/data/vcf/sample1-bcbio-cancer'
+$ curl --header "Content-Type: application/json" -d '{}' '127.0.0.1:8080/variants/vcf/sample1-bcbio-cancer'
 ```
 
 ### Parametrised GET
 
 ```shell
-$ curl '127.0.0.1:8080/variants/data/vcf/sample1-bcbio-cancer?format=VCF&class=header'
+$ curl '127.0.0.1:8080/variants/vcf/sample1-bcbio-cancer?format=VCF&class=header'
 ```
 
 ### Parametrised POST
 
 ```shell
-$ curl --header "Content-Type: application/json" -d '{"format": "VCF", "regions": [{"referenceName": "chrM"}]}' '127.0.0.1:8080/variants/data/vcf/sample1-bcbio-cancer'
+$ curl --header "Content-Type: application/json" -d '{"format": "VCF", "regions": [{"referenceName": "chrM"}]}' '127.0.0.1:8080/variants/vcf/sample1-bcbio-cancer'
 ```
 
 ### Service-info

--- a/htsget-http-actix/README.md
+++ b/htsget-http-actix/README.md
@@ -38,11 +38,11 @@ Since this service can be used in serverless environments, no `dotenv` configura
 | HTSGET_S3_BUCKET           | The name of the AWS S3 bucket. Unused if HTSGET_STORAGE_TYPE is not "AwsS3Storage".                                                      | ""               |
 | HTSGET_ID                  | ID of the service.                                                                                                                       | "None"           |
 | HTSGET_NAME                | Name of the service.                                                                                                                     | "None"           |
-| HTSGET_VERSION             | Version of the service                                                                                                                   | "None"           |
-| HTSGET_ORGANIZATION_NAME   | Name of the organization                                                                                                                 | "None"           |
-| HTSGET_ORGANIZATION_URL    | URL of the organization                                                                                                                  | "None"           |
-| HTSGET_CONTACT_URL         | URL to provide contact to the users                                                                                                      | "None"           |
-| HTSGET_DOCUMENTATION_URL   | Link to documentation                                                                                                                    | "None"           |
+| HTSGET_VERSION             | Version of the service.                                                                                                                  | "None"           |
+| HTSGET_ORGANIZATION_NAME   | Name of the organization.                                                                                                                | "None"           |
+| HTSGET_ORGANIZATION_URL    | URL of the organization.                                                                                                                 | "None"           |
+| HTSGET_CONTACT_URL         | URL to provide contact to the users.                                                                                                     | "None"           |
+| HTSGET_DOCUMENTATION_URL   | Link to documentation.                                                                                                                   | "None"           |
 | HTSGET_CREATED_AT          | Date of the creation of the service.                                                                                                     | "None"           |
 | HTSGET_UPDATED_AT          | Date of the last update of the service.                                                                                                  | "None"           |
 | HTSGET_ENVIRONMENT         | Environment in which the service is running.                                                                                             | "None"           |
@@ -85,6 +85,6 @@ $ curl 127.0.0.1:8080/variants/service-info
 ## Example Regular expressions
 In this example 'data/' is added after the first '/'.
 ```shell
-$ HTSGET_REGEX='(?P<group1>.*?)/(?P<group2>.*)' HTSGET_REPLACEMENT='$group1/data/$group2' cargo run --release -p htsget-http-actix
+$ HTSGET_REGEX='(?P<group1>.*?)/(?P<group2>.*)' HTSGET_SUBSTITUTION_STRING='$group1/data/$group2' cargo run --release -p htsget-http-actix
 ```
 For more information about the regex options look in the [documentation of the regex crate](https://docs.rs/regex/).

--- a/htsget-http-actix/README.md
+++ b/htsget-http-actix/README.md
@@ -25,23 +25,27 @@ There are reasonable defaults to allow the user to spin up the server as fast as
 
 Since this service can be used in serverless environments, no `dotenv` configuration is needed, [adjusting the environment variables below prevent accidental leakage of settings and sensitive information](https://medium.com/@softprops/configuration-envy-a09584386705).
 
-| Variable | Description | Default |
-|---|---|---|
-| HTSGET_IP| IP address | 127.0.0.1 |
-| HTSGET_PORT| TCP Port | 8080 |
-| HTSGET_PATH| The path to the directory where the server starts | `$PWD` | 
-| HTSGET_REGEX| The regular expression an ID should match. | ".*" |
-| HTSGET_REPLACEMENT| The replacement expression, to produce a key from an ID. | "$0" |
-| HTSGET_ID| ID of the service. | "" |
-| HTSGET_NAME| Name of the service. | HtsGet service |
-| HTSGET_VERSION | Version of the service | ""
-| HTSGET_ORGANIZATION_NAME| Name of the organization | Snake oil
-| HTSGET_ORGANIZATION_URL| URL of the organization | https://en.wikipedia.org/wiki/Snake_oil |
-| HTSGET_CONTACT_URL | URL to provide contact to the users | "" |
-| HTSGET_DOCUMENTATION_URL| Link to documentation | https://github.com/umccr/htsget-rs/tree/main/htsget-http-actix |
-| HTSGET_CREATED_AT | Date of the creation of the service. | "" |
-| HTSGET_UPDATED_AT | Date of the last update of the service. | "" |
-| HTSGET_ENVIRONMENT | Environment in which the service is running. | Testing |
+| Variable                   | Description                                                                                                                              | Default          |
+|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------|------------------|
+| HTSGET_ADDR                | The socket address for the server which creates response tickets.                                                                        | "127.0.0.1:8080" |
+| HTSGET_PATH                | The path to the directory where the server starts                                                                                        | "."              | 
+| HTSGET_REGEX               | The regular expression an ID should match.                                                                                               | ".*"             |
+| HTSGET_SUBSTITUTION_STRING | The replacement expression, to produce a key from an ID.                                                                                 | "$0"             |
+| HTSGET_STORAGE_TYPE        | Either "LocalStorage" or "AwsS3Storage", representing which storage type to use.                                                         | "LocalStorage"   |
+| HTSGET_TICKET_SERVER_ADDR  | The socket address to use for the server which responds to tickets. Unused if HTSGET_STORAGE_TYPE is not "LocalStorage".                 | "127.0.0.1:8081" |
+| HTSGET_TICKET_SERVER_KEY   | The path to the PEM formatted X.509 private key used by the ticket response server. Unused if HTSGET_STORAGE_TYPE is not "LocalStorage". | "key.pem"        |
+| HTSGET_TICKET_SERVER_CERT  | The path to the PEM formatted X.509 certificate used by the ticket response server. Unused if HTSGET_STORAGE_TYPE is not "LocalStorage". | "cert.pem"       |
+| HTSGET_S3_BUCKET           | The name of the AWS S3 bucket. Unused if HTSGET_STORAGE_TYPE is not "AwsS3Storage".                                                      | ""               |
+| HTSGET_ID                  | ID of the service.                                                                                                                       | "None"           |
+| HTSGET_NAME                | Name of the service.                                                                                                                     | "None"           |
+| HTSGET_VERSION             | Version of the service                                                                                                                   | "None"           |
+| HTSGET_ORGANIZATION_NAME   | Name of the organization                                                                                                                 | "None"           |
+| HTSGET_ORGANIZATION_URL    | URL of the organization                                                                                                                  | "None"           |
+| HTSGET_CONTACT_URL         | URL to provide contact to the users                                                                                                      | "None"           |
+| HTSGET_DOCUMENTATION_URL   | Link to documentation                                                                                                                    | "None"           |
+| HTSGET_CREATED_AT          | Date of the creation of the service.                                                                                                     | "None"           |
+| HTSGET_UPDATED_AT          | Date of the last update of the service.                                                                                                  | "None"           |
+| HTSGET_ENVIRONMENT         | Environment in which the service is running.                                                                                             | "None"           |
 For more information about the regex options look in the [documentation of the regex crate](https://docs.rs/regex/).
 
 ## Example cURL requests

--- a/htsget-http-actix/src/handlers/get.rs
+++ b/htsget-http-actix/src/handlers/get.rs
@@ -4,6 +4,7 @@ use actix_web::{
   web::{Data, Path, Query},
   Responder,
 };
+use tracing::info;
 
 use htsget_http_core::{get_response_for_get_request, Endpoint};
 use htsget_search::htsget::HtsGet;
@@ -20,6 +21,7 @@ pub async fn reads<H: HtsGet + Send + Sync + 'static>(
 ) -> impl Responder {
   let mut query_information = request.into_inner();
   query_information.insert("id".to_string(), path.into_inner());
+  info!(query = ?query_information, "Reads endpoint GET request");
   handle_response(
     get_response_for_get_request(
       app_state.get_ref().htsget.clone(),
@@ -38,6 +40,7 @@ pub async fn variants<H: HtsGet + Send + Sync + 'static>(
 ) -> impl Responder {
   let mut query_information = request.into_inner();
   query_information.insert("id".to_string(), path.into_inner());
+  info!(query = ?query_information, "Variants endpoint GET request");
   handle_response(
     get_response_for_get_request(
       app_state.get_ref().htsget.clone(),

--- a/htsget-http-actix/src/handlers/post.rs
+++ b/htsget-http-actix/src/handlers/post.rs
@@ -2,6 +2,7 @@ use actix_web::{
   web::{Data, Json, Path},
   Responder,
 };
+use tracing::info;
 
 use htsget_http_core::{get_response_for_post_request, Endpoint, PostRequest};
 use htsget_search::htsget::HtsGet;
@@ -16,6 +17,7 @@ pub async fn reads<H: HtsGet + Send + Sync + 'static>(
   path: Path<String>,
   app_state: Data<AppState<H>>,
 ) -> impl Responder {
+  info!(request = ?request, "Reads endpoint POST request");
   handle_response(
     get_response_for_post_request(
       app_state.get_ref().htsget.clone(),
@@ -33,6 +35,7 @@ pub async fn variants<H: HtsGet + Send + Sync + 'static>(
   path: Path<String>,
   app_state: Data<AppState<H>>,
 ) -> impl Responder {
+  info!(request = ?request, "Variants endpoint POST request");
   handle_response(
     get_response_for_post_request(
       app_state.get_ref().htsget.clone(),

--- a/htsget-http-actix/src/handlers/service_info.rs
+++ b/htsget-http-actix/src/handlers/service_info.rs
@@ -1,5 +1,6 @@
 use actix_web::web::Data;
 use actix_web::Responder;
+use tracing::info;
 
 use htsget_http_core::get_service_info_json as get_base_service_info_json;
 use htsget_http_core::Endpoint;
@@ -13,6 +14,7 @@ pub fn get_service_info_json<H: HtsGet + Send + Sync + 'static>(
   app_state: &AppState<H>,
   endpoint: Endpoint,
 ) -> impl Responder {
+  info!(endpoint = ?endpoint, "Service info request");
   PrettyJson(get_base_service_info_json(
     endpoint,
     app_state.htsget.clone(),

--- a/htsget-http-actix/src/lib.rs
+++ b/htsget-http-actix/src/lib.rs
@@ -134,8 +134,7 @@ mod tests {
               self.config.path.clone(),
               self.config.resolver.clone(),
               HttpsFormatter::from(self.config.addr),
-            )
-            .unwrap(),
+            ),
             self.config.service_info.clone(),
           );
         },

--- a/htsget-http-actix/src/lib.rs
+++ b/htsget-http-actix/src/lib.rs
@@ -133,8 +133,9 @@ mod tests {
             HtsGetFromStorage::local_from(
               self.config.path.clone(),
               self.config.resolver.clone(),
-              HttpsFormatter::from(self.config.addr),
-            ),
+              HttpsFormatter::from(self.config.ticket_server_addr),
+            )
+            .unwrap(),
             self.config.service_info.clone(),
           );
         },

--- a/htsget-http-actix/src/main.rs
+++ b/htsget-http-actix/src/main.rs
@@ -32,7 +32,7 @@ async fn local_storage_server(config: Config) -> std::io::Result<()> {
     config.path.clone(),
     config.resolver.clone(),
     formatter.clone(),
-  );
+  )?;
   let local_server = tokio::spawn(async move {
     local_server
       .serve(

--- a/htsget-http-actix/src/main.rs
+++ b/htsget-http-actix/src/main.rs
@@ -32,7 +32,7 @@ async fn local_storage_server(config: Config) -> std::io::Result<()> {
     config.path.clone(),
     config.resolver.clone(),
     formatter.clone(),
-  )?;
+  );
   let local_server = tokio::spawn(async move {
     local_server
       .serve(

--- a/htsget-http-actix/src/main.rs
+++ b/htsget-http-actix/src/main.rs
@@ -25,7 +25,7 @@ async fn main() -> std::io::Result<()> {
 }
 
 async fn local_storage_server(config: Config) -> std::io::Result<()> {
-  let formatter = HttpsFormatter::from(config.addr);
+  let formatter = HttpsFormatter::from(config.ticket_server_addr);
   let mut local_server = formatter.bind_axum_server().await?;
 
   let searcher = HtsGetFromStorage::local_from(

--- a/htsget-http-core/src/lib.rs
+++ b/htsget-http-core/src/lib.rs
@@ -276,8 +276,7 @@ mod tests {
         "../data",
         RegexResolver::new(".*", "$0").unwrap(),
         HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
-      )
-      .unwrap(),
+      ),
     ))
   }
 }

--- a/htsget-http-core/src/lib.rs
+++ b/htsget-http-core/src/lib.rs
@@ -237,28 +237,20 @@ mod tests {
   fn example_vcf_json_response(headers: HashMap<String, String>) -> JsonResponse {
     JsonResponse::from_response(Response::new(
       Format::Vcf,
-      vec![Url::new(format!(
-        "https://127.0.0.1:8081{}",
-        get_base_path()
-          .join("vcf")
-          .join("sample1-bcbio-cancer.vcf.gz")
-          .to_string_lossy()
-      ))
-      .with_headers(Headers::new(headers))],
+      vec![
+        Url::new("https://127.0.0.1:8081/data/vcf/sample1-bcbio-cancer.vcf.gz".to_string())
+          .with_headers(Headers::new(headers)),
+      ],
     ))
   }
 
   fn example_bam_json_response(headers: HashMap<String, String>) -> JsonResponse {
     JsonResponse::from_response(Response::new(
       Format::Bam,
-      vec![Url::new(format!(
-        "https://127.0.0.1:8081{}",
-        get_base_path()
-          .join("bam")
-          .join("htsnexus_test_NA12878.bam")
-          .to_string_lossy()
-      ))
-      .with_headers(Headers::new(headers))],
+      vec![
+        Url::new("https://127.0.0.1:8081/data/bam/htsnexus_test_NA12878.bam".to_string())
+          .with_headers(Headers::new(headers)),
+      ],
     ))
   }
 
@@ -273,10 +265,11 @@ mod tests {
   fn get_searcher() -> Arc<impl HtsGet> {
     Arc::new(HtsGetFromStorage::new(
       LocalStorage::new(
-        "../data",
+        get_base_path(),
         RegexResolver::new(".*", "$0").unwrap(),
         HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
-      ),
+      )
+      .unwrap(),
     ))
   }
 }

--- a/htsget-http-lambda/src/lib.rs
+++ b/htsget-http-lambda/src/lib.rs
@@ -265,8 +265,9 @@ mod tests {
           HtsGetFromStorage::local_from(
             &self.config.path,
             self.config.resolver.clone(),
-            HttpsFormatter::from(self.config.addr),
-          ),
+            HttpsFormatter::from(self.config.ticket_server_addr),
+          )
+          .unwrap(),
         ),
         &self.config.service_info,
       );
@@ -520,13 +521,14 @@ mod tests {
     Fut: Future<Output = ()>,
   {
     let router = Router::new(
-      Arc::new(HtsGetFromStorage::new(
-        LocalStorage::new(
+      Arc::new(
+        HtsGetFromStorage::local_from(
           &config.path,
           config.resolver.clone(),
-          HttpsFormatter::new("127.0.0.1", "8080").unwrap(),
-        ),
-      )),
+          HttpsFormatter::from(config.ticket_server_addr),
+        )
+        .unwrap(),
+      ),
       &config.service_info,
     );
     test(router).await

--- a/htsget-http-lambda/src/lib.rs
+++ b/htsget-http-lambda/src/lib.rs
@@ -266,8 +266,7 @@ mod tests {
             &self.config.path,
             self.config.resolver.clone(),
             HttpsFormatter::from(self.config.addr),
-          )
-          .expect("Couldn't create a Storage with the provided path"),
+          ),
         ),
         &self.config.service_info,
       );
@@ -526,8 +525,7 @@ mod tests {
           &config.path,
           config.resolver.clone(),
           HttpsFormatter::new("127.0.0.1", "8080").unwrap(),
-        )
-        .unwrap(),
+        ),
       )),
       &config.service_info,
     );

--- a/htsget-http-lambda/src/main.rs
+++ b/htsget-http-lambda/src/main.rs
@@ -25,7 +25,7 @@ async fn local_storage_server(config: Config) -> Result<(), Error> {
     config.path,
     config.resolver,
     HttpsFormatter::from(config.addr),
-  ));
+  )?);
   let router = &Router::new(searcher, &config.service_info);
 
   let handler = |event: Request| async move {

--- a/htsget-http-lambda/src/main.rs
+++ b/htsget-http-lambda/src/main.rs
@@ -25,7 +25,7 @@ async fn local_storage_server(config: Config) -> Result<(), Error> {
     config.path,
     config.resolver,
     HttpsFormatter::from(config.addr),
-  )?);
+  ));
   let router = &Router::new(searcher, &config.service_info);
 
   let handler = |event: Request| async move {

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -209,7 +209,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bam,
-        vec![Url::new(expected_url(storage))
+        vec![Url::new(expected_url())
           .with_headers(Headers::default().with_header("Range", "bytes=4668-2596799"))],
       ));
       assert_eq!(response, expected_response)
@@ -227,7 +227,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bam,
-        vec![Url::new(expected_url(storage))
+        vec![Url::new(expected_url())
           .with_headers(Headers::default().with_header("Range", "bytes=2060795-2596799"))],
       ));
       assert_eq!(response, expected_response)
@@ -245,7 +245,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bam,
-        vec![Url::new(expected_url(storage))
+        vec![Url::new(expected_url())
           .with_headers(Headers::default().with_header("Range", "bytes=977196-2128166"))],
       ));
       assert_eq!(response, expected_response)
@@ -267,11 +267,11 @@ pub mod tests {
       let expected_response = Ok(Response::new(
         Format::Bam,
         vec![
-          Url::new(expected_url(storage.clone()))
+          Url::new(expected_url())
             .with_headers(Headers::default().with_header("Range", "bytes=256721-647346")),
-          Url::new(expected_url(storage.clone()))
+          Url::new(expected_url())
             .with_headers(Headers::default().with_header("Range", "bytes=824361-842101")),
-          Url::new(expected_url(storage))
+          Url::new(expected_url())
             .with_headers(Headers::default().with_header("Range", "bytes=977196-996015")),
         ],
       ));
@@ -290,7 +290,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bam,
-        vec![Url::new(expected_url(storage))
+        vec![Url::new(expected_url())
           .with_headers(Headers::default().with_header("Range", "bytes=0-4668"))
           .with_class(Class::Header)],
       ));
@@ -314,18 +314,13 @@ pub mod tests {
         base_path,
         RegexResolver::new(".*", "$0").unwrap(),
         HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
-      ),
+      )
+      .unwrap(),
     ))
     .await
   }
 
-  pub(crate) fn expected_url(storage: Arc<LocalStorage<HttpsFormatter>>) -> String {
-    format!(
-      "https://127.0.0.1:8081{}",
-      storage
-        .base_path()
-        .join("htsnexus_test_NA12878.bam")
-        .to_string_lossy()
-    )
+  pub(crate) fn expected_url() -> String {
+    "https://127.0.0.1:8081/data/htsnexus_test_NA12878.bam".to_string()
   }
 }

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -314,8 +314,7 @@ pub mod tests {
         base_path,
         RegexResolver::new(".*", "$0").unwrap(),
         HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
-      )
-      .unwrap(),
+      ),
     ))
     .await
   }

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -272,8 +272,7 @@ pub mod tests {
         base_path,
         RegexResolver::new(".*", "$0").unwrap(),
         HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
-      )
-      .unwrap(),
+      ),
     ))
     .await
   }

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -170,7 +170,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bcf,
-        vec![Url::new(expected_url(storage, filename))
+        vec![Url::new(expected_url(filename))
           .with_headers(Headers::default().with_header("Range", "bytes=0-3530"))],
       ));
       assert_eq!(response, expected_response)
@@ -189,7 +189,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bcf,
-        vec![Url::new(expected_url(storage, filename))
+        vec![Url::new(expected_url(filename))
           .with_headers(Headers::default().with_header("Range", "bytes=0-950"))],
       ));
       assert_eq!(response, expected_response)
@@ -211,7 +211,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bcf,
-        vec![Url::new(expected_url(storage, filename))
+        vec![Url::new(expected_url(filename))
           .with_headers(Headers::default().with_header("Range", "bytes=0-3530"))],
       ));
       assert_eq!(response, expected_response)
@@ -248,7 +248,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bcf,
-        vec![Url::new(expected_url(storage, filename))
+        vec![Url::new(expected_url(filename))
           .with_headers(Headers::default().with_header("Range", "bytes=0-950"))
           .with_class(Class::Header)],
       ));
@@ -272,18 +272,13 @@ pub mod tests {
         base_path,
         RegexResolver::new(".*", "$0").unwrap(),
         HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
-      ),
+      )
+      .unwrap(),
     ))
     .await
   }
 
-  pub(crate) fn expected_url(storage: Arc<LocalStorage<HttpsFormatter>>, name: &str) -> String {
-    format!(
-      "https://127.0.0.1:8081{}",
-      storage
-        .base_path()
-        .join(format!("{}.bcf", name))
-        .to_string_lossy()
-    )
+  pub(crate) fn expected_url(name: &str) -> String {
+    format!("https://127.0.0.1:8081/data/{}.bcf", name)
   }
 }

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -284,7 +284,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Cram,
-        vec![Url::new(expected_url(storage))
+        vec![Url::new(expected_url())
           .with_headers(Headers::default().with_header("Range", "bytes=6087-1627756"))],
       ));
       assert_eq!(response, expected_response)
@@ -302,7 +302,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Cram,
-        vec![Url::new(expected_url(storage))
+        vec![Url::new(expected_url())
           .with_headers(Headers::default().with_header("Range", "bytes=1280106-1627756"))],
       ));
       assert_eq!(response, expected_response)
@@ -320,7 +320,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Cram,
-        vec![Url::new(expected_url(storage))
+        vec![Url::new(expected_url())
           .with_headers(Headers::default().with_header("Range", "bytes=604231-1280106"))],
       ));
       assert_eq!(response, expected_response)
@@ -341,7 +341,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Cram,
-        vec![Url::new(expected_url(storage))
+        vec![Url::new(expected_url())
           .with_headers(Headers::default().with_header("Range", "bytes=6087-465709"))],
       ));
       assert_eq!(response, expected_response)
@@ -362,7 +362,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Cram,
-        vec![Url::new(expected_url(storage))
+        vec![Url::new(expected_url())
           .with_headers(Headers::default().with_header("Range", "bytes=6087-604231"))],
       ));
       assert_eq!(response, expected_response)
@@ -380,7 +380,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Cram,
-        vec![Url::new(expected_url(storage))
+        vec![Url::new(expected_url())
           .with_headers(Headers::default().with_header("Range", "bytes=26-6087"))
           .with_class(Class::Header)],
       ));
@@ -404,18 +404,13 @@ pub mod tests {
         base_path,
         RegexResolver::new(".*", "$0").unwrap(),
         HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
-      ),
+      )
+      .unwrap(),
     ))
     .await
   }
 
-  pub(crate) fn expected_url(storage: Arc<LocalStorage<HttpsFormatter>>) -> String {
-    format!(
-      "https://127.0.0.1:8081{}",
-      storage
-        .base_path()
-        .join("htsnexus_test_NA12878.cram")
-        .to_string_lossy()
-    )
+  pub(crate) fn expected_url() -> String {
+    "https://127.0.0.1:8081/data/htsnexus_test_NA12878.cram".to_string()
   }
 }

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -404,8 +404,7 @@ pub mod tests {
         base_path,
         RegexResolver::new(".*", "$0").unwrap(),
         HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
-      )
-      .unwrap(),
+      ),
     ))
     .await
   }

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -86,10 +86,10 @@ impl<T: UrlFormatter + Send + Sync> HtsGetFromStorage<LocalStorage<T>> {
     path: P,
     resolver: RegexResolver,
     formatter: T,
-  ) -> Self {
-    HtsGetFromStorage::new(LocalStorage::new(
+  ) -> Result<Self> {
+    Ok(HtsGetFromStorage::new(LocalStorage::new(
       path, resolver, formatter,
-    ))
+    )?))
   }
 }
 
@@ -115,7 +115,7 @@ mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bam,
-        vec![Url::new(bam_expected_url(htsget.storage()))
+        vec![Url::new(bam_expected_url())
           .with_headers(Headers::default().with_header("Range", "bytes=4668-2596799"))],
       ));
       assert_eq!(response, expected_response)
@@ -134,7 +134,7 @@ mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Vcf,
-        vec![Url::new(vcf_expected_url(htsget.storage(), filename))
+        vec![Url::new(vcf_expected_url(filename))
           .with_headers(Headers::default().with_header("Range", "bytes=0-823"))],
       ));
       assert_eq!(response, expected_response)

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -86,10 +86,10 @@ impl<T: UrlFormatter + Send + Sync> HtsGetFromStorage<LocalStorage<T>> {
     path: P,
     resolver: RegexResolver,
     formatter: T,
-  ) -> Result<Self> {
-    Ok(HtsGetFromStorage::new(LocalStorage::new(
+  ) -> Self {
+    HtsGetFromStorage::new(LocalStorage::new(
       path, resolver, formatter,
-    )?))
+    ))
   }
 }
 

--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -102,9 +102,9 @@ impl From<StorageError> for HtsGetError {
       StorageError::InvalidKey(key) => {
         Self::InvalidInput(format!("Wrong key derived from ID: {}", key))
       }
-      StorageError::IoError(e) => Self::IoError(format!("Io error: {}", e)),
+      StorageError::IoError(_, _) => Self::IoError(format!("Io Error: {:?}", err)),
       #[cfg(feature = "s3-storage")]
-      StorageError::AwsS3Error { .. } => Self::IoError(format!("AWS S3 error: {:?}", err)),
+      StorageError::AwsS3Error(_, _) => Self::IoError(format!("AWS S3 error: {:?}", err)),
       StorageError::TicketServerError(e) => {
         Self::InternalError(format!("Error using url response server: {}", e))
       }

--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -111,6 +111,7 @@ impl From<StorageError> for HtsGetError {
       StorageError::InvalidInput(e) => Self::InvalidInput(format!("Invalid input: {}", e)),
       StorageError::InvalidUri(e) => Self::InternalError(format!("Invalid uri produced: {}", e)),
       StorageError::InvalidAddress(e) => Self::InternalError(format!("Invalid address: {}", e)),
+      StorageError::InternalError(e) => Self::InternalError(e),
     }
   }
 }

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -278,8 +278,7 @@ pub mod tests {
         base_path,
         RegexResolver::new(".*", "$0").unwrap(),
         HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
-      )
-      .unwrap(),
+      ),
     ))
     .await
   }

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -176,7 +176,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Vcf,
-        vec![Url::new(expected_url(storage, filename))
+        vec![Url::new(expected_url(filename))
           .with_headers(Headers::default().with_header("Range", "bytes=0-3367"))],
       ));
       assert_eq!(response, expected_response)
@@ -195,7 +195,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Vcf,
-        vec![Url::new(expected_url(storage, filename))
+        vec![Url::new(expected_url(filename))
           .with_headers(Headers::default().with_header("Range", "bytes=0-823"))],
       ));
       assert_eq!(response, expected_response)
@@ -217,7 +217,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Vcf,
-        vec![Url::new(expected_url(storage, filename))
+        vec![Url::new(expected_url(filename))
           .with_headers(Headers::default().with_header("Range", "bytes=0-3367"))],
       ));
       assert_eq!(response, expected_response)
@@ -254,7 +254,7 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Vcf,
-        vec![Url::new(expected_url(storage, filename))
+        vec![Url::new(expected_url(filename))
           .with_headers(Headers::default().with_header("Range", "bytes=0-823"))
           .with_class(Class::Header)],
       ));
@@ -278,18 +278,13 @@ pub mod tests {
         base_path,
         RegexResolver::new(".*", "$0").unwrap(),
         HttpsFormatter::new("127.0.0.1", "8081").unwrap(),
-      ),
+      )
+      .unwrap(),
     ))
     .await
   }
 
-  pub(crate) fn expected_url(storage: Arc<LocalStorage<HttpsFormatter>>, name: &str) -> String {
-    format!(
-      "https://127.0.0.1:8081{}",
-      storage
-        .base_path()
-        .join(format!("{}.vcf.gz", name))
-        .to_string_lossy()
-    )
+  pub(crate) fn expected_url(name: &str) -> String {
+    format!("https://127.0.0.1:8081/data/{}.vcf.gz", name)
   }
 }

--- a/htsget-search/src/storage/axum_server.rs
+++ b/htsget-search/src/storage/axum_server.rs
@@ -37,6 +37,8 @@ pub struct HttpsFormatter {
 }
 
 impl HttpsFormatter {
+  const SERVE_ASSETS_AT: &'static str = "/data";
+
   pub fn new(ip: impl Into<String>, port: impl Into<String>) -> Result<Self> {
     Ok(Self {
       addr: SocketAddr::from_str(&format!("{}:{}", ip.into(), port.into()))?,
@@ -45,7 +47,7 @@ impl HttpsFormatter {
 
   /// Eagerly bind the address by returing an AxumStorageServer.
   pub async fn bind_axum_server(&self) -> Result<AxumStorageServer> {
-    AxumStorageServer::bind_addr(&self.addr).await
+    AxumStorageServer::bind_addr(&self.addr, Self::SERVE_ASSETS_AT).await
   }
 }
 
@@ -65,22 +67,26 @@ impl From<SocketAddr> for HttpsFormatter {
 #[derive(Debug)]
 pub struct AxumStorageServer {
   listener: AddrIncoming,
+  serve_assets_at: String,
 }
 
 impl AxumStorageServer {
-  const SERVE_ASSETS_AT: &'static str = "/data";
-
   /// Eagerly bind the the address for use with the server, returning any errors.
-  pub async fn bind_addr(addr: &SocketAddr) -> Result<Self> {
-    let listener = TcpListener::bind(addr).await.map_err(|err| IoError("Failed to bind ticket server addr".to_string(), err))?;
+  pub async fn bind_addr(addr: &SocketAddr, serve_assets_at: impl Into<String>) -> Result<Self> {
+    let listener = TcpListener::bind(addr)
+      .await
+      .map_err(|err| IoError("Failed to bind ticket server addr".to_string(), err))?;
     let listener = AddrIncoming::from_listener(listener)?;
-    Ok(Self { listener })
+    Ok(Self {
+      serve_assets_at: serve_assets_at.into(),
+      listener,
+    })
   }
 
   /// Run the actual server, using the provided path, key and certificate.
   pub async fn serve<P: AsRef<Path>>(&mut self, path: P, key: P, cert: P) -> Result<()> {
     let mut app = Router::new()
-      .merge(SpaRouter::new(Self::SERVE_ASSETS_AT, path))
+      .merge(SpaRouter::new(&self.serve_assets_at, path))
       .into_make_service_with_connect_info::<SocketAddr>();
 
     let rustls_config = Self::rustls_server_config(key, cert)?;
@@ -108,11 +114,20 @@ impl AxumStorageServer {
   }
 
   fn rustls_server_config<P: AsRef<Path>>(key: P, cert: P) -> Result<Arc<ServerConfig>> {
-    let mut key_reader = BufReader::new(File::open(key).map_err(|err| IoError("Failed to open key file".to_string(), err))?);
-    let mut cert_reader = BufReader::new(File::open(cert).map_err(|err| IoError("Failed to open cert file".to_string(), err))?);
+    let mut key_reader = BufReader::new(
+      File::open(key).map_err(|err| IoError("Failed to open key file".to_string(), err))?,
+    );
+    let mut cert_reader = BufReader::new(
+      File::open(cert).map_err(|err| IoError("Failed to open cert file".to_string(), err))?,
+    );
 
-    let key = PrivateKey(pkcs8_private_keys(&mut key_reader).map_err(|err| IoError("Failed to read private keys".to_string(), err))?.remove(0));
-    let certs = certs(&mut cert_reader).map_err(|err| IoError("Failed to read certificate".to_string(), err))?
+    let key = PrivateKey(
+      pkcs8_private_keys(&mut key_reader)
+        .map_err(|err| IoError("Failed to read private keys".to_string(), err))?
+        .remove(0),
+    );
+    let certs = certs(&mut cert_reader)
+      .map_err(|err| IoError("Failed to read certificate".to_string(), err))?
       .into_iter()
       .map(Certificate)
       .collect();
@@ -136,11 +151,11 @@ impl From<hyper::Error> for StorageError {
 }
 
 impl UrlFormatter for HttpsFormatter {
-  fn format_url(&self, path: String) -> Result<String> {
+  fn format_url<K: AsRef<str>>(&self, key: K) -> Result<String> {
     http::uri::Builder::new()
       .scheme(http::uri::Scheme::HTTPS)
       .authority(self.addr.to_string())
-      .path_and_query(path)
+      .path_and_query(format!("{}/{}", Self::SERVE_ASSETS_AT, key.as_ref()))
       .build()
       .map_err(|err| StorageError::InvalidUri(err.to_string()))
       .map(|value| value.to_string())
@@ -153,10 +168,10 @@ mod tests {
   use std::io::Read;
 
   use http::{Method, Request};
-  use hyper::{Body, Client};
   use hyper::client::HttpConnector;
-  use hyper_tls::HttpsConnector;
+  use hyper::{Body, Client};
   use hyper_tls::native_tls::TlsConnector;
+  use hyper_tls::HttpsConnector;
   use rcgen::generate_simple_self_signed;
 
   use crate::storage::local::tests::create_local_test_files;
@@ -193,7 +208,7 @@ mod tests {
 
     // Start server.
     let addr = SocketAddr::from_str(&format!("{}:{}", "127.0.0.1", "8080")).unwrap();
-    let mut server = AxumStorageServer::bind_addr(&addr).await.unwrap();
+    let mut server = AxumStorageServer::bind_addr(&addr, "/data").await.unwrap();
     tokio::spawn(async move {
       server
         .serve(base_path.path(), &key_path, &cert_path)
@@ -220,8 +235,11 @@ mod tests {
   fn https_formatter_format_authority() {
     let formatter = HttpsFormatter::new("127.0.0.1", "8080").unwrap();
     assert_eq!(
-      formatter.format_url("/path".to_string()).unwrap(),
-      "https://127.0.0.1:8080/path"
+      formatter.format_url("path").unwrap(),
+      format!(
+        "https://127.0.0.1:8080{}/path",
+        HttpsFormatter::SERVE_ASSETS_AT
+      )
     )
   }
 }

--- a/htsget-search/src/storage/local.rs
+++ b/htsget-search/src/storage/local.rs
@@ -74,7 +74,7 @@ impl<T: UrlFormatter + Send + Sync> LocalStorage<T> {
 
   async fn get<K: AsRef<str>>(&self, key: K) -> Result<File> {
     let path = self.get_path_from_key(&key)?;
-    Ok(File::open(path).await?)
+    File::open(path).await.map_err(|_| StorageError::KeyNotFound(key.as_ref().to_string()))
   }
 }
 
@@ -123,8 +123,8 @@ pub(crate) mod tests {
   use tokio::io::AsyncWriteExt;
 
   use crate::htsget::{Headers, Url};
-  use crate::storage::axum_server::HttpsFormatter;
   use crate::storage::{BytesRange, GetOptions, StorageError, UrlOptions};
+  use crate::storage::axum_server::HttpsFormatter;
 
   use super::*;
 

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -42,7 +42,7 @@ pub trait Storage {
 /// Formats a url for use with storage.
 pub trait UrlFormatter {
   /// Returns the url with the path.
-  fn format_url(&self, path: String) -> Result<String>;
+  fn format_url<K: AsRef<str>>(&self, key: K) -> Result<String>;
 }
 
 #[derive(Error, Debug)]
@@ -71,13 +71,16 @@ pub enum StorageError {
 
   #[error("Invalid address: {0}")]
   InvalidAddress(AddrParseError),
+
+  #[error("Internal error: {0}")]
+  InternalError(String),
 }
 
 impl From<StorageError> for io::Error {
   fn from(err: StorageError) -> Self {
     match err {
       StorageError::IoError(_, ref io_error) => Self::new(io_error.kind(), err),
-      err => Self::new(ErrorKind::Other, err)
+      err => Self::new(ErrorKind::Other, err),
     }
   }
 }

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -53,8 +53,8 @@ pub enum StorageError {
   #[error("Key not found: {0}")]
   KeyNotFound(String),
 
-  #[error("Io error: {0}")]
-  IoError(#[from] io::Error),
+  #[error("Io error: {0} {1}")]
+  IoError(String, io::Error),
 
   #[cfg(feature = "s3-storage")]
   #[error("Aws error: {0}, with key: {1}")]
@@ -75,7 +75,10 @@ pub enum StorageError {
 
 impl From<StorageError> for io::Error {
   fn from(err: StorageError) -> Self {
-    Self::new(ErrorKind::Other, err)
+    match err {
+      StorageError::IoError(_, ref io_error) => Self::new(io_error.kind(), err),
+      err => Self::new(ErrorKind::Other, err)
+    }
   }
 }
 

--- a/htsget-test-utils/src/server_tests.rs
+++ b/htsget-test-utils/src/server_tests.rs
@@ -114,8 +114,6 @@ pub fn expected_response(path: &Path, class: Class, url_path: String) -> JsonRes
         .join("data")
         .join("vcf")
         .join("sample1-bcbio-cancer.vcf.gz")
-        .canonicalize()
-        .unwrap()
         .to_string_lossy()
     ))
     .with_headers(Headers::new(headers))
@@ -129,8 +127,6 @@ pub fn default_dir() -> PathBuf {
     .parent()
     .unwrap()
     .to_path_buf()
-    .canonicalize()
-    .unwrap()
 }
 
 /// Default config using the current cargo manifest directory.

--- a/htsget-test-utils/src/server_tests.rs
+++ b/htsget-test-utils/src/server_tests.rs
@@ -15,7 +15,7 @@ pub fn test_response(response: &Response, config: &Config, class: Class) {
   let url_path = expected_local_storage_path(config);
   assert!(response.is_success());
   assert_eq!(
-    expected_response(&config.path, class, url_path),
+    expected_response(class, url_path),
     response.deserialize_body().unwrap()
   );
 }
@@ -37,7 +37,7 @@ pub async fn test_get<T: TestRequest>(tester: &impl TestServer<T>) {
   let request = tester
     .get_request()
     .method(Method::GET.to_string())
-    .uri("/variants/data/vcf/sample1-bcbio-cancer");
+    .uri("/variants/vcf/sample1-bcbio-cancer");
   let response = tester.test_server(request).await;
   test_response(&response, tester.get_config(), Class::Body);
 }
@@ -46,7 +46,7 @@ fn post_request<T: TestRequest>(tester: &impl TestServer<T>) -> T {
   tester
     .get_request()
     .method(Method::POST.to_string())
-    .uri("/variants/data/vcf/sample1-bcbio-cancer")
+    .uri("/variants/vcf/sample1-bcbio-cancer")
     .insert_header(Header {
       name: http::header::CONTENT_TYPE.to_string(),
       value: mime::APPLICATION_JSON.to_string(),
@@ -65,7 +65,7 @@ pub async fn test_parameterized_get<T: TestRequest>(tester: &impl TestServer<T>)
   let request = tester
     .get_request()
     .method(Method::GET.to_string())
-    .uri("/variants/data/vcf/sample1-bcbio-cancer?format=VCF&class=header");
+    .uri("/variants/vcf/sample1-bcbio-cancer?format=VCF&class=header");
   let response = tester.test_server(request).await;
   test_response(&response, tester.get_config(), Class::Header);
 }
@@ -98,26 +98,20 @@ pub async fn test_service_info<T: TestRequest>(tester: &impl TestServer<T>) {
 }
 
 fn expected_local_storage_path(config: &Config) -> String {
-  format!("https://{}", config.addr)
+  format!("https://{}", config.ticket_server_addr)
 }
 
 /// An example VCF search response.
-pub fn expected_response(path: &Path, class: Class, url_path: String) -> JsonResponse {
+pub fn expected_response(class: Class, url_path: String) -> JsonResponse {
   let mut headers = HashMap::new();
   headers.insert("Range".to_string(), "bytes=0-3367".to_string());
   JsonResponse::from_response(HtsgetResponse::new(
     Format::Vcf,
-    vec![Url::new(format!(
-      "{}{}",
-      url_path,
-      path
-        .join("data")
-        .join("vcf")
-        .join("sample1-bcbio-cancer.vcf.gz")
-        .to_string_lossy()
-    ))
-    .with_headers(Headers::new(headers))
-    .with_class(class)],
+    vec![
+      Url::new(format!("{}/data/vcf/sample1-bcbio-cancer.vcf.gz", url_path))
+        .with_headers(Headers::new(headers))
+        .with_class(class),
+    ],
   ))
 }
 
@@ -131,7 +125,7 @@ pub fn default_dir() -> PathBuf {
 
 /// Default config using the current cargo manifest directory.
 pub fn default_test_config() -> Config {
-  std::env::set_var("HTSGET_PATH", default_dir());
+  std::env::set_var("HTSGET_PATH", default_dir().join("data"));
   Config::from_env().expect("Expected valid environment variables.")
 }
 


### PR DESCRIPTION
Fixes #84 

Changes:
* `LocalStorage` now returns the correct url paths which correspond to the ticket server.
* Fix numerous tests which were broken.
* Update README.md in htsget-http-lambda.