### PR TITLE
Fix eof errors

### DIFF
--- a/htsget-http-actix/benches/request_benchmarks.rs
+++ b/htsget-http-actix/benches/request_benchmarks.rs
@@ -1,17 +1,19 @@
-use criterion::measurement::WallTime;
-use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion};
-use htsget_http_core::{JsonResponse, PostRequest, Region};
-use htsget_test_utils::server_tests::{default_dir, default_test_config};
-use htsget_test_utils::util::generate_test_certificates;
-use reqwest::blocking::Client;
-use reqwest::blocking::ClientBuilder;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::{Child, Command};
 use std::thread::sleep;
 use std::{convert::TryInto, fs, time::Duration};
+
+use criterion::measurement::WallTime;
+use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion};
+use reqwest::blocking::Client;
+use reqwest::blocking::ClientBuilder;
+use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
+
+use htsget_http_core::{JsonResponse, PostRequest, Region};
+use htsget_test_utils::server_tests::{default_dir, default_test_config};
+use htsget_test_utils::util::generate_test_certificates;
 
 const REFSERVER_DOCKER_IMAGE: &str = "ga4gh/htsget-refserver:1.5.0";
 const BENCHMARK_DURATION_SECONDS: u64 = 30;

--- a/htsget-http-core/Cargo.toml
+++ b/htsget-http-core/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>
 edition = "2021"
 
 [features]
-s3-storage = ["htsget-config/s3-storage", "htsget-search/s3-storage"]
+s3-storage = ["htsget-config/s3-storage", "htsget-search/s3-storage", "htsget-test-utils/s3-storage"]
 default = ["s3-storage"]
 
 [dependencies]
@@ -16,3 +16,6 @@ htsget-config = { path = "../htsget-config", default-features = false }
 futures = { version = "0.3" }
 tokio = { version = "1.17", features = ["full"] }
 tracing = "0.1"
+
+[dev-dependencies]
+htsget-test-utils = { path = "../htsget-test-utils", default-features = false }

--- a/htsget-http-core/src/lib.rs
+++ b/htsget-http-core/src/lib.rs
@@ -127,7 +127,7 @@ mod tests {
     let mut request = HashMap::new();
     request.insert("id".to_string(), "bam/htsnexus_test_NA12878".to_string());
     let mut headers = HashMap::new();
-    headers.insert("Range".to_string(), "bytes=4668-2596798".to_string());
+    headers.insert("Range".to_string(), "bytes=0-2596798".to_string());
     assert_eq!(
       get_response_for_get_request(get_searcher(), request, Endpoint::Reads).await,
       Ok(example_bam_json_response(headers))
@@ -171,7 +171,7 @@ mod tests {
       regions: None,
     };
     let mut headers = HashMap::new();
-    headers.insert("Range".to_string(), "bytes=4668-2596798".to_string());
+    headers.insert("Range".to_string(), "bytes=0-2596798".to_string());
     assert_eq!(
       get_response_for_post_request(
         get_searcher(),

--- a/htsget-http-core/src/lib.rs
+++ b/htsget-http-core/src/lib.rs
@@ -116,9 +116,10 @@ mod tests {
   use htsget_search::htsget::HtsGet;
   use htsget_search::storage::axum_server::HttpsFormatter;
   use htsget_search::{
-    htsget::{from_storage::HtsGetFromStorage, Format, Headers, Url},
+    htsget::{from_storage::HtsGetFromStorage, Class::Body, Format, Headers, Url},
     storage::local::LocalStorage,
   };
+  use htsget_test_utils::util::expected_bgzf_eof_data_url;
 
   use super::*;
 
@@ -240,6 +241,7 @@ mod tests {
       vec![
         Url::new("https://127.0.0.1:8081/data/vcf/sample1-bcbio-cancer.vcf.gz".to_string())
           .with_headers(Headers::new(headers)),
+        Url::new(expected_bgzf_eof_data_url()).with_class(Body),
       ],
     ))
   }
@@ -250,6 +252,7 @@ mod tests {
       vec![
         Url::new("https://127.0.0.1:8081/data/bam/htsnexus_test_NA12878.bam".to_string())
           .with_headers(Headers::new(headers)),
+        Url::new(expected_bgzf_eof_data_url()).with_class(Body),
       ],
     ))
   }

--- a/htsget-http-core/src/lib.rs
+++ b/htsget-http-core/src/lib.rs
@@ -128,7 +128,7 @@ mod tests {
     let mut request = HashMap::new();
     request.insert("id".to_string(), "bam/htsnexus_test_NA12878".to_string());
     let mut headers = HashMap::new();
-    headers.insert("Range".to_string(), "bytes=0-2596798".to_string());
+    headers.insert("Range".to_string(), "bytes=0-2596770".to_string());
     assert_eq!(
       get_response_for_get_request(get_searcher(), request, Endpoint::Reads).await,
       Ok(example_bam_json_response(headers))
@@ -172,7 +172,7 @@ mod tests {
       regions: None,
     };
     let mut headers = HashMap::new();
-    headers.insert("Range".to_string(), "bytes=0-2596798".to_string());
+    headers.insert("Range".to_string(), "bytes=0-2596770".to_string());
     assert_eq!(
       get_response_for_post_request(
         get_searcher(),
@@ -241,7 +241,6 @@ mod tests {
       vec![
         Url::new("https://127.0.0.1:8081/data/vcf/sample1-bcbio-cancer.vcf.gz".to_string())
           .with_headers(Headers::new(headers)),
-        Url::new(expected_bgzf_eof_data_url()).with_class(Body),
       ],
     ))
   }

--- a/htsget-http-core/src/lib.rs
+++ b/htsget-http-core/src/lib.rs
@@ -241,6 +241,7 @@ mod tests {
       vec![
         Url::new("https://127.0.0.1:8081/data/vcf/sample1-bcbio-cancer.vcf.gz".to_string())
           .with_headers(Headers::new(headers)),
+        Url::new(expected_bgzf_eof_data_url()).with_class(Body),
       ],
     ))
   }

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -26,6 +26,7 @@ tokio-util = { version = "0.7", features = ["io", "compat"] }
 futures = { version = "0.3" }
 htsget-config = { path = "../htsget-config", default-features = false }
 tracing = "0.1"
+base64 = "0.13"
 
 noodles = { version = "0.21", features = ["core", "bgzf", "bam", "bcf", "cram", "csi", "sam", "tabix", "vcf"] }
 noodles-bam = { version = "0.17", features = ["async"] }
@@ -41,6 +42,7 @@ aws-config = { version = "0.9", optional = true }
 [dev-dependencies]
 htsget-test-utils = { path = "../htsget-test-utils", default-features = false }
 tempfile = "3.3"
+data-url = "0.1"
 
 # Aws S3 storage dependencies.
 anyhow = "1.0"

--- a/htsget-search/benches/search_benchmarks.rs
+++ b/htsget-search/benches/search_benchmarks.rs
@@ -1,5 +1,10 @@
+use std::net::SocketAddr;
+use std::time::Duration;
+
 use criterion::measurement::WallTime;
 use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion};
