### PR TITLE
Small changes related to indices

### DIFF
--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -230,7 +230,9 @@ where
 
     match crai_index.last() {
       None => {
-        byte_ranges.push(BytesPosition::default().with_end(self.position_at_eof(id, format).await?))
+        return Err(HtsGetError::InvalidInput(
+          "No entries found in `CRAI`".to_string(),
+        ));
       }
       Some(last) if predicate(last) => {
         if let Some(range) = Self::bytes_ranges_for_record(

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -413,6 +413,12 @@ where
       )
       .map_err(|err| HtsGetError::InvalidRange(format!("querying range: {}", err)))?;
 
+    if chunks.is_empty() {
+      return Err(HtsGetError::NotFound(
+        "could not find byte ranges for reference sequence".to_string(),
+      ));
+    }
+
     let gzi_data = self
       .get_storage()
       .get(self.get_format().fmt_gzi(&query.id)?, GetOptions::default())

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -404,7 +404,7 @@ where
     ref_seq_id: usize,
     index: &Index,
   ) -> Result<Vec<BytesPosition>> {
-    let chunks = index
+    let mut chunks: Vec<Chunk> = index
       .query(
         ref_seq_id,
         query
@@ -419,28 +419,37 @@ where
       ));
     }
 
+    chunks.sort_unstable_by_key(|a| a.end().compressed());
+
     let gzi_data = self
       .get_storage()
       .get(self.get_format().fmt_gzi(&query.id)?, GetOptions::default())
       .await;
     let byte_ranges: Vec<BytesPosition> = match gzi_data {
       Ok(gzi_data) => {
-        let gzi = gzi::AsyncReader::new(gzi_data).read_index().await?;
+        let mut gzi: Vec<u64> = gzi::AsyncReader::new(gzi_data)
+          .read_index()
+          .await?
+          .into_iter()
+          .map(|(compressed, _)| compressed)
+          .collect();
+        gzi.sort_unstable();
+
         self
           .bytes_positions_from_chunks(
-            chunks,
             &query.id,
             &query.format,
-            gzi.into_iter().map(|(compressed, _)| compressed),
+            chunks.into_iter(),
+            gzi.into_iter(),
           )
           .await?
       }
       Err(_) => {
         self
           .bytes_positions_from_chunks(
-            chunks,
             &query.id,
             &query.format,
+            chunks.into_iter(),
             Self::index_positions(index).into_iter(),
           )
           .await?
@@ -450,18 +459,37 @@ where
     Ok(byte_ranges)
   }
 
+  /// Assumes sorted chunks by compressed end position, and sorted positions.
   async fn bytes_positions_from_chunks<'a>(
     &self,
-    chunks: Vec<Chunk>,
     id: &str,
     format: &Format,
+    chunks: impl Iterator<Item = Chunk> + Send + 'a,
     mut positions: impl Iterator<Item = u64> + Send + 'a,
   ) -> Result<Vec<BytesPosition>> {
     let mut end_position: Option<u64> = None;
     let mut bytes_positions = Vec::new();
+    let mut maybe_end: Option<u64> = None;
+
+    let mut append_position = |chunk: Chunk, end: u64| {
+      bytes_positions.push(
+        BytesPosition::default()
+          .with_start(chunk.start().compressed())
+          .with_end(end)
+          .with_class(Body),
+      );
+    };
 
     for chunk in chunks {
-      let maybe_end = positions.find(|pos| pos > &chunk.end().compressed());
+      match maybe_end {
+        Some(pos) if pos > chunk.end().compressed() => {
+          append_position(chunk, pos);
+          continue;
+        }
+        _ => {}
+      }
+
+      maybe_end = positions.find(|pos| pos > &chunk.end().compressed());
 
       let end = match maybe_end {
         None => match end_position {
@@ -475,12 +503,7 @@ where
         Some(pos) => pos,
       };
 
-      bytes_positions.push(
-        BytesPosition::default()
-          .with_start(chunk.start().compressed())
-          .with_end(end)
-          .with_class(Body),
-      )
+      append_position(chunk, end);
     }
 
     Ok(bytes_positions)


### PR DESCRIPTION
Changes:
* Return an error when no chunks are found in BGZF indices.
* Return an error if no entries are found in CRAI.
* Sort BGZF indices, and search through GZI only once.