### PR TITLE
Address full object request corner case and resolve file format extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ target
 Cargo.lock
 *.code-workspace
 *.vcf.gz
-.vscode
 .idea
 package-lock.json
 deploy/.build

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+    {
+        "name": "(lldb) Launch",
+        "type": "cppdbg",
+        "request": "launch",
+        "program": "${workspaceFolder}/target/debug/htsget-http-actix",
+        "args": [],
+        "stopAtEntry": false,
+        "cwd": "${fileDirname}",
+        "environment": [{"name": "HTSGET_S3_BUCKET", "value": "umccr-research-dev"}, {"name": "HTSGET_STORAGE_TYPE", "value": "AwsS3Storage"}],
+        "externalConsole": false,
+        "MIMode": "lldb"
+    },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug",
+            "program": "${workspaceFolder}target/debug/htsget-http-actix",
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "zenMode.hideLineNumbers": false,
+    "search.showLineNumbers": true,
+    "notebook.lineNumbers": "on"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,31 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "cargo",
+			"command": "build",
+			"args": [ "--all-features" ],
+			"problemMatcher": [
+				"$rustc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"label": "rust: cargo build"
+		},
+		{
+			"type": "cargo",
+			"command": "test",
+			"args": [ "--all-features" ],
+			"problemMatcher": [
+				"$rustc"
+			],
+			"group": {
+				"kind": "test",
+				"isDefault": true
+			},
+			"label": "rust: cargo test"
+		}
+	]
+}

--- a/htsget-http-core/src/post_request.rs
+++ b/htsget-http-core/src/post_request.rs
@@ -23,8 +23,8 @@ pub struct PostRequest {
 pub struct Region {
   #[serde(rename = "referenceName")]
   pub reference_name: String,
-  pub start: Option<u32>,
-  pub end: Option<u32>,
+  pub start: Option<u64>,
+  pub end: Option<u64>,
 }
 
 impl PostRequest {
@@ -39,7 +39,7 @@ impl PostRequest {
             self
               .get_base_query_builder(id.clone())?
               .with_reference_name(Some(region.reference_name.clone()))
-              .with_range_from_u32(region.start, region.end)?
+              .with_range_from_u64(region.start, region.end)?
               .build(),
           )
         })