+use tokio::runtime::Runtime;
+
 use htsget_config::regex_resolver::RegexResolver;
 use htsget_search::htsget::from_storage::HtsGetFromStorage;
 use htsget_search::htsget::Class::Header;
@@ -7,9 +12,6 @@ use htsget_search::htsget::Format::{Bam, Bcf, Cram, Vcf};
 use htsget_search::htsget::HtsGet;
 use htsget_search::htsget::{HtsGetError, Query};
 use htsget_search::storage::axum_server::HttpsFormatter;
-use std::net::SocketAddr;
-use std::time::Duration;
-use tokio::runtime::Runtime;
 
 const BENCHMARK_DURATION_SECONDS: u64 = 15;
 const NUMBER_OF_SAMPLES: usize = 150;

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -3,26 +3,24 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use noodles::{bgzf, sam};
 use noodles::bam::bai;
-use noodles::bam::bai::Index;
 use noodles::bam::bai::index::ReferenceSequence;
+use noodles::bam::bai::Index;
 use noodles::bgzf::VirtualPosition;
 use noodles::csi::BinningIndex;
 use noodles::sam::Header;
+use noodles::{bgzf, sam};
 use noodles_bam as bam;
 use tokio::io;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncSeek;
 
-use crate::{
-  htsget::{Format, Query, Result},
-  htsget::search::BlockPosition,
-  storage::{BytesPosition, Storage},
-};
+use crate::htsget::search::{BgzfSearch, Search, SearchReads, VirtualPositionExt, BGZF_EOF};
 use crate::htsget::HtsGetError;
-use crate::htsget::search::{
-  BGZF_EOF, BgzfSearch, Search, SearchReads, VirtualPositionExt,
+use crate::{
+  htsget::search::BlockPosition,
+  htsget::{Format, Query, Result},
+  storage::{BytesPosition, Storage},
 };
 
 type AsyncReader<ReaderType> = bam::AsyncReader<bgzf::AsyncReader<ReaderType>>;

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -3,27 +3,26 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use noodles::{bgzf, sam};
 use noodles::bam::bai;
-use noodles::bam::bai::index::ReferenceSequence;
 use noodles::bam::bai::Index;
+use noodles::bam::bai::index::ReferenceSequence;
 use noodles::bgzf::VirtualPosition;
 use noodles::csi::BinningIndex;
 use noodles::sam::Header;
-use noodles::{bgzf, sam};
 use noodles_bam as bam;
 use tokio::io;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncSeek;
 
-use crate::htsget::search::{
-  BgzfSearch, Search, SearchEof, SearchReads, VirtualPositionExt, BGZF_EOF,
+use crate::{
+  htsget::{Format, Query, Result},
+  htsget::search::BlockPosition,
+  storage::{BytesPosition, Storage},
 };
 use crate::htsget::HtsGetError;
-use crate::storage::DataBlock;
-use crate::{
-  htsget::search::BlockPosition,
-  htsget::{Format, Query, Result},
-  storage::{BytesPosition, Storage},
+use crate::htsget::search::{
+  BGZF_EOF, BgzfSearch, Search, SearchReads, VirtualPositionExt,
 };
 
 type AsyncReader<ReaderType> = bam::AsyncReader<bgzf::AsyncReader<ReaderType>>;
@@ -47,18 +46,6 @@ where
 
   fn virtual_position(&self) -> VirtualPosition {
     self.virtual_position()
-  }
-}
-
-impl<S, ReaderType>
-  SearchEof<S, ReaderType, ReferenceSequence, Index, AsyncReader<ReaderType>, Header>
-  for BamSearch<S>
-where
-  S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
-  ReaderType: AsyncRead + AsyncSeek + Unpin + Send + Sync,
-{
-  fn get_eof_marker(&self) -> Option<DataBlock> {
-    Some(DataBlock::Data(Vec::from(BGZF_EOF)))
   }
 }
 

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -15,8 +15,11 @@ use tokio::io;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncSeek;
 
-use crate::htsget::search::{BgzfSearch, Search, SearchReads, VirtualPositionExt};
+use crate::htsget::search::{
+  BgzfSearch, Search, SearchEof, SearchReads, VirtualPositionExt, BGZF_EOF,
+};
 use crate::htsget::HtsGetError;
+use crate::storage::DataBlock;
 use crate::{
   htsget::search::BlockPosition,
   htsget::{Format, Query, Result},
@@ -44,6 +47,18 @@ where
 
   fn virtual_position(&self) -> VirtualPosition {
     self.virtual_position()
+  }
+}
+
+impl<S, ReaderType>
+  SearchEof<S, ReaderType, ReferenceSequence, Index, AsyncReader<ReaderType>, Header>
+  for BamSearch<S>
+where
+  S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
+  ReaderType: AsyncRead + AsyncSeek + Unpin + Send + Sync,
+{
+  fn get_eof_marker(&self) -> Option<DataBlock> {
+    Some(DataBlock::Data(Vec::from(BGZF_EOF)))
   }
 }
 

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -20,7 +20,7 @@ use crate::htsget::HtsGetError;
 use crate::{
   htsget::search::BlockPosition,
   htsget::{Format, Query, Result},
-  storage::{BytesRange, Storage},
+  storage::{BytesPosition, Storage},
 };
 
 type AsyncReader<ReaderType> = bam::AsyncReader<bgzf::AsyncReader<ReaderType>>;
@@ -66,7 +66,7 @@ where
     id: &str,
     format: &Format,
     index: &Index,
-  ) -> Result<Vec<BytesRange>> {
+  ) -> Result<Vec<BytesPosition>> {
     let last_interval = index
       .reference_sequences()
       .iter()
@@ -87,7 +87,7 @@ where
       .await
       .map_err(|_| HtsGetError::io_error("Reading file size"))?;
 
-    Ok(vec![BytesRange::default()
+    Ok(vec![BytesPosition::default()
       .with_start(start.bytes_range_start())
       .with_end(file_size)])
   }
@@ -121,7 +121,7 @@ where
     reference_name: String,
     index: &Index,
     query: Query,
-  ) -> Result<Vec<BytesRange>> {
+  ) -> Result<Vec<BytesPosition>> {
     self
       .get_byte_ranges_for_reference_name_reads(&reference_name, index, query)
       .await
@@ -156,7 +156,7 @@ where
     &self,
     query: &Query,
     bai_index: &Index,
-  ) -> Result<Vec<BytesRange>> {
+  ) -> Result<Vec<BytesPosition>> {
     self
       .get_byte_ranges_for_unmapped(&query.id, &self.get_format(), bai_index)
       .await
@@ -168,7 +168,7 @@ where
     ref_seq_id: usize,
     query: Query,
     index: &Index,
-  ) -> Result<Vec<BytesRange>> {
+  ) -> Result<Vec<BytesPosition>> {
     let start = query.start.map(|start| start as i32);
     let end = query.end.map(|end| end as i32);
     self

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -104,7 +104,7 @@ where
 
     Ok(vec![BytesPosition::default()
       .with_start(start.bytes_range_start())
-      .with_end(file_size)])
+      .with_end(file_size - BGZF_EOF.len() as u64)])
   }
 }
 
