### PR TITLE
Improve descriptiveness of errors

### DIFF
--- a/htsget-config/src/config.rs
+++ b/htsget-config/src/config.rs
@@ -54,7 +54,7 @@ fn default_path() -> PathBuf {
 }
 
 /// Specify the storage type to use.
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum StorageType {
   LocalStorage,

--- a/htsget-config/src/config.rs
+++ b/htsget-config/src/config.rs
@@ -42,11 +42,11 @@ The next variables are used to configure the info for the service-info endpoints
 const ENVIRONMENT_VARIABLE_PREFIX: &str = "HTSGET_";
 
 fn default_localstorage_addr() -> SocketAddr {
-  "127.0.0.1:8081".parse().expect("Expected valid address.")
+  "127.0.0.1:8081".parse().expect("expected valid address")
 }
 
 fn default_addr() -> SocketAddr {
-  "127.0.0.1:8080".parse().expect("Expected valid address.")
+  "127.0.0.1:8080".parse().expect("expected valid address")
 }
 
 fn default_path() -> PathBuf {
@@ -121,7 +121,7 @@ impl Config {
       .map_err(|err| {
         std::io::Error::new(
           ErrorKind::Other,
-          format!("Config not properly set: {}", err),
+          format!("config not properly set: {}", err),
         )
       });
     info!(config = ?config, "Config created from environment variables.");

--- a/htsget-config/src/regex_resolver.rs
+++ b/htsget-config/src/regex_resolver.rs
@@ -18,7 +18,7 @@ pub struct RegexResolver {
 
 impl Default for RegexResolver {
   fn default() -> Self {
-    Self::new(".*", "$0").expect("Expected valid resolver.")
+    Self::new(".*", "$0").expect("expected valid resolver")
   }
 }
 

--- a/htsget-http-actix/Cargo.toml
+++ b/htsget-http-actix/Cargo.toml
@@ -17,7 +17,7 @@ htsget-http-core = { path = "../htsget-http-core", default-features = false }
 htsget-search = { path = "../htsget-search", default-features = false}
 htsget-config = { path = "../htsget-config", default-features = false }
 futures = { version = "0.3" }
-tokio = { version = "1.19", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.20", features = ["macros", "rt-multi-thread"] }
 tracing-actix-web = "0.6"
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/htsget-http-actix/benches/request_benchmarks.rs
+++ b/htsget-http-actix/benches/request_benchmarks.rs
@@ -81,9 +81,9 @@ fn request(url: reqwest::Url, json_content: &impl Serialize, client: &Client) ->
 
 fn format_url(url: &str, path: &str) -> reqwest::Url {
   reqwest::Url::parse(url)
-    .expect("Invalid url")
+    .expect("invalid url")
     .join(path)
-    .expect("Invalid url")
+    .expect("invalid url")
 }
 
 fn bench_pair(

--- a/htsget-http-actix/src/lib.rs
+++ b/htsget-http-actix/src/lib.rs
@@ -109,7 +109,7 @@ mod tests {
       Self(
         self
           .0
-          .method(method.into().parse().expect("Expected valid method.")),
+          .method(method.into().parse().expect("expected valid method")),
       )
     }
   }

--- a/htsget-http-actix/src/main.rs
+++ b/htsget-http-actix/src/main.rs
@@ -23,7 +23,7 @@ async fn main() -> std::io::Result<()> {
     StorageType::LocalStorage => local_storage_server(config).await,
     #[cfg(feature = "s3-storage")]
     StorageType::AwsS3Storage => s3_storage_server(config).await,
-    _ => Err(Error::new(ErrorKind::Other, "Unsupported storage type")),
+    _ => Err(Error::new(ErrorKind::Other, "unsupported storage type")),
   }
 }
 

--- a/htsget-http-core/Cargo.toml
+++ b/htsget-http-core/Cargo.toml
@@ -15,7 +15,7 @@ http = "0.2"
 htsget-search = { path = "../htsget-search", default-features = false }
 htsget-config = { path = "../htsget-config", default-features = false }
 futures = { version = "0.3" }
-tokio = { version = "1.19", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.20", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/htsget-http-core/src/error.rs
+++ b/htsget-http-core/src/error.rs
@@ -8,7 +8,7 @@ pub type Result<T> = core::result::Result<T, HtsGetError>;
 
 /// An error type that describes the errors specified in the
 /// [HtsGet specification](https://samtools.github.io/hts-specs/htsget.html)
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum HtsGetError {
   #[error("InvalidAuthentication")]
   InvalidAuthentication(String),

--- a/htsget-http-core/src/http_core.rs
+++ b/htsget-http-core/src/http_core.rs
@@ -57,7 +57,7 @@ pub async fn get_response_for_post_request(
   let mut futures = FuturesOrdered::new();
   for query in request.get_queries(id)? {
     let owned_searcher = searcher.clone();
-    futures.push(tokio::spawn(
+    futures.push_back(tokio::spawn(
       async move { owned_searcher.search(query).await },
     ));
   }

--- a/htsget-http-core/src/http_core.rs
+++ b/htsget-http-core/src/http_core.rs
@@ -71,6 +71,6 @@ pub async fn get_response_for_post_request(
 
   Ok(JsonResponse::from(
     // It's okay to unwrap because there will be at least one response
-    merge_responses(responses).expect("Expected valid response."),
+    merge_responses(responses).expect("expected valid response"),
   ))
 }

--- a/htsget-http-core/src/http_core.rs
+++ b/htsget-http-core/src/http_core.rs
@@ -70,7 +70,6 @@ pub async fn get_response_for_post_request(
   }
 
   Ok(JsonResponse::from(
-    // It's okay to unwrap because there will be at least one response
-    merge_responses(responses).expect("expected valid response"),
+    merge_responses(responses).expect("expected at least one response"),
   ))
 }

--- a/htsget-http-core/src/lib.rs
+++ b/htsget-http-core/src/lib.rs
@@ -56,7 +56,7 @@ pub(crate) fn match_endpoints_get_request(
     (Endpoint::Variants, Some(s)) if VARIANTS_FORMATS.contains(&s.as_str()) => (),
     (_, Some(s)) => {
       return Err(HtsGetError::UnsupportedFormat(format!(
-        "{} isn't a supported format for this endpoint.",
+        "{} isn't a supported format for this endpoint",
         s
       )))
     }
@@ -75,7 +75,7 @@ pub(crate) fn match_endpoints_post_request(
     (Endpoint::Variants, Some(s)) if VARIANTS_FORMATS.contains(&s.as_str()) => (),
     (_, Some(s)) => {
       return Err(HtsGetError::UnsupportedFormat(format!(
-        "{} isn't a supported format for this endpoint.",
+        "{} isn't a supported format for this endpoint",
         s
       )))
     }

--- a/htsget-http-core/src/lib.rs
+++ b/htsget-http-core/src/lib.rs
@@ -23,7 +23,7 @@ const VARIANTS_FORMATS: [&str; 2] = ["VCF", "BCF"];
 
 /// A enum to distinguish between the two endpoint defined in the
 /// [HtsGet specification](https://samtools.github.io/hts-specs/htsget.html)
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Endpoint {
   Reads,
   Variants,

--- a/htsget-http-core/src/query_builder.rs
+++ b/htsget-http-core/src/query_builder.rs
@@ -12,10 +12,10 @@ impl QueryBuilder {
   pub fn new(id: Option<impl Into<String>>, format: Option<impl Into<String>>) -> Result<Self> {
     let format = format
       .map(Into::into)
-      .ok_or_else(|| HtsGetError::InvalidInput("Format needed".to_string()))?;
+      .ok_or_else(|| HtsGetError::InvalidInput("format required".to_string()))?;
     Ok(Self {
       query: Query::new(
-        id.ok_or_else(|| HtsGetError::InvalidInput("ID needed".to_string()))?,
+        id.ok_or_else(|| HtsGetError::InvalidInput("ID required".to_string()))?,
         match format.as_str() {
           "BAM" => Format::Bam,
           "CRAM" => Format::Cram,
@@ -23,7 +23,7 @@ impl QueryBuilder {
           "BCF" => Format::Bcf,
           _ => {
             return Err(HtsGetError::UnsupportedFormat(format!(
-              "The {} format isn't supported",
+              "`{}`isn't supported",
               format
             )))
           }
@@ -43,7 +43,7 @@ impl QueryBuilder {
       Some(class) if class == "header" => Class::Header,
       Some(class) => {
         return Err(HtsGetError::InvalidInput(format!(
-          "Invalid class: {}",
+          "invalid class `{}`",
           class
         )))
       }
@@ -67,7 +67,7 @@ impl QueryBuilder {
       .map(Into::into)
       .map(|start| {
         start.parse::<u32>().map_err(|err| {
-          HtsGetError::InvalidInput(format!("{}: '{}' isn't a valid start", err, start))
+          HtsGetError::InvalidInput(format!("`{}` isn't a valid start: {}", start, err))
         })
       })
       .transpose()?;
@@ -76,7 +76,7 @@ impl QueryBuilder {
       .map(|end| {
         end
           .parse::<u32>()
-          .map_err(|err| HtsGetError::InvalidInput(format!("{}: '{}' isn't a valid end", err, end)))
+          .map_err(|err| HtsGetError::InvalidInput(format!("`{}` isn't a valid end: {}", end, err)))
       })
       .transpose()?;
     self.with_range_from_u32(start, end)
@@ -93,7 +93,7 @@ impl QueryBuilder {
       && (self.query.reference_name.is_none() || self.query.reference_name.clone().unwrap() == "*")
     {
       return Err(HtsGetError::InvalidInput(
-        "Can't use range whitout specifying the reference name or with \"*\"".to_string(),
+        "reference name must be specified with start or end range".to_string(),
       ));
     }
     if self.query.interval.start.is_some()
@@ -101,7 +101,7 @@ impl QueryBuilder {
       && self.query.interval.start.unwrap() > self.query.interval.end.unwrap()
     {
       return Err(HtsGetError::InvalidRange(format!(
-        "end({}) is greater than start({})",
+        "end is greater than start (`{}` > `{}`)",
         self.query.interval.end.unwrap(),
         self.query.interval.start.unwrap()
       )));
@@ -148,7 +148,7 @@ impl QueryBuilder {
       let tags: Vec<String> = tags.into_iter().map(Into::into).collect();
       if tags.iter().any(|tag| notags.contains(tag)) {
         return Err(HtsGetError::InvalidInput(
-          "Tags and notags can't intersect".to_string(),
+          "tags and notags can't intersect".to_string(),
         ));
       }
       self.query = self.query.with_tags(Tags::List(tags));

--- a/htsget-http-core/src/service_info.rs
+++ b/htsget-http-core/src/service_info.rs
@@ -9,7 +9,7 @@ use htsget_search::htsget::{Format, HtsGet};
 use crate::{Endpoint, READS_FORMATS, VARIANTS_FORMATS};
 
 /// A struct representing the information that should be present in a service-info response.
-#[derive(Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ServiceInfo {
   pub id: String,
   pub name: String,
@@ -31,20 +31,20 @@ pub struct ServiceInfo {
   pub environment: String,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct Organisation {
   pub name: String,
   pub url: String,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct Type {
   pub group: String,
   pub artifact: String,
   pub version: String,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct Htsget {
   pub datatype: String,
   pub formats: Vec<String>,

--- a/htsget-http-core/src/service_info.rs
+++ b/htsget-http-core/src/service_info.rs
@@ -148,5 +148,6 @@ fn fill_out_service_info_json(
   if let Some(environment) = &config.environment {
     service_info_json.environment = environment.clone();
   }
+
   service_info_json
 }

--- a/htsget-http-lambda/Cargo.toml
+++ b/htsget-http-lambda/Cargo.toml
@@ -10,7 +10,7 @@ default = ["s3-storage"]
 
 [dependencies]
 envy = "0.4"
-tokio = { version = "1.19", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.20", features = ["macros", "rt-multi-thread"] }
 lambda_http = { version = "0.6" }
 lambda_runtime = { version = "0.6" }
 htsget-config = { path = "../htsget-config", default-features = false }
@@ -22,7 +22,7 @@ mime = "0.3"
 regex = "1.6"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-bytes = "1.1"
+bytes = "1.2"
 
 [dev-dependencies]
 htsget-test-utils = { path = "../htsget-test-utils", features = ["server-tests"], default-features = false }

--- a/htsget-http-lambda/src/handlers/mod.rs
+++ b/htsget-http-lambda/src/handlers/mod.rs
@@ -49,7 +49,7 @@ impl TryFrom<Error> for FormatJson<Response<Body>> {
       Response::builder()
         .status(StatusCode::INTERNAL_SERVER_ERROR)
         .header(header::CONTENT_TYPE, mime::TEXT_PLAIN_UTF_8.as_ref())
-        .body(Body::from(format!("{}", error)))?,
+        .body(Body::from(error.to_string()))?,
     ))
   }
 }

--- a/htsget-http-lambda/src/lib.rs
+++ b/htsget-http-lambda/src/lib.rs
@@ -20,7 +20,7 @@ use crate::handlers::service_info::get_service_info_json;
 pub mod handlers;
 
 /// A request route, with a method, endpoint and route type.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Route {
   method: HtsgetMethod,
   endpoint: Endpoint,
@@ -28,14 +28,14 @@ pub struct Route {
 }
 
 /// Valid htsget http request methods.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum HtsgetMethod {
   Get,
   Post,
 }
 
 /// A route type, which is either the service info endpoint, or an id represented by a string.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum RouteType {
   ServiceInfo,
   Id(String),

--- a/htsget-http-lambda/src/lib.rs
+++ b/htsget-http-lambda/src/lib.rs
@@ -205,12 +205,12 @@ mod tests {
   impl TestRequest for LambdaTestRequest<Request> {
     fn insert_header(mut self, header: Header<impl Into<String>>) -> Self {
       self.0.headers_mut().insert(
-        HeaderName::from_str(&header.name.into()).expect("Expected valid header name."),
+        HeaderName::from_str(&header.name.into()).expect("expected valid header name"),
         header
           .value
           .into()
           .parse()
-          .expect("Expected valid header value."),
+          .expect("expected valid header value"),
       );
       self
     }
@@ -222,7 +222,7 @@ mod tests {
 
     fn uri(mut self, uri: impl Into<String>) -> Self {
       let uri = uri.into();
-      *self.0.uri_mut() = uri.parse().expect("Expected valid uri.");
+      *self.0.uri_mut() = uri.parse().expect("expected valid uri");
       if let Some(query) = self.0.uri().query().map(|s| s.to_string()) {
         Self(
           self
@@ -230,7 +230,7 @@ mod tests {
             .with_query_string_parameters(
               query
                 .parse::<QueryMap>()
-                .expect("Expected valid query parameters."),
+                .expect("expected valid query parameters"),
             )
             .with_raw_http_path(&uri),
         )
@@ -240,7 +240,7 @@ mod tests {
     }
 
     fn method(mut self, method: impl Into<String>) -> Self {
-      *self.0.method_mut() = method.into().parse().expect("Expected valid method.");
+      *self.0.method_mut() = method.into().parse().expect("expected valid method");
       self
     }
   }

--- a/htsget-http-lambda/src/main.rs
+++ b/htsget-http-lambda/src/main.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Error> {
     StorageType::LocalStorage => local_storage_server(config).await,
     #[cfg(feature = "s3-storage")]
     StorageType::AwsS3Storage => s3_storage_server(config).await,
-    _ => Err("Unsupported storage type".into()),
+    _ => Err("unsupported storage type".into()),
   }
 }
 

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -19,26 +19,25 @@ tower = { version = "0.4", features = ["make"] }
 
 # Async
 tokio-rustls = "0.23"
-tokio = { version = "1.19", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.20", features = ["macros", "rt-multi-thread"] }
 tokio-util = { version = "0.7", features = ["io", "compat"] }
 futures = { version = "0.3" }
 futures-util = "0.3"
 async-trait = "0.1"
 
 # Noodles
-noodles = { version = "0.25", features = ["core", "bgzf", "bam", "bcf", "cram", "csi", "sam", "tabix", "vcf"] }
-noodles-bgzf = { git = "https://github.com/zaeleus/noodles", features = ["async"] }
-noodles-bam = { version = "0.20", features = ["async"] }
-noodles-bcf = { version = "0.14", features = ["async"] }
-noodles-cram = { version = "0.17", features = ["async"] }
-noodles-vcf = { version = "0.17", features = ["async"] }
+noodles = { version = "0.26", features = ["core", "bgzf", "bam", "bcf", "cram", "csi", "sam", "tabix", "vcf"] }
+noodles-bam = { version = "0.21", features = ["async"] }
+noodles-bcf = { version = "0.15", features = ["async"] }
+noodles-cram = { version = "0.18", features = ["async"] }
+noodles-vcf = { version = "0.18", features = ["async"] }
 
 # Amazon S3
-bytes = { version = "1.1", optional = true }
-aws-sdk-s3 = { version = "0.16", optional = true }
-aws-config = { version = "0.46", optional = true }
+bytes = { version = "1.2", optional = true }
+aws-sdk-s3 = { version = "0.17", optional = true }
+aws-config = { version = "0.47", optional = true }
 
-# Error control, tracing, config..
+# Error control, tracing, config
 thiserror = "1.0"
 htsget-config = { path = "../htsget-config", default-features = false }
 tracing = "0.1"
@@ -54,7 +53,7 @@ data-url = "0.1"
 anyhow = "1.0"
 s3-server = "0.2"
 http = "0.2"
-aws-types = { version = "0.46", features = ["hardcoded-credentials"] }
+aws-types = { version = "0.47", features = ["hardcoded-credentials"] }
 
 # Axum server dependencies
 hyper-tls = "0.5"

--- a/htsget-search/benches/search_benchmarks.rs
+++ b/htsget-search/benches/search_benchmarks.rs
@@ -19,7 +19,7 @@ async fn perform_query(query: Query) -> Result<(), HtsGetError> {
   let htsget = HtsGetFromStorage::local_from(
     "../data",
     RegexResolver::new(".*", "$0").unwrap(),
-    HttpTicketFormatter::new("127.0.0.1:8081".parse().expect("Expected valid address.")),
+    HttpTicketFormatter::new("127.0.0.1:8081".parse().expect("expected valid address")),
   )?;
 
   htsget.search(query).await?;

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -66,7 +66,7 @@ where
       None => {
         VirtualPosition::try_from((self.get_header_end_offset(index).await?, 0)).map_err(|err| {
           HtsGetError::InternalError(format!(
-            "Invalid virtual position generated from header end offset: {}.",
+            "invalid virtual position generated from header end offset `{}`.",
             err
           ))
         })?

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -65,7 +65,7 @@ where
       Some(start) => start,
       None => {
         VirtualPosition::try_from((self.get_header_end_offset(index).await?, 0)).map_err(|err| {
-          HtsGetError::InternalError(format!(
+          HtsGetError::InvalidInput(format!(
             "invalid virtual position generated from header end offset `{}`.",
             err
           ))

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -97,7 +97,7 @@ where
       }));
     }
     let (ref_seq_index, (_, contig)) = find_first(
-      &format!("Reference name not found in the header: {}", reference_name,),
+      &format!("reference name not found in header: {}", reference_name,),
       futures,
     )
     .await?;
@@ -107,7 +107,7 @@ where
         .len()
         .map(u32::try_from)
         .transpose()
-        .map_err(|_| HtsGetError::invalid_input("Failed to convert contig length to u32."))?,
+        .map_err(|err| HtsGetError::invalid_input(format!("converting contig length to `u32`: {}", err)))?,
       value => value,
     };
 

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -103,11 +103,9 @@ where
     .await?;
 
     query.interval.end = match query.interval.end {
-      None => contig
-        .len()
-        .map(u32::try_from)
-        .transpose()
-        .map_err(|err| HtsGetError::invalid_input(format!("converting contig length to `u32`: {}", err)))?,
+      None => contig.len().map(u32::try_from).transpose().map_err(|err| {
+        HtsGetError::invalid_input(format!("converting contig length to `u32`: {}", err))
+      })?,
       value => value,
     };
 

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -88,7 +88,7 @@ where
       let owned_contig = contig.clone();
       let owned_name = name.to_owned();
       let owned_reference_name = reference_name.clone();
-      futures.push(tokio::spawn(async move {
+      futures.push_back(tokio::spawn(async move {
         if owned_name == owned_reference_name {
           Some((ref_seq_index, (owned_name, owned_contig)))
         } else {
@@ -103,9 +103,13 @@ where
     .await?;
 
     query.interval.end = match query.interval.end {
-      None => contig.len().map(u32::try_from).transpose().map_err(|err| {
-        HtsGetError::invalid_input(format!("converting contig length to `u32`: {}", err))
-      })?,
+      None => contig
+        .length()
+        .map(u32::try_from)
+        .transpose()
+        .map_err(|err| {
+          HtsGetError::invalid_input(format!("converting contig length to `u32`: {}", err))
+        })?,
       value => value,
     };
 

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -44,7 +44,6 @@ where
     &self,
     id: String,
     format: Format,
-    _index: &Index,
   ) -> Result<Vec<BytesPosition>> {
     Ok(vec![
       BytesPosition::default().with_end(self.position_at_eof(&id, &format).await?)

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -268,7 +268,7 @@ where
         let record_end = record_start
           .checked_add(record.alignment_span())
           .ok_or_else(|| {
-            HtsGetError::invalid_input("Failed to add record alignment span to Position.")
+            HtsGetError::invalid_input("adding record alignment span to `Position`")
           })?;
 
         let interval = seq_range.into_one_based(|| ref_seq.len().get())?.into();

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -202,7 +202,7 @@ where
       let ref_seq_owned = ref_seq.cloned();
       let owned_predicate = predicate.clone();
       let range = interval.clone();
-      futures.push(tokio::spawn(async move {
+      futures.push_back(tokio::spawn(async move {
         if owned_predicate(&owned_record) {
           Self::bytes_ranges_for_record(
             ref_seq_owned.as_ref(),

--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -36,7 +36,7 @@ pub trait HtsGet {
   fn are_tag_parameters_effective(&self) -> bool;
 }
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum HtsGetError {
   #[error("not found: {0}")]
   NotFound(String),
@@ -128,7 +128,7 @@ impl From<io::Error> for HtsGetError {
 
 /// A query contains all the parameters that can be used when requesting
 /// a search for either of `reads` or `variants`.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Query {
   pub id: String,
   pub format: Format,
@@ -199,7 +199,7 @@ impl Query {
 
 /// An interval represents the start (0-based, inclusive) and end (0-based exclusive) ranges of the
 /// query.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Interval {
   pub start: Option<u32>,
   pub end: Option<u32>,
@@ -252,7 +252,7 @@ impl Interval {
 }
 
 /// An enumeration with all the possible formats.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum Format {
   Bam,
@@ -310,7 +310,7 @@ impl fmt::Display for Format {
   }
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Class {
   Header,
@@ -318,7 +318,7 @@ pub enum Class {
 }
 
 /// Possible values for the fields parameter.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Fields {
   /// Include all fields
   All,
@@ -327,7 +327,7 @@ pub enum Fields {
 }
 
 /// Possible values for the tags parameter.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Tags {
   /// Include all tags
   All,
@@ -336,7 +336,7 @@ pub enum Tags {
 }
 
 /// The headers that need to be supplied when requesting data from a url.
-#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Headers(HashMap<String, String>);
 
 impl Headers {
@@ -367,7 +367,7 @@ impl Headers {
 }
 
 /// A url from which raw data can be retrieved.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Url {
   pub url: String,
   #[serde(skip_serializing_if = "Option::is_none")]
@@ -401,7 +401,7 @@ impl Url {
 }
 
 /// Wrapped json response for htsget.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JsonResponse {
   pub htsget: Response,
 }
@@ -419,7 +419,7 @@ impl From<Response> for JsonResponse {
 }
 
 /// The response for a HtsGet query.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Response {
   pub format: Format,
   pub urls: Vec<Url>,

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -13,10 +13,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::StreamExt;
 use futures_util::stream::FuturesOrdered;
+use noodles::bgzf::gzi;
 use noodles::csi::index::reference_sequence::bin::Chunk;
 use noodles::csi::{BinningIndex, BinningIndexReferenceSequence};
 use noodles::sam;
-use noodles_bgzf::gzi;
 use tokio::io;
 use tokio::io::AsyncRead;
 use tokio::select;
@@ -297,14 +297,14 @@ where
         DataBlock::Range(range) => {
           let storage = self.get_storage();
           let id = id.clone();
-          storage_futures.push(tokio::spawn(async move {
+          storage_futures.push_back(tokio::spawn(async move {
             storage
               .range_url(format.fmt_file(&id), RangeUrlOptions::from(range))
               .await
           }));
         }
         DataBlock::Data(data, class) => {
-          storage_futures.push(tokio::spawn(async move { Ok(S::data_url(data, class)) }));
+          storage_futures.push_back(tokio::spawn(async move { Ok(S::data_url(data, class)) }));
         }
       }
     }

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -215,9 +215,7 @@ where
 
   /// Get the position at the end of file marker.
   async fn position_at_eof(&self, id: &str, format: &Format) -> Result<u64> {
-    let file_size = self
-      .get_storage()
-      .head(format.fmt_file(id)).await?;
+    let file_size = self.get_storage().head(format.fmt_file(id)).await?;
     Ok(
       file_size
         - u64::try_from(self.get_eof_marker().len())
@@ -335,7 +333,9 @@ where
         HtsGetError::io_error(format!("reading `{}` header: {}", self.get_format(), err))
       })?
       .parse::<Header>()
-      .map_err(|err| HtsGetError::io_error(format!("parsing `{}` header: {}", self.get_format(), err)))
+      .map_err(|err| {
+        HtsGetError::parse_error(format!("parsing `{}` header: {}", self.get_format(), err))
+      })
   }
 }
 

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -102,19 +102,15 @@ where
       }));
     }
     let ref_seq_index = find_first(
-      &format!(
-        "reference name not found in TBI file: {}",
-        reference_name,
-      ),
+      &format!("reference name not found in TBI file: {}", reference_name,),
       futures,
     )
     .await?;
 
     query.interval.end = match query.interval.end {
-      None => maybe_len
-        .map(u32::try_from)
-        .transpose()
-        .map_err(|err| HtsGetError::invalid_input(format!("converting contig length to u32: {}", err)))?,
+      None => maybe_len.map(u32::try_from).transpose().map_err(|err| {
+        HtsGetError::invalid_input(format!("converting contig length to u32: {}", err))
+      })?,
       value => value,
     };
 

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -103,7 +103,7 @@ where
     }
     let ref_seq_index = find_first(
       &format!(
-        "Reference name not found in the TBI file: {}",
+        "reference name not found in TBI file: {}",
         reference_name,
       ),
       futures,
@@ -114,7 +114,7 @@ where
       None => maybe_len
         .map(u32::try_from)
         .transpose()
-        .map_err(|_| HtsGetError::invalid_input("Failed to convert contig length to u32."))?,
+        .map_err(|err| HtsGetError::invalid_input(format!("converting contig length to u32: {}", err)))?,
       value => value,
     };
 

--- a/htsget-search/src/storage/aws.rs
+++ b/htsget-search/src/storage/aws.rs
@@ -150,7 +150,7 @@ impl AwsS3Storage {
   ) -> Result<ByteStream> {
     if let Delayed(class) = self.get_retrieval_type(&key).await? {
       return Err(AwsS3Error(
-        format!("Cannot retrieve object immediately, class is {:?}.", class),
+        format!("cannot retrieve object immediately, class is `{:?}`", class),
         key.as_ref().to_string(),
       ));
     }

--- a/htsget-search/src/storage/local.rs
+++ b/htsget-search/src/storage/local.rs
@@ -56,13 +56,13 @@ impl<T: UrlFormatter + Send + Sync> LocalStorage<T> {
       .and_then(|path| {
         path
           .starts_with(&self.base_path)
-          .then(|| path)
+          .then_some(path)
           .ok_or_else(|| StorageError::InvalidKey(key.to_string()))
       })
       .and_then(|path| {
         path
           .is_file()
-          .then(|| path)
+          .then_some(path)
           .ok_or_else(|| StorageError::KeyNotFound(key.to_string()))
       })
   }

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -53,33 +53,33 @@ pub trait UrlFormatter {
 
 #[derive(Error, Debug)]
 pub enum StorageError {
-  #[error("Invalid key: {0}")]
+  #[error("wrong key derived from ID: `{0}`")]
   InvalidKey(String),
 
-  #[error("Key not found: {0}")]
+  #[error("key not found in storage: `{0}`")]
   KeyNotFound(String),
 
-  #[error("Io error: {0} {1}")]
+  #[error("{0}: {1}")]
   IoError(String, io::Error),
 
-  #[cfg(feature = "s3-storage")]
-  #[error("Aws error: {0}, with key: {1}")]
-  AwsS3Error(String, String),
-
-  #[error("Url response ticket server error: {0}")]
+  #[error("url response ticket server error: {0}")]
   TicketServerError(String),
 
-  #[error("Invalid input: {0}")]
+  #[error("invalid input: {0}")]
   InvalidInput(String),
 
-  #[error("Invalid uri: {0}")]
+  #[error("invalid uri: {0}")]
   InvalidUri(String),
 
-  #[error("Invalid address: {0}")]
+  #[error("invalid address: {0}")]
   InvalidAddress(AddrParseError),
 
-  #[error("Internal error: {0}")]
+  #[error("internal error: {0}")]
   InternalError(String),
+
+  #[cfg(feature = "s3-storage")]
+  #[error("aws error: {0}, with key: `{1}`")]
+  AwsS3Error(String, String),
 }
 
 impl From<StorageError> for io::Error {

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -151,7 +151,7 @@ impl From<&BytesRange> for String {
     if ranges.start.is_none() && ranges.end.is_none() {
       return "".to_string();
     }
-    format!("{}", ranges)
+    ranges.to_string()
   }
 }
 

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -92,7 +92,7 @@ impl From<StorageError> for io::Error {
 }
 
 /// A DataBlock is either a range of bytes, or a data blob that gets transformed into a data uri.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DataBlock {
   Range(BytesPosition),
   Data(Vec<u8>, Option<Class>),
@@ -132,7 +132,7 @@ impl DataBlock {
 /// formatted into url responses. The class is set to `Header` for byte positions containing only
 /// header bytes, `Body` for byte positions containing only body bytes, and None for byte positions
 /// with a mix of header and body bytes.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BytesPosition {
   start: Option<u64>,
   end: Option<u64>,

--- a/htsget-search/src/storage/ticket_server.rs
+++ b/htsget-search/src/storage/ticket_server.rs
@@ -79,7 +79,7 @@ impl HttpTicketFormatter {
     match (cert, key) {
       (Some(cert), Some(key)) => Ok(Self::new_with_tls(addr, cert, key)),
       (Some(_), None) | (None, Some(_)) => Err(TicketServerError(
-        "Both the cert and key must be provided for the ticket server.".to_string(),
+        "both the cert and key must be provided for the ticket server".to_string(),
       )),
       (None, None) => Ok(Self::new(addr)),
     }
@@ -128,7 +128,7 @@ impl TicketServer {
   ) -> Result<TicketServer> {
     let listener = TcpListener::bind(addr)
       .await
-      .map_err(|err| IoError("Failed to bind ticket server addr".to_string(), err))?;
+      .map_err(|err| IoError("binding ticket server addr".to_string(), err))?;
     let listener = AddrIncoming::from_listener(listener)?;
 
     info!(address = ?listener.local_addr(), "Htsget ticket server address bound to");
@@ -158,7 +158,7 @@ impl TicketServer {
         loop {
           let stream = poll_fn(|cx| Pin::new(&mut self.listener).poll_accept(cx))
             .await
-            .ok_or_else(|| TicketServerError("Poll accept failed".to_string()))?
+            .ok_or_else(|| TicketServerError("poll accept failed".to_string()))?
             .map_err(|err| TicketServerError(err.to_string()))?;
           let acceptor = acceptor.clone();
 
@@ -184,19 +184,19 @@ impl TicketServer {
 
   fn rustls_server_config<P: AsRef<Path>>(key: P, cert: P) -> Result<Arc<ServerConfig>> {
     let mut key_reader = BufReader::new(
-      File::open(key).map_err(|err| IoError("Failed to open key file".to_string(), err))?,
+      File::open(key).map_err(|err| IoError("failed to open key file".to_string(), err))?,
     );
     let mut cert_reader = BufReader::new(
-      File::open(cert).map_err(|err| IoError("Failed to open cert file".to_string(), err))?,
+      File::open(cert).map_err(|err| IoError("failed to open cert file".to_string(), err))?,
     );
 
     let key = PrivateKey(
       pkcs8_private_keys(&mut key_reader)
-        .map_err(|err| IoError("Failed to read private keys".to_string(), err))?
+        .map_err(|err| IoError("failed to read private keys".to_string(), err))?
         .remove(0),
     );
     let certs = certs(&mut cert_reader)
-      .map_err(|err| IoError("Failed to read certificate".to_string(), err))?
+      .map_err(|err| IoError("failed to read certificate".to_string(), err))?
       .into_iter()
       .map(Certificate)
       .collect();

--- a/htsget-test-utils/Cargo.toml
+++ b/htsget-test-utils/Cargo.toml
@@ -32,11 +32,11 @@ htsget-http-core = { path = "../htsget-http-core", default-features = false, opt
 htsget-config = { path = "../htsget-config", default-features = false, optional = true }
 htsget-search = { path = "../htsget-search", default-features = false, optional = true }
 
-noodles-vcf = { version = "0.17", features = ["async"], optional = true }
-noodles-bgzf = { version = "0.13", features = ["async"], optional = true }
+noodles-vcf = { version = "0.18", features = ["async"], optional = true }
+noodles-bgzf = { version = "0.14", features = ["async"], optional = true }
 
 reqwest = { version = "0.11", features = ["json", "blocking", "rustls-tls"], optional = true }
-tokio = { version = "1.19", features = ["rt-multi-thread"], optional = true }
+tokio = { version = "1.20", features = ["rt-multi-thread"], optional = true }
 futures = { version = "0.3", optional = true }
 async-trait = { version = "0.1", optional = true }
 http = { version = "0.2", optional = true }

--- a/htsget-test-utils/src/server_tests.rs
+++ b/htsget-test-utils/src/server_tests.rs
@@ -308,5 +308,5 @@ pub fn config_with_tls<P: AsRef<Path>>(path: P) -> Config {
 /// Get the event associated with the file.
 pub fn get_test_file<P: AsRef<Path>>(path: P) -> String {
   let path = default_dir().join("data").join(path);
-  fs::read_to_string(path).expect("Failed to read file.")
+  fs::read_to_string(path).expect("failed to read file")
 }


### PR DESCRIPTION
Closes #112 

Changes:
* Improve errors so that they are more informative, propagating information from their cause to the http responses.
* Avoid reading indices unless it is necessary.