### PR TITLE
Out of order urls

### DIFF
--- a/htsget-http-actix/benches/request_benchmarks.rs
+++ b/htsget-http-actix/benches/request_benchmarks.rs
@@ -215,7 +215,6 @@ fn start_htsget_refserver() -> (DropGuard, String) {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-
   let certs = TempDir::new().unwrap();
 
   let mut group = c.benchmark_group("Requests");

--- a/htsget-http-core/src/error.rs
+++ b/htsget-http-core/src/error.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize};
+use serde::Serialize;
 use thiserror::Error;
 
 use htsget_search::htsget::HtsGetError as HtsGetSearchError;
@@ -37,10 +37,9 @@ pub struct JsonHtsGetError {
 
 /// The "htsget" container wrapping the actual error response above
 #[derive(Serialize)]
-pub struct ContainerHtsGetError{
+pub struct ContainerHtsGetError {
   htsget: JsonHtsGetError,
 }
-
 
 impl HtsGetError {
   /// Allows converting the error to JSON and the correspondent
@@ -64,12 +63,7 @@ impl HtsGetError {
     };
 
     // ...and "htsget" wrapping
-    (
-      ContainerHtsGetError {
-        htsget: inner_json
-      },
-      status_code,
-    )
+    (ContainerHtsGetError { htsget: inner_json }, status_code)
   }
 }
 

--- a/htsget-http-core/src/http_core.rs
+++ b/htsget-http-core/src/http_core.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use futures::stream::FuturesUnordered;
+use futures::stream::FuturesOrdered;
 use futures::StreamExt;
 use tokio::select;
 use tracing::debug;
@@ -56,7 +56,7 @@ pub async fn get_response_for_post_request(
     request
   );
 
-  let mut futures = FuturesUnordered::new();
+  let mut futures = FuturesOrdered::new();
   for query in request.get_queries(id)? {
     let owned_searcher = searcher.clone();
     futures.push(tokio::spawn(

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -28,12 +28,11 @@ htsget-config = { path = "../htsget-config", default-features = false }
 tracing = "0.1"
 base64 = "0.13"
 
-noodles = { version = "0.21", features = ["core", "bgzf", "bam", "bcf", "cram", "csi", "sam", "tabix", "vcf"] }
-noodles-bam = { version = "0.17", features = ["async"] }
+noodles = { version = "0.24", features = ["core", "bgzf", "bam", "bcf", "cram", "csi", "sam", "tabix", "vcf"] }
+noodles-bam = { version = "0.19", features = ["async"] }
 noodles-bcf = { version = "0.13", features = ["async"] }
-noodles-cram = { version = "0.14", features = ["async"] }
-noodles-vcf = { version = "0.15", features = ["async"] }
-noodles-tabix = { version = "=0.9.0", features = ["async"] }
+noodles-cram = { version = "0.16", features = ["async"] }
+noodles-vcf = { version = "0.16", features = ["async"] }
 
 # Aws S3 storage dependencies.
 bytes = { version = "1.1", optional = true }

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -35,7 +35,10 @@ where
   ReaderType: AsyncRead + AsyncSeek + Unpin + Send + Sync,
 {
   async fn read_bytes(&mut self) -> Option<usize> {
-    self.read_record(&mut sam::alignment::Record::default()).await.ok()
+    self
+      .read_record(&mut sam::alignment::Record::default())
+      .await
+      .ok()
   }
 
   async fn seek_vpos(&mut self, pos: VirtualPosition) -> io::Result<VirtualPosition> {

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -298,6 +298,34 @@ pub mod tests {
   }
 
   #[tokio::test]
+  async fn search_many_response_urls() {
+    with_local_storage(|storage| async move {
+      let search = BamSearch::new(storage.clone());
+      let query = Query::new("htsnexus_test_NA12878", Format::Bam).with_reference_name("11").with_start(4999976).with_end(5003981);
+      let response = search.search(query).await;
+      println!("{:#?}", response);
+
+      let expected_response = Ok(Response::new(
+        Format::Bam,
+        vec![
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=0-273085")),
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=499249-574358")),
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=627987-647345")),
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=824361-842100")),
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=977196-996014")),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+        ],
+      ));
+      assert_eq!(response, expected_response)
+    }).await
+  }
+
+  #[tokio::test]
   async fn search_header() {
     with_local_storage(|storage| async move {
       let search = BamSearch::new(storage.clone());

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -301,7 +301,10 @@ pub mod tests {
   async fn search_many_response_urls() {
     with_local_storage(|storage| async move {
       let search = BamSearch::new(storage.clone());
-      let query = Query::new("htsnexus_test_NA12878", Format::Bam).with_reference_name("11").with_start(4999976).with_end(5003981);
+      let query = Query::new("htsnexus_test_NA12878", Format::Bam)
+        .with_reference_name("11")
+        .with_start(4999976)
+        .with_end(5003981);
       let response = search.search(query).await;
       println!("{:#?}", response);
 
@@ -322,7 +325,8 @@ pub mod tests {
         ],
       ));
       assert_eq!(response, expected_response)
-    }).await
+    })
+    .await
   }
 
   #[tokio::test]

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -35,7 +35,7 @@ where
   ReaderType: AsyncRead + AsyncSeek + Unpin + Send + Sync,
 {
   async fn read_bytes(&mut self) -> Option<usize> {
-    self.read_record(&mut bam::Record::default()).await.ok()
+    self.read_record(&mut sam::alignment::Record::default()).await.ok()
   }
 
   async fn seek_vpos(&mut self, pos: VirtualPosition) -> io::Result<VirtualPosition> {
@@ -58,7 +58,7 @@ where
   type ReferenceSequenceHeader = sam::header::ReferenceSequence;
 
   fn max_seq_position(ref_seq: &Self::ReferenceSequenceHeader) -> i32 {
-    ref_seq.len()
+    ref_seq.len().get() as i32
   }
 
   async fn get_byte_ranges_for_unmapped(

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::prelude::stream::FuturesUnordered;
+use futures_util::stream::FuturesOrdered;
 use noodles::bgzf::VirtualPosition;
 use noodles::csi::index::ReferenceSequence;
 use noodles::csi::Index;
@@ -91,7 +91,7 @@ where
 
     // We are assuming the order of the contigs in the header and the references sequences
     // in the index is the same
-    let futures = FuturesUnordered::new();
+    let mut futures = FuturesOrdered::new();
     for (ref_seq_index, (name, contig)) in header.contigs().iter().enumerate() {
       let owned_contig = contig.clone();
       let owned_name = name.to_owned();

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -133,7 +133,7 @@ where
           .map(|end| end as i32)
           .map(into_one_based_position)
           .transpose()?
-          .unwrap_or(ref_seq.len()),
+          .unwrap_or(ref_seq.len().get() as i32),
       index,
       Arc::new(move |record: &Record| record.reference_sequence_id() == Some(ref_seq_id)),
     )

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -6,8 +6,8 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::prelude::stream::FuturesUnordered;
 use futures::StreamExt;
+use futures_util::stream::FuturesOrdered;
 use noodles::cram::crai;
 use noodles::cram::crai::{Index, Record};
 use noodles::sam;
@@ -207,7 +207,7 @@ where
     F: Fn(&Record) -> bool + Send + Sync + 'static,
   {
     // This could be improved by using some sort of index mapping.
-    let mut futures = FuturesUnordered::new();
+    let mut futures = FuturesOrdered::new();
     for (record, next) in crai_index.iter().zip(crai_index.iter().skip(1)) {
       let owned_record = record.clone();
       let owned_next = next.clone();

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -9,8 +9,8 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::stream::FuturesUnordered;
 use futures::StreamExt;
+use futures_util::stream::FuturesOrdered;
 use noodles::bgzf::VirtualPosition;
 use noodles::core::Position;
 use noodles::csi::binning_index::merge_chunks;
@@ -36,7 +36,7 @@ pub(crate) static BGZF_EOF: &[u8] = &[
 /// Helper function to find the first non-none value from a set of futures.
 pub(crate) async fn find_first<T>(
   msg: &str,
-  mut futures: FuturesUnordered<JoinHandle<Option<T>>>,
+  mut futures: FuturesOrdered<JoinHandle<Option<T>>>,
 ) -> Result<T> {
   let mut result = None;
   loop {
@@ -288,7 +288,7 @@ where
     format: Format,
     byte_ranges: Vec<DataBlock>,
   ) -> Result<Response> {
-    let mut storage_futures = FuturesUnordered::new();
+    let mut storage_futures = FuturesOrdered::new();
     for block in byte_ranges {
       match block {
         DataBlock::Range(range) => {
@@ -391,7 +391,7 @@ where
       .query(ref_seq_id, seq_start..=seq_end)
       .map_err(|_| invalid_range())?;
 
-    let mut futures: FuturesUnordered<JoinHandle<Result<BytesPosition>>> = FuturesUnordered::new();
+    let mut futures: FuturesOrdered<JoinHandle<Result<BytesPosition>>> = FuturesOrdered::new();
     for chunk in merge_chunks(&chunks) {
       let storage = self.get_storage();
       let id = query.id.clone();
@@ -446,7 +446,7 @@ where
     format: Format,
     index: &Index,
   ) -> Result<Vec<BytesPosition>> {
-    let mut futures: FuturesUnordered<JoinHandle<Result<BytesPosition>>> = FuturesUnordered::new();
+    let mut futures: FuturesOrdered<JoinHandle<Result<BytesPosition>>> = FuturesOrdered::new();
     for ref_sequences in index.reference_sequences() {
       if let Some(metadata) = ref_sequences.metadata() {
         let storage = self.get_storage();

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -359,7 +359,7 @@ where
   ReaderType: AsyncRead + Unpin + Send + Sync,
   Reader: BlockPosition + Send + Sync,
   ReferenceSequence: BinningIndexReferenceSequence,
-  Index: BinningIndex<ReferenceSequence> + Send + Sync,
+  Index: BinningIndex + Send + Sync,
   Header: FromStr + Send,
 {
   type ReferenceSequenceHeader: Sync;
@@ -437,7 +437,7 @@ where
   Reader: BlockPosition + Send + Sync,
   Header: FromStr + Send,
   ReferenceSequence: BinningIndexReferenceSequence + Sync,
-  Index: BinningIndex<ReferenceSequence> + Send + Sync,
+  Index: BinningIndex + Send + Sync,
   T: BgzfSearch<S, ReaderType, ReferenceSequence, Index, Reader, Header> + Send + Sync,
 {
   async fn get_byte_ranges_for_all(
@@ -499,7 +499,7 @@ where
   Reader: BlockPosition + Send + Sync,
   Header: FromStr + Send,
   ReferenceSequence: BinningIndexReferenceSequence + Sync,
-  Index: BinningIndex<ReferenceSequence> + Send + Sync,
+  Index: BinningIndex + Send + Sync,
   T: BgzfSearch<S, ReaderType, ReferenceSequence, Index, Reader, Header> + Send + Sync,
 {
   fn get_eof_marker(&self) -> Option<DataBlock> {

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::prelude::stream::FuturesUnordered;
+use futures_util::stream::FuturesOrdered;
 use noodles::bgzf;
 use noodles::bgzf::VirtualPosition;
 use noodles::tabix;
@@ -95,7 +95,7 @@ where
 
     // We are assuming the order of the names and the references sequences
     // in the index is the same
-    let futures = FuturesUnordered::new();
+    let mut futures = FuturesOrdered::new();
     for (index, name) in index.reference_sequence_names().iter().enumerate() {
       let owned_name = name.to_owned();
       let owned_reference_name = reference_name.clone();


### PR DESCRIPTION
Fixes #85

The following PR fixes out of order urls in response tickets, which were caused by using `FuturesUnordered`, instead of `FuturesOrdered`.

Changes:
* Change `FuturesUnordered` to `FuturesOrdered`.
* Bump noodles to version 0.24.