@@ -227,7 +227,7 @@ pub mod tests {
         Format::Bam,
         vec![
           Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=0-2596798")),
+            .with_headers(Headers::default().with_header("Range", "bytes=0-2596770")),
           Url::new(expected_bgzf_eof_data_url()).with_class(Body),
         ],
       ));
@@ -250,7 +250,7 @@ pub mod tests {
           Url::new(expected_url())
             .with_headers(Headers::default().with_header("Range", "bytes=0-4667")),
           Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=2060795-2596798")),
+            .with_headers(Headers::default().with_header("Range", "bytes=2060795-2596770")),
           Url::new(expected_bgzf_eof_data_url()).with_class(Body),
         ],
       ));

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -210,7 +210,7 @@ pub mod tests {
       let expected_response = Ok(Response::new(
         Format::Bam,
         vec![Url::new(expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=4668-2596798"))],
+          .with_headers(Headers::default().with_header("Range", "bytes=0-2596798"))],
       ));
       assert_eq!(response, expected_response)
     })
@@ -227,8 +227,12 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bam,
-        vec![Url::new(expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=2060795-2596798"))],
+        vec![
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=0-4667")),
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=2060795-2596798")),
+        ],
       ));
       assert_eq!(response, expected_response)
     })
@@ -245,8 +249,12 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bam,
-        vec![Url::new(expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=977196-2128165"))],
+        vec![
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=0-4667")),
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=977196-2128165")),
+        ],
       ));
       assert_eq!(response, expected_response)
     })
@@ -267,6 +275,8 @@ pub mod tests {
       let expected_response = Ok(Response::new(
         Format::Bam,
         vec![
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=0-4667")),
           Url::new(expected_url())
             .with_headers(Headers::default().with_header("Range", "bytes=256721-647345")),
           Url::new(expected_url())

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -22,6 +22,7 @@ use crate::{
   htsget::{Format, Query, Result},
   storage::{BytesPosition, Storage},
 };
+use crate::storage::DataBlock;
 
 type AsyncReader<ReaderType> = bam::AsyncReader<bgzf::AsyncReader<ReaderType>>;
 

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -22,7 +22,6 @@ use crate::{
   htsget::{Format, Query, Result},
   storage::{BytesPosition, Storage},
 };
-use crate::storage::DataBlock;
 
 type AsyncReader<ReaderType> = bam::AsyncReader<bgzf::AsyncReader<ReaderType>>;
 
@@ -193,8 +192,9 @@ pub mod tests {
   use std::future::Future;
 
   use htsget_config::regex_resolver::RegexResolver;
+  use htsget_test_utils::util::expected_bgzf_eof_data_url;
 
-  use crate::htsget::{Class, Headers, Response, Url};
+  use crate::htsget::{Class, Class::Body, Headers, Response, Url};
   use crate::storage::axum_server::HttpsFormatter;
   use crate::storage::local::LocalStorage;
 
@@ -210,8 +210,11 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bam,
-        vec![Url::new(expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=0-2596798"))],
+        vec![
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=0-2596798")),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+        ],
       ));
       assert_eq!(response, expected_response)
     })
@@ -233,6 +236,7 @@ pub mod tests {
             .with_headers(Headers::default().with_header("Range", "bytes=0-4667")),
           Url::new(expected_url())
             .with_headers(Headers::default().with_header("Range", "bytes=2060795-2596798")),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
         ],
       ));
       assert_eq!(response, expected_response)
@@ -255,6 +259,7 @@ pub mod tests {
             .with_headers(Headers::default().with_header("Range", "bytes=0-4667")),
           Url::new(expected_url())
             .with_headers(Headers::default().with_header("Range", "bytes=977196-2128165")),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
         ],
       ));
       assert_eq!(response, expected_response)
@@ -284,6 +289,7 @@ pub mod tests {
             .with_headers(Headers::default().with_header("Range", "bytes=824361-842100")),
           Url::new(expected_url())
             .with_headers(Headers::default().with_header("Range", "bytes=977196-996014")),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
         ],
       ));
       assert_eq!(response, expected_response)

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -15,7 +15,8 @@ use noodles_bcf as bcf;
 use tokio::io;
 use tokio::io::{AsyncRead, AsyncSeek};
 
-use crate::htsget::search::{find_first, BgzfSearch, BlockPosition, Search};
+use crate::htsget::search::{find_first, BgzfSearch, BlockPosition, Search, SearchEof, BGZF_EOF};
+use crate::storage::DataBlock;
 use crate::{
   htsget::{Format, Query, Result},
   storage::{BytesPosition, Storage},
@@ -42,6 +43,18 @@ where
 
   fn virtual_position(&self) -> VirtualPosition {
     self.virtual_position()
+  }
+}
+
+impl<S, ReaderType>
+  SearchEof<S, ReaderType, ReferenceSequence, Index, AsyncReader<ReaderType>, vcf::Header>
+  for BcfSearch<S>
+where
+  S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
+  ReaderType: AsyncRead + AsyncSeek + Unpin + Send + Sync,
+{
+  fn get_eof_marker(&self) -> Option<DataBlock> {
+    Some(DataBlock::Data(Vec::from(BGZF_EOF)))
   }
 }
 

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -152,8 +152,9 @@ pub mod tests {
   use std::future::Future;
 
   use htsget_config::regex_resolver::RegexResolver;
+  use htsget_test_utils::util::expected_bgzf_eof_data_url;
 
-  use crate::htsget::{Class, Headers, HtsGetError, Response, Url};
+  use crate::htsget::{Class, Class::Body, Headers, HtsGetError, Response, Url};
   use crate::storage::axum_server::HttpsFormatter;
   use crate::storage::local::LocalStorage;
 
@@ -168,11 +169,7 @@ pub mod tests {
       let response = search.search(query).await;
       println!("{:#?}", response);
 
-      let expected_response = Ok(Response::new(
-        Format::Bcf,
-        vec![Url::new(expected_url(filename))
-          .with_headers(Headers::default().with_header("Range", "bytes=0-3529"))],
-      ));
+      let expected_response = Ok(expected_bcf_response(filename));
       assert_eq!(response, expected_response)
     })
     .await