--- a/htsget-http-core/src/query_builder.rs
+++ b/htsget-http-core/src/query_builder.rs
@@ -67,7 +67,7 @@ impl QueryBuilder {
       .map(|start| start.into())
       .map(|start| {
         start
-          .parse::<u32>()
+          .parse::<u64>()
           .map_err(|_| HtsGetError::InvalidInput(format!("{} isn't a valid start", start)))
       })
       .transpose()?;
@@ -75,14 +75,14 @@ impl QueryBuilder {
       .map(|end| end.into())
       .map(|end| {
         end
-          .parse::<u32>()
+          .parse::<u64>()
           .map_err(|_| HtsGetError::InvalidInput(format!("{} isn't a valid end", end)))
       })
       .transpose()?;
-    self.with_range_from_u32(start, end)
+    self.with_range_from_u64(start, end)
   }
 
-  pub fn with_range_from_u32(mut self, start: Option<u32>, end: Option<u32>) -> Result<Self> {
+  pub fn with_range_from_u64(mut self, start: Option<u64>, end: Option<u64>) -> Result<Self> {
     if let Some(start) = start {
       self.query = self.query.with_start(start);
     }
@@ -93,7 +93,7 @@ impl QueryBuilder {
       && (self.query.reference_name.is_none() || self.query.reference_name.clone().unwrap() == "*")
     {
       return Err(HtsGetError::InvalidInput(
-        "Can't use range whitout specifying the reference name or with \"*\"".to_string(),
+        "Can't use range without specifying the reference name or with \"*\"".to_string(),
       ));
     }
     if self.query.start.is_some()

--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -138,8 +138,8 @@ pub struct Query {
   /// Reference name
   pub reference_name: Option<String>,
   /// The start and end positions are 0-based. [start, end)  
-  pub start: Option<u32>,
-  pub end: Option<u32>,
+  pub start: Option<u64>,
+  pub end: Option<u64>,
   pub fields: Fields,
   pub tags: Tags,
   pub no_tags: Option<Vec<String>>,
@@ -175,12 +175,12 @@ impl Query {
     self
   }
 
-  pub fn with_start(mut self, start: u32) -> Self {
+  pub fn with_start(mut self, start: u64) -> Self {
     self.start = Some(start);
     self
   }
 
-  pub fn with_end(mut self, end: u32) -> Self {
+  pub fn with_end(mut self, end: u64) -> Self {
     self.end = Some(end);
     self
   }

--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -214,19 +214,19 @@ pub enum Format {
 impl Format {
   pub(crate) fn fmt_file(&self, id: &str) -> String {
     match self {
-      Format::Bam => format!("{}.bam", id),
-      Format::Cram => format!("{}.cram", id),
-      Format::Vcf => format!("{}.vcf.gz", id),
-      Format::Bcf => format!("{}.bcf", id),
+      Format::Bam => format!("{}", id),
+      Format::Cram => format!("{}", id),
+      Format::Vcf => format!("{}", id),
+      Format::Bcf => format!("{}", id),
     }
   }
 
   pub(crate) fn fmt_index(&self, id: &str) -> String {
     match self {
-      Format::Bam => format!("{}.bam.bai", id),
-      Format::Cram => format!("{}.cram.crai", id),
-      Format::Vcf => format!("{}.vcf.gz.tbi", id),
-      Format::Bcf => format!("{}.bcf.csi", id),
+      Format::Bam => format!("{}.bai", id),
+      Format::Cram => format!("{}.crai", id),
+      Format::Vcf => format!("{}.tbi", id),
+      Format::Bcf => format!("{}.csi", id),
     }
   }
 }

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -236,7 +236,7 @@ where
       let object_size = self.get_storage().head(key).await?;
       let whole_file_query = Query::new(&query.id, format)
             .with_start(0)
-            .with_end(object_size); // TODO: u32 to u64?
+            .with_end(object_size.try_into().map_err(|_| HtsGetError::InvalidRange("Probably out of range".to_string()))?);
       header_byte_ranges = self.get_byte_ranges_for_header(&whole_file_query).await?;
     } else {
       header_byte_ranges = self.get_byte_ranges_for_header(&query).await?;

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -236,7 +236,7 @@ where
       let object_size = self.get_storage().head(key).await?;
       let whole_file_query = Query::new(&query.id, format)
             .with_start(0)
-            .with_start(object_size.try_into().unwrap()); // TODO: u32 to u64?
+            .with_end(object_size); // TODO: u32 to u64?
       header_byte_ranges = self.get_byte_ranges_for_header(&whole_file_query).await?;
     } else {
       header_byte_ranges = self.get_byte_ranges_for_header(&query).await?;

--- a/htsget-search/src/storage/aws.rs
+++ b/htsget-search/src/storage/aws.rs
@@ -199,21 +199,7 @@ impl Storage for AwsS3Storage {
   ) -> Result<Self::Streamable> {
     let key = key.as_ref();
     debug!(calling_from = ?self, key, "Getting file with key {:?}", key);
-    // If no range information is available,
-    // take a shortcut since client is asking
-    // for the whole object.
-    if options.range.start == None || options.range.end == None {
-      let s3_head = self.s3_head(key).await?;
-      let whole_file_options = GetOptions::default()
-        .range
-        .with_start(0)
-        .with_end(s3_head.content_length().try_into().unwrap()); // TODO: When would that be negative? Handle better!
-      let new_options = GetOptions::default().with_range(whole_file_options);
-      self.create_buf_reader(key, new_options).await
-    } else {
-      // Client has supplied range, we must fetch bytes anyway...
-      self.create_buf_reader(key, options).await
-    }
+    self.create_buf_reader(key, options).await
   }
 
   /// Returns a S3-presigned htsget URL


### PR DESCRIPTION
Thanks @victorskl for reporting this issue, it exposes a few areas that need improvement, namely [this excessive fetching in the AWS backend](https://github.com/umccr/htsget-rs/blob/40a9c93f8ae8a2bf4dc3142003e051ea73c50c6f/htsget-search/src/storage/aws.rs#L147-L151).

# How to reproduce

```shell
export HTSGET_STORAGE_TYPE=AwsS3Storage
export HTSGET_S3_BUCKET=umccr-research-dev
cargo run -p htsget-http-actix &
curl -s 'http://127.0.0.1:8080/reads/example.bam'  <--- See Slack's UMCCR #htsget-rs for a more suitable one
```

I will address the failing tests next, but with these changes @victorskl would be able to get htsget-rs to not block on big files (114G) on the reproducer we discussed.