### PR TITLE
Headers have EOF too

### DIFF
--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -345,7 +345,7 @@ pub mod tests {
         vec![Url::new(expected_url())
           .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
           .with_class(Class::Header),
-          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Class::Header),
         ],
       ));
       assert_eq!(response, expected_response)

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -342,9 +342,10 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bam,
-        vec![Url::new(expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
-          .with_class(Class::Header),
+        vec![
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
+            .with_class(Class::Header),
           Url::new(expected_bgzf_eof_data_url()).with_class(Class::Header),
         ],
       ));

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -344,7 +344,9 @@ pub mod tests {
         Format::Bam,
         vec![Url::new(expected_url())
           .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
-          .with_class(Class::Header)],
+          .with_class(Class::Header),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+        ],
       ));
       assert_eq!(response, expected_response)
     })

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -237,9 +237,12 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Bcf,
-        vec![Url::new(expected_url(filename))
-          .with_headers(Headers::default().with_header("Range", "bytes=0-949"))
-          .with_class(Class::Header)],
+        vec![
+          Url::new(expected_url(filename))
+            .with_headers(Headers::default().with_header("Range", "bytes=0-949"))
+            .with_class(Class::Header),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Class::Header),
+        ],
       ));
       assert_eq!(response, expected_response)
     })

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -425,9 +425,12 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Cram,
-        vec![Url::new(expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=0-6086"))
-          .with_class(Class::Header)],
+        vec![
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=0-6086"))
+            .with_class(Class::Header),
+          Url::new(expected_cram_eof_data_url()).with_class(Class::Header),
+        ],
       ));
       assert_eq!(response, expected_response)
     })

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -268,12 +268,18 @@ where
         self.build_response(class, id, format, blocks).await
       }
       Class::Header => {
+        // Spec is unclear about this, headers do need EOFs too.
+        let mut blocks = DataBlock::from_bytes_positions(header_byte_ranges);
+        if let Some(eof) = self.get_eof_marker() {
+          blocks.push(eof);
+        }
+
         self
           .build_response(
             query.class,
             query.id,
             self.get_format(),
-            DataBlock::from_bytes_positions(header_byte_ranges),
+            blocks,
           )
           .await
       }

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -275,12 +275,7 @@ where
         }
 
         self
-          .build_response(
-            query.class,
-            query.id,
-            self.get_format(),
-            blocks,
-          )
+          .build_response(query.class, query.id, self.get_format(), blocks)
           .await
       }
     }

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -232,9 +232,12 @@ pub mod tests {
 
       let expected_response = Ok(Response::new(
         Format::Vcf,
-        vec![Url::new(expected_url(filename))
-          .with_headers(Headers::default().with_header("Range", "bytes=0-822"))
-          .with_class(Class::Header)],
+        vec![
+          Url::new(expected_url(filename))
+            .with_headers(Headers::default().with_header("Range", "bytes=0-822"))
+            .with_class(Class::Header),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Class::Header),
+        ],
       ));
       assert_eq!(response, expected_response)
     })

--- a/htsget-test-utils/src/server_tests.rs
+++ b/htsget-test-utils/src/server_tests.rs
@@ -9,7 +9,6 @@ use serde::Deserialize;
 
 use htsget_config::config::Config;
 use htsget_http_core::{get_service_info_with, Endpoint, JsonResponse};
-use htsget_search::htsget::Class::Body;
 use htsget_search::htsget::Response as HtsgetResponse;
 use htsget_search::htsget::{Class, Format, Headers, Url};
 
@@ -172,10 +171,13 @@ pub fn expected_response(class: Class, url_path: String) -> JsonResponse {
     .with_headers(Headers::new(headers))
     .with_class(class.clone());
   let urls = match class {
-    Class::Header => vec![http_url],
+    Class::Header => vec![
+      http_url,
+      Url::new(expected_bgzf_eof_data_url()).with_class(Class::Header),
+    ],
     Class::Body => vec![
       http_url,
-      Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+      Url::new(expected_bgzf_eof_data_url()).with_class(Class::Body),
     ],
   };
 


### PR DESCRIPTION
This PR fixes another subtle issue not tackled in PR https://github.com/umccr/htsget-rs/pull/87.

The htsget spec is not entirely clear about headers having to send EOF blocks:

<img width="1334" alt="Screen Shot 2022-06-15 at 3 20 52 pm" src="https://user-images.githubusercontent.com/175587/173742942-4319bc9f-6930-4bc9-8eff-27560e2b6b34.png">

This ambiguous prose formulation leads to misunderstanding among developers, i.e:

> It says: "Request the SAM/CRAM/VCF headers only." for a request with class=header.
> To me that means without EOF

OTOH tooling like samtools expects such EOFs not only for body but headers too (because it's a BGZF or CRAM file after all):

```
$ samtools view -H htsnexus_test_NA12878__igv__header_only.bam
[W::bam_hdr_read] EOF marker is absent. The input is probably truncated
<SNIP>
```