@@ -189,8 +186,11 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bcf,
-        vec![Url::new(expected_url(filename))
-          .with_headers(Headers::default().with_header("Range", "bytes=0-949"))],
+        vec![
+          Url::new(expected_url(filename))
+            .with_headers(Headers::default().with_header("Range", "bytes=0-949")),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+        ],
       ));
       assert_eq!(response, expected_response)
     })
@@ -209,11 +209,7 @@ pub mod tests {
       let response = search.search(query).await;
       println!("{:#?}", response);
 
-      let expected_response = Ok(Response::new(
-        Format::Bcf,
-        vec![Url::new(expected_url(filename))
-          .with_headers(Headers::default().with_header("Range", "bytes=0-3529"))],
-      ));
+      let expected_response = Ok(expected_bcf_response(filename));
       assert_eq!(response, expected_response)
     })
     .await
@@ -235,6 +231,17 @@ pub mod tests {
       assert_eq!(response, expected_response)
     })
     .await
+  }
+
+  fn expected_bcf_response(filename: &str) -> Response {
+    Response::new(
+      Format::Bcf,
+      vec![
+        Url::new(expected_url(filename))
+          .with_headers(Headers::default().with_header("Range", "bytes=0-3529")),
+        Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+      ],
+    )
   }
 
   #[tokio::test]

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -6,20 +6,20 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::prelude::stream::FuturesUnordered;
-use noodles::{bgzf, csi};
 use noodles::bgzf::VirtualPosition;
-use noodles::csi::Index;
 use noodles::csi::index::ReferenceSequence;
+use noodles::csi::Index;
 use noodles::vcf;
+use noodles::{bgzf, csi};
 use noodles_bcf as bcf;
 use tokio::io;
 use tokio::io::{AsyncRead, AsyncSeek};
 
+use crate::htsget::search::{find_first, BgzfSearch, BlockPosition, Search};
 use crate::{
   htsget::{Format, Query, Result},
   storage::{BytesPosition, Storage},
 };
-use crate::htsget::search::{BgzfSearch, BlockPosition, find_first, Search};
 
 type AsyncReader<ReaderType> = bcf::AsyncReader<bgzf::AsyncReader<ReaderType>>;
 
@@ -154,7 +154,7 @@ pub mod tests {
   use htsget_config::regex_resolver::RegexResolver;
   use htsget_test_utils::util::expected_bgzf_eof_data_url;
 
-  use crate::htsget::{Class, Class::Body, Headers, HtsGetError, Response, Url};
+  use crate::htsget::{Class, Class::Body, Headers, Response, Url};
   use crate::storage::axum_server::HttpsFormatter;
   use crate::storage::local::LocalStorage;
 
@@ -210,24 +210,6 @@ pub mod tests {
       println!("{:#?}", response);
 
       let expected_response = Ok(expected_bcf_response(filename));
-      assert_eq!(response, expected_response)
-    })
-    .await
-  }
-
-  #[tokio::test]
-  async fn search_reference_name_with_invalid_seq_range() {
-    with_local_storage(|storage| async move {
-      let search = BcfSearch::new(storage);
-      let filename = "sample1-bcbio-cancer";
-      let query = Query::new(filename, Format::Bcf)
-        .with_reference_name("chrM")
-        .with_start(0)
-        .with_end(153);
-      let response = search.search(query).await;
-      println!("{:#?}", response);
-
-      let expected_response = Err(HtsGetError::InvalidRange("0-153".to_string()));
       assert_eq!(response, expected_response)
     })
     .await

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -6,21 +6,20 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::prelude::stream::FuturesUnordered;
-use noodles::bgzf::VirtualPosition;
-use noodles::csi::index::ReferenceSequence;
-use noodles::csi::Index;
-use noodles::vcf;
 use noodles::{bgzf, csi};
+use noodles::bgzf::VirtualPosition;
+use noodles::csi::Index;
+use noodles::csi::index::ReferenceSequence;
+use noodles::vcf;
 use noodles_bcf as bcf;
 use tokio::io;
 use tokio::io::{AsyncRead, AsyncSeek};
 
-use crate::htsget::search::{find_first, BgzfSearch, BlockPosition, Search, SearchEof, BGZF_EOF};
-use crate::storage::DataBlock;
 use crate::{
   htsget::{Format, Query, Result},
   storage::{BytesPosition, Storage},
 };
+use crate::htsget::search::{BgzfSearch, BlockPosition, find_first, Search};
 
 type AsyncReader<ReaderType> = bcf::AsyncReader<bgzf::AsyncReader<ReaderType>>;
 
@@ -43,18 +42,6 @@ where
 
   fn virtual_position(&self) -> VirtualPosition {
     self.virtual_position()
-  }
-}
-
-impl<S, ReaderType>
-  SearchEof<S, ReaderType, ReferenceSequence, Index, AsyncReader<ReaderType>, vcf::Header>
-  for BcfSearch<S>
-where
-  S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
-  ReaderType: AsyncRead + AsyncSeek + Unpin + Send + Sync,
-{
-  fn get_eof_marker(&self) -> Option<DataBlock> {
-    Some(DataBlock::Data(Vec::from(BGZF_EOF)))
   }
 }
 

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -18,7 +18,7 @@ use tokio::io::{AsyncRead, AsyncSeek};
 use crate::htsget::search::{find_first, BgzfSearch, BlockPosition, Search};
 use crate::{
   htsget::{Format, Query, Result},
-  storage::{BytesRange, Storage},
+  storage::{BytesPosition, Storage},
 };
 
 type AsyncReader<ReaderType> = bcf::AsyncReader<bgzf::AsyncReader<ReaderType>>;
@@ -86,7 +86,7 @@ where
     reference_name: String,
     index: &Index,
     query: Query,
