### PR TITLE
Tracing and buffered reads

### DIFF
--- a/htsget-config/Cargo.toml
+++ b/htsget-config/Cargo.toml
@@ -14,3 +14,4 @@ serde_regex = "1.1"
 regex = "1.6"
 envy = "0.4"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }

--- a/htsget-config/src/config.rs
+++ b/htsget-config/src/config.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 use tracing::info;
+use tracing::instrument;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{fmt, EnvFilter, Registry};
 
@@ -118,6 +119,7 @@ impl Default for Config {
 
 impl Config {
   /// Read the environment variables into a Config struct.
+  #[instrument]
   pub fn from_env() -> io::Result<Self> {
     let config = envy::prefixed(ENVIRONMENT_VARIABLE_PREFIX)
       .from_env()
@@ -127,7 +129,7 @@ impl Config {
           format!("config not properly set: {}", err),
         )
       });
-    info!(config = ?config, "Config created from environment variables.");
+    info!(config = ?config, "config created from environment variables");
     config
   }
 

--- a/htsget-config/src/regex_resolver.rs
+++ b/htsget-config/src/regex_resolver.rs
@@ -1,5 +1,6 @@
 use regex::{Error, Regex};
 use serde::Deserialize;
+use tracing::instrument;
 
 /// Represents an id resolver, which matches the id, replacing the match in the substitution text.
 pub trait HtsGetIdResolver {
@@ -33,6 +34,7 @@ impl RegexResolver {
 }
 
 impl HtsGetIdResolver for RegexResolver {
+  #[instrument(level = "trace", skip(self), ret)]
   fn resolve_id(&self, id: &str) -> Option<String> {
     if self.regex.is_match(id) {
       Some(

--- a/htsget-http-actix/Cargo.toml
+++ b/htsget-http-actix/Cargo.toml
@@ -20,9 +20,7 @@ futures = { version = "0.3" }
 tokio = { version = "1.20", features = ["macros", "rt-multi-thread"] }
 
 tracing-actix-web = "0.6"
-tracing-flame = "0.2.0"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 
 [dev-dependencies]
 htsget-test-utils = { path = "../htsget-test-utils", features = ["server-tests"], default-features = false }

--- a/htsget-http-actix/Cargo.toml
+++ b/htsget-http-actix/Cargo.toml
@@ -18,9 +18,11 @@ htsget-search = { path = "../htsget-search", default-features = false}
 htsget-config = { path = "../htsget-config", default-features = false }
 futures = { version = "0.3" }
 tokio = { version = "1.20", features = ["macros", "rt-multi-thread"] }
+
 tracing-actix-web = "0.6"
+tracing-flame = "0.2.0"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 
 [dev-dependencies]
 htsget-test-utils = { path = "../htsget-test-utils", features = ["server-tests"], default-features = false }

--- a/htsget-http-actix/src/handlers/get.rs
+++ b/htsget-http-actix/src/handlers/get.rs
@@ -5,6 +5,7 @@ use actix_web::{
   Responder,
 };
 use tracing::info;
+use tracing::instrument;
 
 use htsget_http_core::{get_response_for_get_request, Endpoint};
 use htsget_search::htsget::HtsGet;
@@ -14,6 +15,7 @@ use crate::AppState;
 use super::handle_response;
 
 /// GET request reads endpoint
+#[instrument(skip(app_state))]
 pub async fn reads<H: HtsGet + Send + Sync + 'static>(
   request: Query<HashMap<String, String>>,
   path: Path<String>,
@@ -21,7 +23,8 @@ pub async fn reads<H: HtsGet + Send + Sync + 'static>(
 ) -> impl Responder {
   let mut query_information = request.into_inner();
   query_information.insert("id".to_string(), path.into_inner());
-  info!(query = ?query_information, "Reads endpoint GET request");
+  info!(query = ?query_information, "reads endpoint GET request");
+
   handle_response(
     get_response_for_get_request(
       app_state.get_ref().htsget.clone(),
@@ -33,6 +36,7 @@ pub async fn reads<H: HtsGet + Send + Sync + 'static>(
 }
 
 /// GET request variants endpoint
+#[instrument(skip(app_state))]
 pub async fn variants<H: HtsGet + Send + Sync + 'static>(
   request: Query<HashMap<String, String>>,
   path: Path<String>,
@@ -40,7 +44,8 @@ pub async fn variants<H: HtsGet + Send + Sync + 'static>(
 ) -> impl Responder {
   let mut query_information = request.into_inner();
   query_information.insert("id".to_string(), path.into_inner());
-  info!(query = ?query_information, "Variants endpoint GET request");
+  info!(query = ?query_information, "variants endpoint GET request");
+
   handle_response(
     get_response_for_get_request(
       app_state.get_ref().htsget.clone(),

--- a/htsget-http-actix/src/handlers/post.rs
+++ b/htsget-http-actix/src/handlers/post.rs
@@ -3,6 +3,7 @@ use actix_web::{
   Responder,
 };
 use tracing::info;
+use tracing::instrument;
 
 use htsget_http_core::{get_response_for_post_request, Endpoint, PostRequest};
 use htsget_search::htsget::HtsGet;
@@ -12,12 +13,13 @@ use crate::AppState;
 use super::handle_response;
 
 /// POST request reads endpoint
+#[instrument(skip(app_state))]
 pub async fn reads<H: HtsGet + Send + Sync + 'static>(
   request: Json<PostRequest>,
   path: Path<String>,
   app_state: Data<AppState<H>>,
 ) -> impl Responder {
-  info!(request = ?request, "Reads endpoint POST request");
+  info!(request = ?request, "reads endpoint POST request");
   handle_response(
     get_response_for_post_request(
       app_state.get_ref().htsget.clone(),
@@ -30,12 +32,13 @@ pub async fn reads<H: HtsGet + Send + Sync + 'static>(
 }
 
 /// POST request variants endpoint
+#[instrument(skip(app_state))]
 pub async fn variants<H: HtsGet + Send + Sync + 'static>(
   request: Json<PostRequest>,
   path: Path<String>,
   app_state: Data<AppState<H>>,
 ) -> impl Responder {
-  info!(request = ?request, "Variants endpoint POST request");
+  info!(request = ?request, "variants endpoint POST request");
   handle_response(
     get_response_for_post_request(
       app_state.get_ref().htsget.clone(),

--- a/htsget-http-actix/src/handlers/service_info.rs
+++ b/htsget-http-actix/src/handlers/service_info.rs
@@ -1,6 +1,7 @@
 use actix_web::web::Data;
 use actix_web::Responder;
 use tracing::info;
+use tracing::instrument;
 
 use htsget_http_core::get_service_info_json as get_base_service_info_json;
 use htsget_http_core::Endpoint;
@@ -10,11 +11,12 @@ use crate::handlers::pretty_json::PrettyJson;
 use crate::AppState;
 
 /// Gets the JSON to return for a service-info endpoint
+#[instrument(skip(app_state))]
 pub fn get_service_info_json<H: HtsGet + Send + Sync + 'static>(
   app_state: &AppState<H>,
   endpoint: Endpoint,
 ) -> impl Responder {
-  info!(endpoint = ?endpoint, "Service info request");
+  info!(endpoint = ?endpoint, "service info request");
   PrettyJson(get_base_service_info_json(
     endpoint,
     app_state.htsget.clone(),

--- a/htsget-http-actix/src/lib.rs
+++ b/htsget-http-actix/src/lib.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use actix_web::dev::Server;
 use actix_web::{web, App, HttpServer};
 use tracing::info;
+use tracing::instrument;
 use tracing_actix_web::TracingLogger;
 
 use htsget_config::config::ServiceInfo;
@@ -51,6 +52,7 @@ pub fn configure_server<H: HtsGet + Send + Sync + 'static>(
 }
 
 /// Run the server using a http-actix `HttpServer`.
+#[instrument(skip_all)]
 pub fn run_server<H: HtsGet + Clone + Send + Sync + 'static>(
   htsget: H,
   config_service_info: ServiceInfo,
@@ -65,7 +67,7 @@ pub fn run_server<H: HtsGet + Clone + Send + Sync + 'static>(
   }))
   .bind(addr)?;
 
-  info!(addresses = ?server.addrs(), "Htsget query server addresses bound to");
+  info!(addresses = ?server.addrs(), "htsget query server addresses bound");
   Ok(server.run())
 }
 

--- a/htsget-http-actix/src/main.rs
+++ b/htsget-http-actix/src/main.rs
@@ -3,10 +3,6 @@ use std::env::args;
 use std::io::{Error, ErrorKind};
 
 use tokio::select;
-use tracing::Dispatch;
-use tracing_flame::FlameLayer;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::{fmt, EnvFilter, Registry};
 
 use htsget_config::config::{Config, StorageType, USAGE};
 use htsget_http_actix::run_server;
@@ -15,18 +11,7 @@ use htsget_search::storage::ticket_server::HttpTicketFormatter;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-  let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-  let fmt_layer = fmt::Layer::default();
-  let (flame_layer, _guard) = FlameLayer::with_file("tracing.folded").unwrap();
-
-  let subscriber = Registry::default()
-    .with(env_filter)
-    .with(fmt_layer)
-    .with(flame_layer);
-  let dispatcher = Dispatch::new(subscriber);
-
-  tracing::dispatcher::set_global_default(dispatcher)
-    .expect("Failed to install `tracing` dispatch.");
+  Config::setup_tracing()?;
 
   if args().len() > 1 {
     // Show help if command line options are provided

--- a/htsget-http-actix/src/main.rs
+++ b/htsget-http-actix/src/main.rs
@@ -3,6 +3,7 @@ use std::env::args;
 use std::io::{Error, ErrorKind};
 
 use tokio::select;
+use tracing::Dispatch;
 use tracing_flame::FlameLayer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{fmt, EnvFilter, Registry};
@@ -22,9 +23,10 @@ async fn main() -> std::io::Result<()> {
     .with(env_filter)
     .with(fmt_layer)
     .with(flame_layer);
+  let dispatcher = Dispatch::new(subscriber);
 
-  tracing::subscriber::set_global_default(subscriber)
-    .expect("Failed to install `tracing` subscriber.");
+  tracing::dispatcher::set_global_default(dispatcher)
+    .expect("Failed to install `tracing` dispatch.");
 
   if args().len() > 1 {
     // Show help if command line options are provided

--- a/htsget-http-core/src/post_request.rs
+++ b/htsget-http-core/src/post_request.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use htsget_search::htsget::Query;
+use tracing::instrument;
 
 use crate::{QueryBuilder, Result};
 
@@ -29,6 +30,7 @@ pub struct Region {
 
 impl PostRequest {
   /// Converts the `PostRequest` into one or more equivalent [Queries](Query)
+  #[instrument(level = "trace", skip_all, ret)]
   pub(crate) fn get_queries(self, id: impl Into<String>) -> Result<Vec<Query>> {
     if let Some(ref regions) = self.regions {
       let id = id.into();

--- a/htsget-http-core/src/query_builder.rs
+++ b/htsget-http-core/src/query_builder.rs
@@ -1,4 +1,5 @@
 use htsget_search::htsget::{Class, Fields, Format, Query, Tags};
+use tracing::instrument;
 
 use crate::error::{HtsGetError, Result};
 
@@ -37,6 +38,7 @@ impl QueryBuilder {
     self.query
   }
 
+  #[instrument(level = "trace", skip_all, ret)]
   pub fn with_class(mut self, class: Option<impl Into<String>>) -> Result<Self> {
     let class = class.map(Into::into);
     self.query = self.query.with_class(match class {
@@ -53,6 +55,7 @@ impl QueryBuilder {
     Ok(self)
   }
 
+  #[instrument(level = "trace", skip_all, ret)]
   pub fn with_reference_name(mut self, reference_name: Option<impl Into<String>>) -> Self {
     if let Some(reference_name) = reference_name {
       self.query = self.query.with_reference_name(reference_name);
@@ -60,6 +63,7 @@ impl QueryBuilder {
     self
   }
 
+  #[instrument(level = "trace", skip_all, ret)]
   pub fn with_range(
     self,
     start: Option<impl Into<String>>,
@@ -118,6 +122,7 @@ impl QueryBuilder {
     Ok(self)
   }
 
+  #[instrument(level = "trace", skip_all, ret)]
   pub fn with_fields(self, fields: Option<impl Into<String>>) -> Self {
     self.with_fields_from_vec(
       fields.map(|fields| fields.into().split(',').map(|s| s.to_string()).collect()),
@@ -134,6 +139,7 @@ impl QueryBuilder {
     self
   }
 
+  #[instrument(level = "trace", skip_all, ret)]
   pub fn with_tags(
     self,
     tags: Option<impl Into<String>>,

--- a/htsget-http-core/src/service_info.rs
+++ b/htsget-http-core/src/service_info.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use tracing::debug;
+use tracing::instrument;
 
 use htsget_config::config::ServiceInfo as ConfigServiceInfo;
 use htsget_search::htsget::{Format, HtsGet};
@@ -93,15 +94,13 @@ pub fn get_service_info_with(
   }
 }
 
+#[instrument(level = "debug", skip_all)]
 pub fn get_service_info_json(
   endpoint: Endpoint,
   searcher: Arc<impl HtsGet + Send + Sync + 'static>,
   config: &ConfigServiceInfo,
 ) -> ServiceInfo {
-  debug!(
-    ?endpoint,
-    "Getting service-info response for endpoint {:?}", endpoint
-  );
+  debug!(endpoint = ?endpoint,"getting service-info response for endpoint");
   fill_out_service_info_json(
     get_service_info_with(
       endpoint,

--- a/htsget-http-lambda/src/handlers/get.rs
+++ b/htsget-http-lambda/src/handlers/get.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use lambda_http::http;
 use tracing::info;
+use tracing::instrument;
 
 use htsget_http_core::{get_response_for_get_request, Endpoint};
 use htsget_search::htsget::HtsGet;
@@ -11,6 +12,7 @@ use crate::handlers::handle_response;
 use crate::{Body, Response};
 
 /// Get request reads endpoint
+#[instrument(skip(searcher))]
 pub async fn get<H: HtsGet + Send + Sync + 'static>(
   id_path: String,
   searcher: Arc<H>,

--- a/htsget-http-lambda/src/handlers/post.rs
+++ b/htsget-http-lambda/src/handlers/post.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use lambda_http::http;
 use tracing::info;
+use tracing::instrument;
 
 use htsget_http_core::{get_response_for_post_request, Endpoint, PostRequest};
 use htsget_search::htsget::HtsGet;
@@ -10,6 +11,7 @@ use crate::handlers::handle_response;
 use crate::{Body, Response};
 
 /// Post request reads endpoint
+#[instrument(skip(searcher))]
 pub async fn post<H: HtsGet + Send + Sync + 'static>(
   id_path: String,
   searcher: Arc<H>,

--- a/htsget-http-lambda/src/handlers/service_info.rs
+++ b/htsget-http-lambda/src/handlers/service_info.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use lambda_http::http;
 use tracing::info;
+use tracing::instrument;
 
 use htsget_config::config::ServiceInfo;
 use htsget_http_core::get_service_info_json as get_base_service_info_json;
@@ -12,11 +13,12 @@ use crate::handlers::FormatJson;
 use crate::{Body, Response};
 
 /// Service info endpoint.
+#[instrument(skip(searcher))]
 pub fn get_service_info_json<H: HtsGet + Send + Sync + 'static>(
   searcher: Arc<H>,
   endpoint: Endpoint,
   config: &ServiceInfo,
 ) -> http::Result<Response<Body>> {
-  info!(endpoint = ?endpoint, "Service info request");
+  info!(endpoint = ?endpoint, "service info request");
   FormatJson(get_base_service_info_json(endpoint, searcher, config)).try_into()
 }

--- a/htsget-http-lambda/src/lib.rs
+++ b/htsget-http-lambda/src/lib.rs
@@ -8,6 +8,7 @@ use lambda_http::ext::RequestExt;
 use lambda_http::http::{Method, StatusCode, Uri};
 use lambda_http::{http, Body, Request, Response};
 use tracing::debug;
+use tracing::instrument;
 
 use htsget_config::config::ServiceInfo;
 use htsget_http_core::{Endpoint, PostRequest};
@@ -141,6 +142,7 @@ impl<'a, H: HtsGet + Send + Sync + 'static> Router<'a, H> {
   }
 
   /// Extracts post request query parameters.
+  #[instrument(level = "debug", ret)]
   fn extract_query_from_payload(request: &Request) -> Option<PostRequest> {
     if request.body().is_empty() {
       Some(PostRequest::default())
@@ -153,6 +155,7 @@ impl<'a, H: HtsGet + Send + Sync + 'static> Router<'a, H> {
   }
 
   /// Extract get request query parameters.
+  #[instrument(level = "debug", ret)]
   fn extract_query(request: &Request) -> HashMap<String, String> {
     let mut query = HashMap::new();
     // Silently ignores all but the last query key, for keys that are present more than once.

--- a/htsget-http-lambda/src/main.rs
+++ b/htsget-http-lambda/src/main.rs
@@ -11,7 +11,7 @@ use htsget_search::storage::ticket_server::HttpTicketFormatter;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-  tracing_subscriber::fmt::init();
+  Config::setup_tracing()?;
   let config = Config::from_env()?;
 
   match config.storage_type {

--- a/htsget-http-lambda/src/main.rs
+++ b/htsget-http-lambda/src/main.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use lambda_http::{service_fn, Error, Request};
 use tracing::info;
+use tracing::instrument;
 
 use htsget_config::config::{Config, StorageType};
 use htsget_http_lambda::Router;
@@ -22,6 +23,7 @@ async fn main() -> Result<(), Error> {
   }
 }
 
+#[instrument(skip_all)]
 async fn local_storage_server(config: Config) -> Result<(), Error> {
   let formatter = HttpTicketFormatter::try_from(
     config.ticket_server_addr,
@@ -34,7 +36,7 @@ async fn local_storage_server(config: Config) -> Result<(), Error> {
   let router = &Router::new(searcher, &config.service_info);
 
   let handler = |event: Request| async move {
-    info!(event = ?event, "Received request");
+    info!(event = ?event, "received request");
     router.route_request(event).await
   };
   lambda_http::run(service_fn(handler)).await?;
@@ -43,12 +45,13 @@ async fn local_storage_server(config: Config) -> Result<(), Error> {
 }
 
 #[cfg(feature = "s3-storage")]
+#[instrument(skip_all)]
 async fn s3_storage_server(config: Config) -> Result<(), Error> {
   let searcher = Arc::new(HtsGetFromStorage::s3_from(config.s3_bucket, config.resolver).await);
   let router = &Router::new(searcher, &config.service_info);
 
   let handler = |event: Request| async move {
-    info!(event = ?event, "Received request");
+    info!(event = ?event, "received request");
     router.route_request(event).await
   };
   lambda_http::run(service_fn(handler)).await?;

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -31,7 +31,7 @@ pub(crate) struct BamSearch<S> {
 }
 
 impl BinningIndexExt for Index {
-  #[instrument(level = "trace", skip_all)]
+  #[instrument(level = "trace", skip_all, ret)]
   fn get_all_chunks(&self) -> Vec<&Chunk> {
     self
       .reference_sequences()
@@ -56,7 +56,7 @@ where
     ref_seq.len().get()
   }
 
-  #[instrument(level = "trace", skip_all)]
+  #[instrument(level = "trace", skip_all, ret, err)]
   async fn get_byte_ranges_for_unmapped(
     &self,
     id: &str,

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -14,7 +14,7 @@ use noodles::{bgzf, sam};
 use noodles_bam as bam;
 use tokio::io;
 use tokio::io::AsyncRead;
-use tracing::instrument;
+use tracing::{instrument, trace};
 
 use crate::htsget::search::{BgzfSearch, BinningIndexExt, Search, SearchAll, SearchReads};
 use crate::htsget::Class::Body;
@@ -31,8 +31,9 @@ pub(crate) struct BamSearch<S> {
 }
 
 impl BinningIndexExt for Index {
-  #[instrument(level = "trace", skip_all, ret)]
+  #[instrument(level = "trace", skip_all)]
   fn get_all_chunks(&self) -> Vec<&Chunk> {
+    trace!("getting vec of chunks");
     self
       .reference_sequences()
       .iter()

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -57,13 +57,14 @@ where
     ref_seq.len().get()
   }
 
-  #[instrument(level = "trace", skip_all, ret, err)]
+  #[instrument(level = "trace", skip(self, index))]
   async fn get_byte_ranges_for_unmapped(
     &self,
     id: &str,
     format: &Format,
     index: &Index,
   ) -> Result<Vec<BytesPosition>> {
+    trace!("getting byte ranges for unmapped reads");
     let last_interval = index.first_record_in_last_linear_bin_start_position();
     let start = match last_interval {
       Some(start) => start,
@@ -107,6 +108,7 @@ where
     reader.read_index().await
   }
 
+  #[instrument(level = "trace", skip(self, index, header, query))]
   async fn get_byte_ranges_for_reference_name(
     &self,
     reference_name: String,
@@ -114,6 +116,7 @@ where
     header: &Header,
     query: Query,
   ) -> Result<Vec<BytesPosition>> {
+    trace!("getting byte ranges for reference name");
     self
       .get_byte_ranges_for_reference_name_reads(&reference_name, index, header, query)
       .await

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -13,7 +13,7 @@ use noodles::sam::Header;
 use noodles::{bgzf, sam};
 use noodles_bam as bam;
 use tokio::io;
-use tokio::io::AsyncRead;
+use tokio::io::{AsyncRead, BufReader};
 use tracing::{instrument, trace};
 
 use crate::htsget::search::{BgzfSearch, BinningIndexExt, Search, SearchAll, SearchReads};
@@ -102,7 +102,7 @@ where
   }
 
   async fn read_index_inner<T: AsyncRead + Unpin + Send>(inner: T) -> io::Result<Index> {
-    let mut reader = bai::AsyncReader::new(inner);
+    let mut reader = bai::AsyncReader::new(BufReader::new(inner));
     reader.read_header().await?;
     reader.read_index().await
   }

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -14,6 +14,7 @@ use noodles::{bgzf, sam};
 use noodles_bam as bam;
 use tokio::io;
 use tokio::io::AsyncRead;
+use tracing::instrument;
 
 use crate::htsget::search::{BgzfSearch, BinningIndexExt, Search, SearchAll, SearchReads};
 use crate::htsget::Class::Body;
@@ -30,6 +31,7 @@ pub(crate) struct BamSearch<S> {
 }
 
 impl BinningIndexExt for Index {
+  #[instrument(level = "trace", skip_all)]
   fn get_all_chunks(&self) -> Vec<&Chunk> {
     self
       .reference_sequences()
@@ -54,6 +56,7 @@ where
     ref_seq.len().get()
   }
 
+  #[instrument(level = "trace", skip_all)]
   async fn get_byte_ranges_for_unmapped(
     &self,
     id: &str,

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -14,7 +14,7 @@ use noodles::{bgzf, csi};
 use noodles_bcf as bcf;
 use tokio::io;
 use tokio::io::AsyncRead;
-use tracing::instrument;
+use tracing::{instrument, trace};
 
 use crate::htsget::search::{find_first, BgzfSearch, BinningIndexExt, Search};
 use crate::htsget::HtsGetError;
@@ -30,8 +30,9 @@ pub(crate) struct BcfSearch<S> {
 }
 
 impl BinningIndexExt for Index {
-  #[instrument(level = "trace", skip_all, ret)]
+  #[instrument(level = "trace", skip_all)]
   fn get_all_chunks(&self) -> Vec<&Chunk> {
+    trace!("getting vec of chunks");
     self
       .reference_sequences()
       .iter()

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -77,7 +77,7 @@ where
     csi::AsyncReader::new(inner).read_index().await
   }
 
-  #[instrument(level = "trace", skip_all, ret, err)]
+  #[instrument(level = "trace", skip(self, index, header, query))]
   async fn get_byte_ranges_for_reference_name(
     &self,
     reference_name: String,
@@ -85,6 +85,7 @@ where
     header: &Header,
     mut query: Query,
   ) -> Result<Vec<BytesPosition>> {
+    trace!("getting byte ranges for reference name");
     // We are assuming the order of the contigs in the header and the references sequences
     // in the index is the same
     let mut futures = FuturesOrdered::new();

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -14,6 +14,7 @@ use noodles::{bgzf, csi};
 use noodles_bcf as bcf;
 use tokio::io;
 use tokio::io::AsyncRead;
+use tracing::instrument;
 
 use crate::htsget::search::{find_first, BgzfSearch, BinningIndexExt, Search};
 use crate::htsget::HtsGetError;
@@ -29,6 +30,7 @@ pub(crate) struct BcfSearch<S> {
 }
 
 impl BinningIndexExt for Index {
+  #[instrument(level = "trace", skip_all)]
   fn get_all_chunks(&self) -> Vec<&Chunk> {
     self
       .reference_sequences()
@@ -74,6 +76,7 @@ where
     csi::AsyncReader::new(inner).read_index().await
   }
 
+  #[instrument(level = "trace", skip_all)]
   async fn get_byte_ranges_for_reference_name(
     &self,
     reference_name: String,

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -30,7 +30,7 @@ pub(crate) struct BcfSearch<S> {
 }
 
 impl BinningIndexExt for Index {
-  #[instrument(level = "trace", skip_all)]
+  #[instrument(level = "trace", skip_all, ret)]
   fn get_all_chunks(&self) -> Vec<&Chunk> {
     self
       .reference_sequences()
@@ -76,7 +76,7 @@ where
     csi::AsyncReader::new(inner).read_index().await
   }
 
-  #[instrument(level = "trace", skip_all)]
+  #[instrument(level = "trace", skip_all, ret, err)]
   async fn get_byte_ranges_for_reference_name(
     &self,
     reference_name: String,

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -41,7 +41,7 @@ where
   S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
   ReaderType: AsyncRead + Unpin + Send + Sync,
 {
-  #[instrument(level = "trace", skip_all)]
+  #[instrument(level = "trace", skip_all, ret, err)]
   async fn get_byte_ranges_for_all(
     &self,
     id: String,
@@ -52,7 +52,7 @@ where
     ])
   }
 
-  #[instrument(level = "trace", skip_all)]
+  #[instrument(level = "trace", skip_all, ret, err)]
   async fn get_header_end_offset(&self, index: &Index) -> Result<u64> {
     // Does the first index entry always contain the first data container?
     index
@@ -95,7 +95,7 @@ where
     header.reference_sequences().get_full(name)
   }
 
-  #[instrument(level = "trace", skip_all)]
+  #[instrument(level = "trace", skip_all, ret, err)]
   async fn get_byte_ranges_for_unmapped_reads(
     &self,
     query: &Query,
@@ -113,7 +113,7 @@ where
     .await
   }
 
-  #[instrument(level = "trace", skip_all)]
+  #[instrument(level = "trace", skip_all, ret, err)]
   async fn get_byte_ranges_for_reference_sequence(
     &self,
     ref_seq: &sam::header::ReferenceSequence,
@@ -187,7 +187,7 @@ where
   }
 
   /// Get bytes ranges using the index.
-  #[instrument(level = "trace", skip_all)]
+  #[instrument(level = "trace", skip_all, ret, err)]
   async fn bytes_ranges_from_index<F>(
     &self,
     id: &str,
@@ -257,7 +257,7 @@ where
   }
 
   /// Gets bytes ranges for a specific index entry.
-  #[instrument(level = "trace", skip_all)]
+  #[instrument(level = "trace", skip_all, ret, err)]
   pub(crate) fn bytes_ranges_for_record(
     ref_seq: Option<&sam::header::ReferenceSequence>,
     seq_range: Interval,

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -10,10 +10,9 @@ use futures_util::stream::FuturesOrdered;
 use noodles::core::Position;
 use noodles::cram::crai;
 use noodles::cram::crai::{Index, Record};
-use noodles::sam;
 use noodles::sam::Header;
-use noodles_cram::AsyncReader;
-use tokio::io::AsyncRead;
+use noodles::{cram, sam};
+use tokio::io::{AsyncRead, BufReader};
 use tokio::{io, select};
 use tracing::instrument;
 
@@ -28,6 +27,8 @@ static CRAM_EOF: &[u8] = &[
   0x00, 0x01, 0x00, 0x05, 0xbd, 0xd9, 0x4f, 0x00, 0x01, 0x00, 0x06, 0x06, 0x01, 0x00, 0x01, 0x00,
   0x01, 0x00, 0xee, 0x63, 0x01, 0x4b,
 ];
+
+type AsyncReader<ReaderType> = cram::AsyncReader<BufReader<ReaderType>>;
 
 pub(crate) struct CramSearch<S> {
   storage: Arc<S>,
@@ -143,7 +144,7 @@ where
   ReaderType: AsyncRead + Unpin + Send + Sync,
 {
   fn init_reader(inner: ReaderType) -> AsyncReader<ReaderType> {
-    AsyncReader::new(inner)
+    AsyncReader::new(BufReader::new(inner))
   }
 
   async fn read_raw_header(reader: &mut AsyncReader<ReaderType>) -> io::Result<String> {

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -3,6 +3,7 @@
 
 use std::marker::PhantomData;
 use std::sync::Arc;
+use tracing::instrument;
 
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -50,6 +51,7 @@ where
     ])
   }
 
+  #[instrument(level = "trace", skip_all)]
   async fn get_header_end_offset(&self, index: &Index) -> Result<u64> {
     // Does the first index entry always contain the first data container?
     index
@@ -92,6 +94,7 @@ where
     header.reference_sequences().get_full(name)
   }
 
+  #[instrument(level = "trace", skip_all)]
   async fn get_byte_ranges_for_unmapped_reads(
     &self,
     query: &Query,
@@ -109,6 +112,7 @@ where
     .await
   }
 
+  #[instrument(level = "trace", skip_all)]
   async fn get_byte_ranges_for_reference_sequence(
     &self,
     ref_seq: &sam::header::ReferenceSequence,
@@ -182,6 +186,7 @@ where
   }
 
   /// Get bytes ranges using the index.
+  #[instrument(level = "trace", skip_all)]
   async fn bytes_ranges_from_index<F>(
     &self,
     id: &str,
@@ -251,6 +256,7 @@ where
   }
 
   /// Gets bytes ranges for a specific index entry.
+  #[instrument(level = "trace", skip_all)]
   pub(crate) fn bytes_ranges_for_record(
     ref_seq: Option<&sam::header::ReferenceSequence>,
     seq_range: Interval,

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -41,6 +41,7 @@ where
   S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
   ReaderType: AsyncRead + Unpin + Send + Sync,
 {
+  #[instrument(level = "trace", skip_all)]
   async fn get_byte_ranges_for_all(
     &self,
     id: String,

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -3,7 +3,6 @@
 
 use std::marker::PhantomData;
 use std::sync::Arc;
-use tracing::instrument;
 
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -16,6 +15,7 @@ use noodles::sam::Header;
 use noodles_cram::AsyncReader;
 use tokio::io::AsyncRead;
 use tokio::{io, select};
+use tracing::instrument;
 
 use crate::htsget::search::{Search, SearchAll, SearchReads};
 use crate::htsget::Class::Body;

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -38,7 +38,7 @@ where
   R: AsyncRead + Send + Sync + Unpin,
   S: Storage<Streamable = R> + Sync + Send + 'static,
 {
-  #[instrument(level = "debug", skip(self), ret, err)]
+  #[instrument(level = "debug", skip(self))]
   async fn search(&self, query: Query) -> Result<Response> {
     debug!(?query.format, ?query, "searching {:?}, with query {:?}", query.format, query);
     let response = match query.format {

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tokio::io::AsyncRead;
 use tracing::debug;
+use tracing::instrument;
 
 use htsget_config::regex_resolver::RegexResolver;
 
@@ -37,15 +38,15 @@ where
   R: AsyncRead + Send + Sync + Unpin,
   S: Storage<Streamable = R> + Sync + Send + 'static,
 {
+  #[instrument(level = "debug", skip(self), ret, err)]
   async fn search(&self, query: Query) -> Result<Response> {
-    debug!(?query.format, ?query, "Searching {:?}, with query {:?}.", query.format, query);
+    debug!(?query.format, ?query, "searching {:?}, with query {:?}", query.format, query);
     let response = match query.format {
       Format::Bam => BamSearch::new(self.storage()).search(query).await,
       Format::Cram => CramSearch::new(self.storage()).search(query).await,
       Format::Vcf => VcfSearch::new(self.storage()).search(query).await,
       Format::Bcf => BcfSearch::new(self.storage()).search(query).await,
     };
-    debug!(?response, "Response obtained {:?}", response);
     response
   }
 

--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -209,7 +209,7 @@ pub struct Interval {
 impl Interval {
   const MIN_SEQ_POSITION: usize = 1;
 
-  #[instrument(level = "trace", skip_all, ret, err)]
+  #[instrument(level = "trace", skip_all, ret)]
   fn into_one_based<F>(self, max_seq_position: F) -> Result<impl Into<NoodlesInterval>>
   where
     F: FnOnce() -> usize,

--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -15,6 +15,7 @@ use noodles::core::Position;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::task::JoinError;
+use tracing::instrument;
 
 use crate::storage::StorageError;
 
@@ -208,6 +209,7 @@ pub struct Interval {
 impl Interval {
   const MIN_SEQ_POSITION: usize = 1;
 
+  #[instrument(level = "trace", skip_all, ret, err)]
   fn into_one_based<F>(self, max_seq_position: F) -> Result<impl Into<NoodlesInterval>>
   where
     F: FnOnce() -> usize,

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -417,7 +417,7 @@ where
     index: &Index,
   ) -> Result<Vec<BytesPosition>> {
     let chunks: Result<Vec<Chunk>> = trace_span!("querying chunks").in_scope(|| {
-      trace!("querying chunks");
+      trace!(query = ?query.id.as_str(), ref_seq_id = ?ref_seq_id, "querying chunks");
       let mut chunks = index
         .query(
           ref_seq_id,
@@ -433,7 +433,7 @@ where
         ));
       }
 
-      trace!("sorting chunks");
+      trace!(query = ?query.id.as_str(), ref_seq_id = ?ref_seq_id, "sorting chunks");
       chunks.sort_unstable_by_key(|a| a.end().compressed());
 
       Ok(chunks)
@@ -446,8 +446,8 @@ where
     let byte_ranges: Vec<BytesPosition> = match gzi_data {
       Ok(gzi_data) => {
         let span = trace_span!("reading gzi");
-        let gzi: Result<Vec<u64>> = async move {
-          trace!("reading gzi");
+        let gzi: Result<Vec<u64>> = async {
+          trace!(query = ?query.id.as_str(), "reading gzi");
           let mut gzi: Vec<u64> = gzi::AsyncReader::new(BufReader::new(gzi_data))
             .read_index()
             .await?
@@ -455,7 +455,7 @@ where
             .map(|(compressed, _)| compressed)
             .collect();
 
-          trace!("sorting gzi");
+          trace!(query = ?query.id.as_str(), "sorting gzi");
           gzi.sort_unstable();
           Ok(gzi)
         }

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -9,7 +9,6 @@ use std::collections::HashSet;
 use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -22,7 +21,6 @@ use tokio::io;
 use tokio::io::AsyncRead;
 use tokio::select;
 use tokio::task::JoinHandle;
-use tokio::time::sleep;
 use tracing::{instrument, trace_span, Instrument};
 
 use crate::htsget::Class::Body;
@@ -444,7 +442,6 @@ where
       Ok(gzi_data) => {
         let span = trace_span!("reading gzi");
         let gzi: Result<Vec<u64>> = async move {
-          sleep(Duration::from_secs(2)).await;
           let mut gzi: Vec<u64> = gzi::AsyncReader::new(gzi_data)
             .read_index()
             .await?

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -454,6 +454,7 @@ where
             .into_iter()
             .map(|(compressed, _)| compressed)
             .collect();
+
           trace!("sorting gzi");
           gzi.sort_unstable();
           Ok(gzi)
@@ -560,6 +561,7 @@ where
   Index: BinningIndex + BinningIndexExt + Send + Sync,
   T: BgzfSearch<S, ReaderType, ReferenceSequence, Index, Reader, Header> + Send + Sync,
 {
+  #[instrument(level = "debug", skip(self), ret, err)]
   async fn get_byte_ranges_for_all(
     &self,
     id: String,

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -80,6 +80,7 @@ where
   async fn get_header_end_offset(&self, index: &Index) -> Result<u64>;
 
   /// Returns the header bytes range.
+  #[instrument(level = "trace", skip_all)]
   async fn get_byte_ranges_for_header(&self, index: &Index) -> Result<BytesPosition> {
     Ok(
       BytesPosition::default()
@@ -213,6 +214,7 @@ where
   fn get_format(&self) -> Format;
 
   /// Get the position at the end of file marker.
+  #[instrument(level = "trace", skip(self))]
   async fn position_at_eof(&self, id: &str, format: &Format) -> Result<u64> {
     let file_size = self.get_storage().head(format.fmt_file(id)).await?;
     Ok(
@@ -223,6 +225,7 @@ where
   }
 
   /// Read the index from the key.
+  #[instrument(level = "trace", skip(self))]
   async fn read_index(&self, id: &str) -> Result<Index> {
     let storage = self
       .get_storage()
@@ -234,6 +237,7 @@ where
   }
 
   /// Search based on the query.
+  #[instrument(level = "trace", skip(self))]
   async fn search(&self, query: Query) -> Result<Response> {
     match query.class {
       Body => {
@@ -288,6 +292,7 @@ where
   }
 
   /// Build the response from the query using urls.
+  #[instrument(level = "trace", skip(self, byte_ranges))]
   async fn build_response(
     &self,
     id: String,
@@ -322,6 +327,7 @@ where
   }
 
   /// Get the header from the file specified by the id and format.
+  #[instrument(level = "trace", skip(self, index))]
   async fn get_header(&self, id: &str, format: &Format, index: &Index) -> Result<Header> {
     let get_options =
       GetOptions::default().with_range(self.get_byte_ranges_for_header(index).await?);
@@ -560,6 +566,7 @@ where
     ])
   }
 
+  #[instrument(level = "trace", skip_all)]
   async fn get_header_end_offset(&self, index: &Index) -> Result<u64> {
     Self::index_positions(index)
       .into_iter()

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -18,7 +18,7 @@ use noodles::csi::index::reference_sequence::bin::Chunk;
 use noodles::csi::{BinningIndex, BinningIndexReferenceSequence};
 use noodles::sam;
 use tokio::io;
-use tokio::io::AsyncRead;
+use tokio::io::{AsyncRead, BufReader};
 use tokio::select;
 use tokio::task::JoinHandle;
 use tracing::{instrument, trace, trace_span, Instrument};
@@ -448,7 +448,7 @@ where
         let span = trace_span!("reading gzi");
         let gzi: Result<Vec<u64>> = async move {
           trace!("reading gzi");
-          let mut gzi: Vec<u64> = gzi::AsyncReader::new(gzi_data)
+          let mut gzi: Vec<u64> = gzi::AsyncReader::new(BufReader::new(gzi_data))
             .read_index()
             .await?
             .into_iter()

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -18,6 +18,7 @@ use noodles_vcf as vcf;
 use noodles_vcf::header::record::value::map::contig::Name;
 use tokio::io;
 use tokio::io::AsyncRead;
+use tracing::instrument;
 
 use crate::htsget::search::{find_first, BgzfSearch, BinningIndexExt, Search};
 use crate::htsget::HtsGetError;
@@ -33,6 +34,7 @@ pub(crate) struct VcfSearch<S> {
 }
 
 impl BinningIndexExt for Index {
+  #[instrument(level = "trace", skip_all)]
   fn get_all_chunks(&self) -> Vec<&Chunk> {
     self
       .reference_sequences()
@@ -77,6 +79,7 @@ where
     tabix::AsyncReader::new(inner).read_index().await
   }
 
+  #[instrument(level = "trace", skip_all)]
   async fn get_byte_ranges_for_reference_name(
     &self,
     reference_name: String,

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -34,7 +34,7 @@ pub(crate) struct VcfSearch<S> {
 }
 
 impl BinningIndexExt for Index {
-  #[instrument(level = "trace", skip_all)]
+  #[instrument(level = "trace", skip_all, ret)]
   fn get_all_chunks(&self) -> Vec<&Chunk> {
     self
       .reference_sequences()
@@ -79,7 +79,7 @@ where
     tabix::AsyncReader::new(inner).read_index().await
   }
 
-  #[instrument(level = "trace", skip_all)]
+  #[instrument(level = "trace", skip_all, ret, err)]
   async fn get_byte_ranges_for_reference_name(
     &self,
     reference_name: String,

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -18,7 +18,7 @@ use noodles_vcf as vcf;
 use noodles_vcf::header::record::value::map::contig::Name;
 use tokio::io;
 use tokio::io::AsyncRead;
-use tracing::instrument;
+use tracing::{instrument, trace};
 
 use crate::htsget::search::{find_first, BgzfSearch, BinningIndexExt, Search};
 use crate::htsget::HtsGetError;
@@ -34,8 +34,9 @@ pub(crate) struct VcfSearch<S> {
 }
 
 impl BinningIndexExt for Index {
-  #[instrument(level = "trace", skip_all, ret)]
+  #[instrument(level = "trace", skip_all)]
   fn get_all_chunks(&self) -> Vec<&Chunk> {
+    trace!("getting vec of chunks");
     self
       .reference_sequences()
       .iter()

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -80,7 +80,7 @@ where
     tabix::AsyncReader::new(inner).read_index().await
   }
 
-  #[instrument(level = "trace", skip_all, ret, err)]
+  #[instrument(level = "trace", skip(self, index, header, query))]
   async fn get_byte_ranges_for_reference_name(
     &self,
     reference_name: String,
@@ -88,6 +88,7 @@ where
     header: &Header,
     mut query: Query,
   ) -> Result<Vec<BytesPosition>> {
+    trace!("getting byte ranges for reference name");
     let maybe_len = header
       .contigs()
       .get(&Name::from_str(&reference_name).map_err(|err| {

--- a/htsget-search/src/storage/aws.rs
+++ b/htsget-search/src/storage/aws.rs
@@ -105,6 +105,7 @@ impl AwsS3Storage {
   }
 
   /// Returns the retrieval type of the object stored with the key.
+  #[instrument(level = "trace", skip_all, ret)]
   pub async fn get_retrieval_type<K: AsRef<str> + Send>(&self, key: &K) -> Result<Retrieval> {
     let head = self.s3_head(&self.resolve_key(key)?).await?;
     Ok(
@@ -194,7 +195,8 @@ impl Storage for AwsS3Storage {
     options: GetOptions,
   ) -> Result<Self::Streamable> {
     let key = key.as_ref();
-    debug!(calling_from = ?self, key, "Getting file with key {:?}", key);
+    debug!(calling_from = ?self, key, "getting file with key {:?}", key);
+
     self.create_stream_reader(key, options).await
   }
 
@@ -208,7 +210,8 @@ impl Storage for AwsS3Storage {
     let key = key.as_ref();
     let presigned_url = self.s3_presign_url(key, options.range.clone()).await?;
     let url = options.apply(Url::new(presigned_url));
-    debug!(calling_from = ?self, key, ?url, "Getting url with key {:?}", key);
+
+    debug!(calling_from = ?self, key, ?url, "getting url with key {:?}", key);
     Ok(url)
   }
 
@@ -218,7 +221,8 @@ impl Storage for AwsS3Storage {
     let key = key.as_ref();
     let head = self.s3_head(key).await?;
     let len = head.content_length as u64;
-    debug!(calling_from = ?self, key, len, "Size of key {:?} is {}", key, len);
+
+    debug!(calling_from = ?self, key, len, "size of key {:?} is {}", key, len);
     Ok(len)
   }
 }

--- a/htsget-search/src/storage/aws.rs
+++ b/htsget-search/src/storage/aws.rs
@@ -1,7 +1,6 @@
 //! Module providing an implementation for the [Storage] trait using Amazon's S3 object storage service.
 use std::fmt::Debug;
 use std::time::Duration;
-use tracing::instrument;
 
 use async_trait::async_trait;
 use aws_sdk_s3::client::fluent_builders;
@@ -14,6 +13,7 @@ use bytes::Bytes;
 use fluent_builders::GetObject;
 use tokio_util::io::StreamReader;
 use tracing::debug;
+use tracing::instrument;
 
 use htsget_config::regex_resolver::{HtsGetIdResolver, RegexResolver};
 

--- a/htsget-search/src/storage/local.rs
+++ b/htsget-search/src/storage/local.rs
@@ -89,14 +89,14 @@ impl<T: UrlFormatter + Send + Sync + Debug> Storage for LocalStorage<T> {
   type Streamable = File;
 
   /// Get the file at the location of the key.
-  #[instrument(level = "trace", skip(self))]
+  #[instrument(level = "debug", skip(self))]
   async fn get<K: AsRef<str> + Send + Debug>(&self, key: K, _options: GetOptions) -> Result<File> {
-    debug!(calling_from = ?self, key = key.as_ref(), "Getting file with key {:?}", key.as_ref());
+    debug!(calling_from = ?self, key = key.as_ref(), "getting file with key {:?}", key.as_ref());
     self.get(key).await
   }
 
   /// Get a url for the file at key.
-  #[instrument(level = "trace", skip(self))]
+  #[instrument(level = "debug", skip(self))]
   async fn range_url<K: AsRef<str> + Send + Debug>(
     &self,
     key: K,
@@ -107,21 +107,24 @@ impl<T: UrlFormatter + Send + Sync + Debug> Storage for LocalStorage<T> {
       .strip_prefix(&self.base_path)
       .map_err(|err| StorageError::InternalError(err.to_string()))?
       .to_string_lossy();
+
     let url = Url::new(self.url_formatter.format_url(&path)?);
     let url = options.apply(url);
-    debug!(calling_from = ?self, key = key.as_ref(), ?url, "Getting url with key {:?}", key.as_ref());
+
+    debug!(calling_from = ?self, key = key.as_ref(), ?url, "getting url with key {:?}", key.as_ref());
     Ok(url)
   }
 
   /// Get the size of the file.
-  #[instrument(level = "trace", skip(self))]
+  #[instrument(level = "debug", skip(self))]
   async fn head<K: AsRef<str> + Send + Debug>(&self, key: K) -> Result<u64> {
     let path = self.get_path_from_key(&key)?;
     let len = tokio::fs::metadata(path)
       .await
       .map_err(|err| StorageError::KeyNotFound(err.to_string()))?
       .len();
-    debug!(calling_from = ?self, key = key.as_ref(), len, "Size of key {:?} is {}", key.as_ref(), len);
+
+    debug!(calling_from = ?self, key = key.as_ref(), len, "size of key {:?} is {}", key.as_ref(), len);
     Ok(len)
   }
 }

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -45,7 +45,7 @@ pub trait Storage {
   async fn head<K: AsRef<str> + Send + Debug>(&self, key: K) -> Result<u64>;
 
   /// Get the url of the object using an inline data uri.
-  #[instrument(level = "trace")]
+  #[instrument(level = "trace", ret)]
   fn data_url(data: Vec<u8>, class: Option<Class>) -> Url {
     Url::new(format!("data:;base64,{}", encode(data))).set_class(class)
   }
@@ -106,6 +106,7 @@ pub enum DataBlock {
 
 impl DataBlock {
   /// Convert a vec of bytes positions to a vec of data blocks. Merges bytes positions.
+  #[instrument(level = "trace", ret)]
   pub fn from_bytes_positions(positions: Vec<BytesPosition>) -> Vec<Self> {
     BytesPosition::merge_all(positions)
       .into_iter()
@@ -115,6 +116,7 @@ impl DataBlock {
 
   /// Update the classes of all blocks so that they all contain a class, or None. Does not merge
   /// byte positions.
+  #[instrument(level = "trace", ret)]
   pub fn update_classes(blocks: Vec<Self>) -> Vec<Self> {
     if blocks.iter().all(|block| match block {
       DataBlock::Range(range) => range.class.is_some(),
@@ -255,6 +257,7 @@ impl BytesPosition {
   }
 
   /// Merge ranges, assuming ending byte ranges are exclusive.
+  #[instrument(level = "trace", ret)]
   pub fn merge_all(mut ranges: Vec<BytesPosition>) -> Vec<BytesPosition> {
     if ranges.len() < 2 {
       ranges

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -106,7 +106,6 @@ pub enum DataBlock {
 
 impl DataBlock {
   /// Convert a vec of bytes positions to a vec of data blocks. Merges bytes positions.
-  #[instrument(level = "trace", ret)]
   pub fn from_bytes_positions(positions: Vec<BytesPosition>) -> Vec<Self> {
     BytesPosition::merge_all(positions)
       .into_iter()
@@ -116,7 +115,6 @@ impl DataBlock {
 
   /// Update the classes of all blocks so that they all contain a class, or None. Does not merge
   /// byte positions.
-  #[instrument(level = "trace", ret)]
   pub fn update_classes(blocks: Vec<Self>) -> Vec<Self> {
     if blocks.iter().all(|block| match block {
       DataBlock::Range(range) => range.class.is_some(),

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -5,12 +5,12 @@ use std::fmt::{Debug, Display, Formatter};
 use std::io;
 use std::io::ErrorKind;
 use std::net::AddrParseError;
-use tracing::instrument;
 
 use async_trait::async_trait;
 use base64::encode;
 use thiserror::Error;
 use tokio::io::AsyncRead;
+use tracing::instrument;
 
 use crate::htsget::{Class, Headers, Url};
 

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -1,10 +1,11 @@
 //! Module providing the abstractions needed to read files from an storage
 //!
 use std::cmp::Ordering;
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::io;
 use std::io::ErrorKind;
 use std::net::AddrParseError;
+use tracing::instrument;
 
 use async_trait::async_trait;
 use base64::encode;
@@ -27,19 +28,24 @@ pub trait Storage {
   type Streamable: AsyncRead + Unpin + Send;
 
   /// Get the object using the key.
-  async fn get<K: AsRef<str> + Send>(
+  async fn get<K: AsRef<str> + Send + Debug>(
     &self,
     key: K,
     options: GetOptions,
   ) -> Result<Self::Streamable>;
 
   /// Get the url of the object represented by the key using a bytes range.
-  async fn range_url<K: AsRef<str> + Send>(&self, key: K, options: RangeUrlOptions) -> Result<Url>;
+  async fn range_url<K: AsRef<str> + Send + Debug>(
+    &self,
+    key: K,
+    options: RangeUrlOptions,
+  ) -> Result<Url>;
 
   /// Get the size of the object represented by the key.
-  async fn head<K: AsRef<str> + Send>(&self, key: K) -> Result<u64>;
+  async fn head<K: AsRef<str> + Send + Debug>(&self, key: K) -> Result<u64>;
 
   /// Get the url of the object using an inline data uri.
+  #[instrument(level = "trace")]
   fn data_url(data: Vec<u8>, class: Option<Class>) -> Url {
     Url::new(format!("data:;base64,{}", encode(data))).set_class(class)
   }


### PR DESCRIPTION
The following PR introduces changes related to logging and tracing.
Changes:
* Add various tracing logs and tracing instrument calls to help with debugging.
* Fixes issue with reading files, where an un-buffered reader was resulting in inefficiency due to many sys-calls. All read calls now use buffered reads.