-  ) -> Result<Vec<BytesRange>> {
+  ) -> Result<Vec<BytesPosition>> {
     let (_, header) = self.create_reader(&query.id, &self.get_format()).await?;
 
     // We are assuming the order of the contigs in the header and the references sequences

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -284,7 +284,7 @@ pub mod tests {
       let expected_response = Ok(Response::new(
         Format::Cram,
         vec![Url::new(expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=6087-1627755"))],
+          .with_headers(Headers::default().with_header("Range", "bytes=0-1627755"))],
       ));
       assert_eq!(response, expected_response)
     })
@@ -301,8 +301,12 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Cram,
-        vec![Url::new(expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=1280106-1627755"))],
+        vec![
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=0-6086")),
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=1280106-1627755")),
+        ],
       ));
       assert_eq!(response, expected_response)
     })
@@ -319,8 +323,12 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Cram,
-        vec![Url::new(expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=604231-1280105"))],
+        vec![
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=0-6086")),
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=604231-1280105")),
+        ],
       ));
       assert_eq!(response, expected_response)
     })
@@ -341,7 +349,7 @@ pub mod tests {
       let expected_response = Ok(Response::new(
         Format::Cram,
         vec![Url::new(expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=6087-465708"))],
+          .with_headers(Headers::default().with_header("Range", "bytes=0-465708"))],
       ));
       assert_eq!(response, expected_response)
     })
@@ -362,7 +370,7 @@ pub mod tests {
       let expected_response = Ok(Response::new(
         Format::Cram,
         vec![Url::new(expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=6087-604230"))],
+          .with_headers(Headers::default().with_header("Range", "bytes=0-604230"))],
       ));
       assert_eq!(response, expected_response)
     })

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -52,9 +52,9 @@ where
 
   async fn get_byte_ranges_for_header(&self, query: &Query) -> Result<Vec<BytesPosition>> {
     let (mut reader, _) = self.create_reader(&query.id, &self.get_format()).await?;
-    Ok(vec![BytesPosition::default()
-      .with_start(Self::FILE_DEFINITION_LENGTH)
-      .with_end(reader.position().await?)])
+    Ok(vec![
+      BytesPosition::default().with_end(reader.position().await?)
+    ])
   }
 }
 
@@ -161,7 +161,6 @@ where
   S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
   ReaderType: AsyncRead + AsyncSeek + Unpin + Send + Sync,
 {
-  const FILE_DEFINITION_LENGTH: u64 = 26;
   const EOF_CONTAINER_LENGTH: u64 = 38;
 
   pub fn new(storage: Arc<S>) -> Self {
@@ -381,7 +380,7 @@ pub mod tests {
       let expected_response = Ok(Response::new(
         Format::Cram,
         vec![Url::new(expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=26-6086"))
+          .with_headers(Headers::default().with_header("Range", "bytes=0-6086"))
           .with_class(Class::Header)],
       ));
       assert_eq!(response, expected_response)

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -119,7 +119,7 @@ mod tests {
         Format::Bam,
         vec![
           Url::new(bam_expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=0-2596798")),
+            .with_headers(Headers::default().with_header("Range", "bytes=0-2596770")),
           Url::new(expected_bgzf_eof_data_url()).with_class(Body),
         ],
       ));
@@ -139,11 +139,8 @@ mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Vcf,
-        vec![
-          Url::new(vcf_expected_url(filename))
-            .with_headers(Headers::default().with_header("Range", "bytes=0-822")),
-          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
-        ],
+        vec![Url::new(vcf_expected_url(filename))
+          .with_headers(Headers::default().with_header("Range", "bytes=0-822"))],
       ));
       assert_eq!(response, expected_response)
     })

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -139,8 +139,11 @@ mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Vcf,
-        vec![Url::new(vcf_expected_url(filename))
-          .with_headers(Headers::default().with_header("Range", "bytes=0-822"))],
+        vec![
+          Url::new(vcf_expected_url(filename))
+            .with_headers(Headers::default().with_header("Range", "bytes=0-822")),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+        ],
       ));
       assert_eq!(response, expected_response)
     })

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -116,7 +116,7 @@ mod tests {
       let expected_response = Ok(Response::new(
         Format::Bam,
         vec![Url::new(bam_expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=4668-2596798"))],
+          .with_headers(Headers::default().with_header("Range", "bytes=0-2596798"))],
       ));
       assert_eq!(response, expected_response)
     })

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -95,13 +95,15 @@ impl<T: UrlFormatter + Send + Sync> HtsGetFromStorage<LocalStorage<T>> {
 
 #[cfg(test)]
 mod tests {
+  use htsget_test_utils::util::expected_bgzf_eof_data_url;
+
   use crate::htsget::bam_search::tests::{
     expected_url as bam_expected_url, with_local_storage as with_bam_local_storage,
   };
   use crate::htsget::vcf_search::tests::{
     expected_url as vcf_expected_url, with_local_storage as with_vcf_local_storage,
   };
-  use crate::htsget::{Headers, Url};
+  use crate::htsget::{Class::Body, Headers, Url};
 
   use super::*;
 
@@ -115,8 +117,11 @@ mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bam,
-        vec![Url::new(bam_expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=0-2596798"))],
+        vec![
+          Url::new(bam_expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=0-2596798")),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+        ],
       ));
       assert_eq!(response, expected_response)
     })
@@ -134,8 +139,11 @@ mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Vcf,
-        vec![Url::new(vcf_expected_url(filename))
-          .with_headers(Headers::default().with_header("Range", "bytes=0-822"))],
+        vec![
+          Url::new(vcf_expected_url(filename))
+            .with_headers(Headers::default().with_header("Range", "bytes=0-822")),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+        ],
       ));
       assert_eq!(response, expected_response)
     })

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -24,7 +24,7 @@ use tokio::task::JoinHandle;
 use crate::storage::GetOptions;
 use crate::{
   htsget::{Class, Format, HtsGetError, Query, Response, Result},
-  storage::{BytesPosition, Storage, UrlOptions},
+  storage::{BytesPosition, RangeUrlOptions, Storage},
 };
 
 /// Helper function to find the first non-none value from a set of futures.
@@ -249,13 +249,13 @@ where
   ) -> Result<Response> {
     let mut storage_futures = FuturesUnordered::new();
     for range in byte_ranges {
-      let options = UrlOptions::default()
+      let options = RangeUrlOptions::default()
         .with_range(range)
         .with_class(class.clone());
       let storage = self.get_storage();
       let id = id.clone();
       storage_futures.push(tokio::spawn(async move {
-        storage.url(format.fmt_file(&id), options).await
+        storage.range_url(format.fmt_file(&id), options).await
       }));
     }
     let mut urls = Vec::new();

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -481,6 +481,22 @@ where
   }
 }
 
+impl<S, ReaderType, ReferenceSequence, Index, Reader, Header, T>
+SearchEof<S, ReaderType, ReferenceSequence, Index, Reader, Header> for T
+  where
+    S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
+    ReaderType: AsyncRead + Unpin + Send + Sync,
+    Reader: BlockPosition + Send + Sync,
+    Header: FromStr + Send,
+    ReferenceSequence: BinningIndexReferenceSequence + Sync,
+    Index: BinningIndex<ReferenceSequence> + Send + Sync,
+    T: BgzfSearch<S, ReaderType, ReferenceSequence, Index, Reader, Header> + Send + Sync,
+{
+  fn get_eof_marker(&self) -> Option<DataBlock> {
+    Some(DataBlock::Data(Vec::from(BGZF_EOF)))
+  }
+}
+
 /// A block position extends the concept of a virtual position for readers.
 #[async_trait]
 pub(crate) trait BlockPosition {

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -17,7 +17,8 @@ use tokio::io;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncSeek;
 
-use crate::htsget::search::{find_first, BgzfSearch, BlockPosition, Search};
+use crate::htsget::search::{find_first, BgzfSearch, BlockPosition, Search, SearchEof};
+use crate::storage::DataBlock;
 use crate::{
   htsget::{Format, Query, Result},
   storage::{BytesPosition, Storage},
@@ -44,6 +45,18 @@ where
 
   fn virtual_position(&self) -> VirtualPosition {
     self.virtual_position()
+  }
+}
+
+impl<S, ReaderType>
+  SearchEof<S, ReaderType, ReferenceSequence, Index, AsyncReader<ReaderType>, Header>
+  for VcfSearch<S>
+where
+  S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
+  ReaderType: AsyncRead + AsyncSeek + Unpin + Send + Sync,
+{
+  fn get_eof_marker(&self) -> Option<DataBlock> {
+    None
   }
 }
 

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -171,9 +171,8 @@ pub mod tests {
   use std::future::Future;
 
   use htsget_config::regex_resolver::RegexResolver;
-  use htsget_test_utils::util::expected_bgzf_eof_data_url;
 
-  use crate::htsget::{Class, Class::Body, Headers, HtsGetError, Response, Url};
+  use crate::htsget::{Class, Headers, HtsGetError, Response, Url};
   use crate::storage::axum_server::HttpsFormatter;
   use crate::storage::local::LocalStorage;
 
@@ -205,11 +204,8 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Vcf,
-        vec![
-          Url::new(expected_url(filename))
-            .with_headers(Headers::default().with_header("Range", "bytes=0-822")),
-          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
-        ],
+        vec![Url::new(expected_url(filename))
+          .with_headers(Headers::default().with_header("Range", "bytes=0-822"))],
       ));
       assert_eq!(response, expected_response)
     })
@@ -275,11 +271,8 @@ pub mod tests {
   fn expected_vcf_response(filename: &str) -> Response {
     Response::new(
       Format::Vcf,
-      vec![
-        Url::new(expected_url(filename))
-          .with_headers(Headers::default().with_header("Range", "bytes=0-3366")),
-        Url::new(expected_bgzf_eof_data_url()).with_class(Body),
-      ],
+      vec![Url::new(expected_url(filename))
+        .with_headers(Headers::default().with_header("Range", "bytes=0-3366"))],
     )
   }
 

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -9,20 +9,19 @@ use futures::prelude::stream::FuturesUnordered;
 use noodles::bgzf;
 use noodles::bgzf::VirtualPosition;
 use noodles::tabix;
-use noodles::tabix::index::ReferenceSequence;
 use noodles::tabix::Index;
+use noodles::tabix::index::ReferenceSequence;
 use noodles::vcf::Header;
 use noodles_vcf as vcf;
 use tokio::io;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncSeek;
 
-use crate::htsget::search::{find_first, BgzfSearch, BlockPosition, Search, SearchEof};
-use crate::storage::DataBlock;
 use crate::{
   htsget::{Format, Query, Result},
   storage::{BytesPosition, Storage},
 };
+use crate::htsget::search::{BgzfSearch, BlockPosition, find_first, Search};
 
 type AsyncReader<ReaderType> = vcf::AsyncReader<bgzf::AsyncReader<ReaderType>>;
 
@@ -45,18 +44,6 @@ where
 
   fn virtual_position(&self) -> VirtualPosition {
     self.virtual_position()
-  }
-}
-
-impl<S, ReaderType>
-  SearchEof<S, ReaderType, ReferenceSequence, Index, AsyncReader<ReaderType>, Header>
-  for VcfSearch<S>
-where
-  S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
-  ReaderType: AsyncRead + AsyncSeek + Unpin + Send + Sync,
-{
-  fn get_eof_marker(&self) -> Option<DataBlock> {
-    None
   }
 }
 

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -20,7 +20,7 @@ use tokio::io::AsyncSeek;
 use crate::htsget::search::{find_first, BgzfSearch, BlockPosition, Search};
 use crate::{
   htsget::{Format, Query, Result},
-  storage::{BytesRange, Storage},
+  storage::{BytesPosition, Storage},
 };
 
 type AsyncReader<ReaderType> = vcf::AsyncReader<bgzf::AsyncReader<ReaderType>>;
@@ -86,7 +86,7 @@ where
     reference_name: String,
     index: &Index,
     query: Query,
-  ) -> Result<Vec<BytesRange>> {
+  ) -> Result<Vec<BytesPosition>> {
     let (_, vcf_header) = self.create_reader(&query.id, &self.get_format()).await?;
     let maybe_len = vcf_header
       .contigs()

--- a/htsget-search/src/storage/axum_server.rs
+++ b/htsget-search/src/storage/axum_server.rs
@@ -166,12 +166,13 @@ impl UrlFormatter for HttpsFormatter {
 mod tests {
   use std::io::Read;
 
-  use htsget_test_utils::util::generate_test_certificates;
   use http::{Method, Request};
   use hyper::client::HttpConnector;
   use hyper::{Body, Client};
   use hyper_tls::native_tls::TlsConnector;
   use hyper_tls::HttpsConnector;
+
+  use htsget_test_utils::util::generate_test_certificates;
 
   use crate::storage::local::tests::create_local_test_files;
 

--- a/htsget-search/src/storage/local.rs
+++ b/htsget-search/src/storage/local.rs
@@ -13,7 +13,7 @@ use htsget_config::regex_resolver::{HtsGetIdResolver, RegexResolver};
 use crate::htsget::Url;
 use crate::storage::{Storage, UrlFormatter};
 
-use super::{GetOptions, Result, StorageError, UrlOptions};
+use super::{GetOptions, RangeUrlOptions, Result, StorageError};
 
 /// Implementation for the [Storage] trait using the local file system. [T] is the type of the
 /// server struct, which is used for formatting urls.
@@ -94,7 +94,7 @@ impl<T: UrlFormatter + Send + Sync + Debug> Storage for LocalStorage<T> {
   }
 
   /// Get a url for the file at key.
-  async fn url<K: AsRef<str> + Send>(&self, key: K, options: UrlOptions) -> Result<Url> {
+  async fn range_url<K: AsRef<str> + Send>(&self, key: K, options: RangeUrlOptions) -> Result<Url> {
     let path = self.get_path_from_key(&key)?;
     let path = path
       .strip_prefix(&self.base_path)
@@ -129,7 +129,7 @@ pub(crate) mod tests {
 
   use crate::htsget::{Headers, Url};
   use crate::storage::axum_server::HttpsFormatter;
-  use crate::storage::{BytesPosition, GetOptions, StorageError, UrlOptions};
+  use crate::storage::{BytesPosition, GetOptions, RangeUrlOptions, StorageError};
 
   use super::*;
 
@@ -174,7 +174,8 @@ pub(crate) mod tests {
   #[tokio::test]
   async fn url_of_non_existing_key() {
     with_local_storage(|storage| async move {
-      let result = Storage::url(&storage, "non-existing-key", UrlOptions::default()).await;
+      let result =
+        Storage::range_url(&storage, "non-existing-key", RangeUrlOptions::default()).await;
       assert!(matches!(result, Err(StorageError::InvalidKey(msg)) if msg == "non-existing-key"));
     })
     .await;
@@ -183,7 +184,7 @@ pub(crate) mod tests {
   #[tokio::test]
   async fn url_of_folder() {
     with_local_storage(|storage| async move {
-      let result = Storage::url(&storage, "folder", UrlOptions::default()).await;
+      let result = Storage::range_url(&storage, "folder", RangeUrlOptions::default()).await;
       assert!(matches!(result, Err(StorageError::KeyNotFound(msg)) if msg == "folder"));
     })
     .await;
@@ -192,7 +193,12 @@ pub(crate) mod tests {
   #[tokio::test]
   async fn url_with_forbidden_path() {
     with_local_storage(|storage| async move {
-      let result = Storage::url(&storage, "folder/../../passwords", UrlOptions::default()).await;
+      let result = Storage::range_url(
+        &storage,
+        "folder/../../passwords",
+        RangeUrlOptions::default(),
+      )
+      .await;
       assert!(
         matches!(result, Err(StorageError::InvalidKey(msg)) if msg == "folder/../../passwords")
       );
@@ -203,7 +209,7 @@ pub(crate) mod tests {
   #[tokio::test]
   async fn url_of_existing_key() {
     with_local_storage(|storage| async move {
-      let result = Storage::url(&storage, "folder/../key1", UrlOptions::default()).await;
+      let result = Storage::range_url(&storage, "folder/../key1", RangeUrlOptions::default()).await;
       let expected = Url::new("https://127.0.0.1:8081/data/key1");
       assert!(matches!(result, Ok(url) if url == expected));
     })
@@ -213,10 +219,10 @@ pub(crate) mod tests {
   #[tokio::test]
   async fn url_of_existing_key_with_specified_range() {
     with_local_storage(|storage| async move {
-      let result = Storage::url(
+      let result = Storage::range_url(
         &storage,
         "folder/../key1",
-        UrlOptions::default().with_range(BytesPosition::new(Some(7), Some(10))),
+        RangeUrlOptions::default().with_range(BytesPosition::new(Some(7), Some(10))),
       )
       .await;
       let expected = Url::new("https://127.0.0.1:8081/data/key1")
@@ -229,10 +235,10 @@ pub(crate) mod tests {
   #[tokio::test]
   async fn url_of_existing_key_with_specified_open_ended_range() {
     with_local_storage(|storage| async move {
-      let result = Storage::url(
+      let result = Storage::range_url(
         &storage,
         "folder/../key1",
-        UrlOptions::default().with_range(BytesPosition::new(Some(7), None)),
+        RangeUrlOptions::default().with_range(BytesPosition::new(Some(7), None)),
       )
       .await;
       let expected = Url::new("https://127.0.0.1:8081/data/key1")

--- a/htsget-search/src/storage/local.rs
+++ b/htsget-search/src/storage/local.rs
@@ -129,7 +129,7 @@ pub(crate) mod tests {
 
   use crate::htsget::{Headers, Url};
   use crate::storage::axum_server::HttpsFormatter;
-  use crate::storage::{BytesRange, GetOptions, StorageError, UrlOptions};
+  use crate::storage::{BytesPosition, GetOptions, StorageError, UrlOptions};
 
   use super::*;
 
@@ -216,7 +216,7 @@ pub(crate) mod tests {
       let result = Storage::url(
         &storage,
         "folder/../key1",
-        UrlOptions::default().with_range(BytesRange::new(Some(7), Some(9))),
+        UrlOptions::default().with_range(BytesPosition::new(Some(7), Some(10))),
       )
       .await;
       let expected = Url::new("https://127.0.0.1:8081/data/key1")
@@ -232,7 +232,7 @@ pub(crate) mod tests {
       let result = Storage::url(
         &storage,
         "folder/../key1",
-        UrlOptions::default().with_range(BytesRange::new(Some(7), None)),
+        UrlOptions::default().with_range(BytesPosition::new(Some(7), None)),
       )
       .await;
       let expected = Url::new("https://127.0.0.1:8081/data/key1")

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -85,6 +85,12 @@ impl From<StorageError> for io::Error {
   }
 }
 
+/// A DataBlock is either a range of bytes, or a data blob that gets transformed into a data uri.
+pub enum DataBlock {
+  Range(BytesRange),
+  Data(Vec<u8>)
+}
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct BytesRange {
   start: Option<u64>,

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -97,6 +97,16 @@ pub enum DataBlock {
   Data(Vec<u8>),
 }
 
+impl DataBlock {
+  /// Convert a vec of bytes positions to a vec of data blocks.
+  pub fn from_bytes_positions(positions: Vec<BytesPosition>) -> Vec<Self> {
+    positions
+      .into_iter()
+      .map(|pos| DataBlock::Range(pos))
+      .collect()
+  }
+}
+
 /// A byte position has an inclusive start value, and an exclusive end value. This is analogous to
 /// query start and end parameters.
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -100,10 +100,7 @@ pub enum DataBlock {
 impl DataBlock {
   /// Convert a vec of bytes positions to a vec of data blocks.
   pub fn from_bytes_positions(positions: Vec<BytesPosition>) -> Vec<Self> {
-    positions
-      .into_iter()
-      .map(|pos| DataBlock::Range(pos))
-      .collect()
+    positions.into_iter().map(DataBlock::Range).collect()
   }
 }
 

--- a/htsget-test-utils/src/server_tests.rs
+++ b/htsget-test-utils/src/server_tests.rs
@@ -9,11 +9,8 @@ use serde::Deserialize;
 
 use htsget_config::config::Config;
 use htsget_http_core::{get_service_info_with, Endpoint, JsonResponse};
-use htsget_search::htsget::Class::Body;
 use htsget_search::htsget::Response as HtsgetResponse;
 use htsget_search::htsget::{Class, Format, Headers, Url};
-
-use crate::util::expected_bgzf_eof_data_url;
 
 /// Represents a http header.
 #[derive(Debug)]
@@ -170,14 +167,8 @@ pub fn expected_response(class: Class, url_path: String) -> JsonResponse {
 
   let http_url = Url::new(format!("{}/data/vcf/sample1-bcbio-cancer.vcf.gz", url_path))
     .with_headers(Headers::new(headers))
-    .with_class(class.clone());
-  let urls = match class {
-    Class::Header => vec![http_url],
-    Class::Body => vec![
-      http_url,
-      Url::new(expected_bgzf_eof_data_url()).with_class(Body),
-    ],
-  };
+    .with_class(class);
+  let urls = vec![http_url];
 
   JsonResponse::from_response(HtsgetResponse::new(Format::Vcf, urls))
 }

--- a/htsget-test-utils/src/server_tests.rs
+++ b/htsget-test-utils/src/server_tests.rs
@@ -2,16 +2,18 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use async_trait::async_trait;
 use http::Method;
+use serde::de;
+use serde::Deserialize;
 
 use htsget_config::config::Config;
 use htsget_http_core::{get_service_info_with, Endpoint, JsonResponse};
+use htsget_search::htsget::Class::Body;
+use htsget_search::htsget::Response as HtsgetResponse;
 use htsget_search::htsget::{Class, Format, Headers, Url};
 
-use async_trait::async_trait;
-use htsget_search::htsget::Response as HtsgetResponse;
-use serde::de;
-use serde::Deserialize;
+use crate::util::expected_bgzf_eof_data_url;
 
 /// Represents a http header.
 #[derive(Debug)]
@@ -165,14 +167,19 @@ fn expected_local_storage_path(config: &Config) -> String {
 pub fn expected_response(class: Class, url_path: String) -> JsonResponse {
   let mut headers = HashMap::new();
   headers.insert("Range".to_string(), "bytes=0-3366".to_string());
-  JsonResponse::from_response(HtsgetResponse::new(
-    Format::Vcf,
-    vec![
-      Url::new(format!("{}/data/vcf/sample1-bcbio-cancer.vcf.gz", url_path))
-        .with_headers(Headers::new(headers))
-        .with_class(class),
+
+  let http_url = Url::new(format!("{}/data/vcf/sample1-bcbio-cancer.vcf.gz", url_path))
+    .with_headers(Headers::new(headers))
+    .with_class(class.clone());
+  let urls = match class {
+    Class::Header => vec![http_url],
+    Class::Body => vec![
+      http_url,
+      Url::new(expected_bgzf_eof_data_url()).with_class(Body),
     ],
-  ))
+  };
+
+  JsonResponse::from_response(HtsgetResponse::new(Format::Vcf, urls))
 }
 
 /// Get the default directory where data is present.

--- a/htsget-test-utils/src/server_tests.rs
+++ b/htsget-test-utils/src/server_tests.rs
@@ -9,8 +9,11 @@ use serde::Deserialize;
 
 use htsget_config::config::Config;
 use htsget_http_core::{get_service_info_with, Endpoint, JsonResponse};
+use htsget_search::htsget::Class::Body;
 use htsget_search::htsget::Response as HtsgetResponse;
 use htsget_search::htsget::{Class, Format, Headers, Url};
+
+use crate::util::expected_bgzf_eof_data_url;
 
 /// Represents a http header.
 #[derive(Debug)]
@@ -167,8 +170,14 @@ pub fn expected_response(class: Class, url_path: String) -> JsonResponse {
 
   let http_url = Url::new(format!("{}/data/vcf/sample1-bcbio-cancer.vcf.gz", url_path))
     .with_headers(Headers::new(headers))
-    .with_class(class);
-  let urls = vec![http_url];
+    .with_class(class.clone());
+  let urls = match class {
+    Class::Header => vec![http_url],
+    Class::Body => vec![
+      http_url,
+      Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+    ],
+  };
 
   JsonResponse::from_response(HtsgetResponse::new(Format::Vcf, urls))
 }

--- a/htsget-test-utils/src/util.rs
+++ b/htsget-test-utils/src/util.rs
@@ -1,6 +1,7 @@
-use rcgen::generate_simple_self_signed;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use rcgen::generate_simple_self_signed;
 
 pub fn generate_test_certificates<P: AsRef<Path>>(
   in_path: P,
@@ -15,4 +16,12 @@ pub fn generate_test_certificates<P: AsRef<Path>>(
   fs::write(&cert_path, cert.serialize_pem().unwrap()).unwrap();
 
   (key_path, cert_path)
+}
+
+pub fn expected_bgzf_eof_data_url() -> String {
+  "data:;base64,H4sIBAAAAAAA/wYAQkMCABsAAwAAAAAAAAAAAA==".to_string()
+}
+
+pub fn expected_cram_eof_data_url() -> String {
+  "data:;base64,DwAAAP////8P4EVPRgAAAAABAAW92U8AAQAGBgEAAQABAO5jAUs=".to_string()
 }


### PR DESCRIPTION
Fixes #85 

The following PR adds EOF urls to all relevant responses except headers. This is done by using an embedded data uri, which contains a base64 encoded payload. Note that all files return EOF markers for non-header requests. VCF, BCF, and BAM return a BGZF EOF marker, and CRAM returns the CRAM EOF container. While VCF does not usually have an EOF marker, BGZF-compressed VCF files should contain EOF markers to avoid errors and warnings from `bcftools view`.

Changes:
* EOF markers are added as inline data uris.
* CRAM header query includes file definition
* Non-header queries encompass a complete data stream, with headers, body records, and EOF markers.
* Change 0-based htsget start and end ranges, to 1-based file format positions.
* ByteRanges (end inclusive) and BytePositions (end exclusive) are distinguished using separate types.