### PR TITLE
Re-export htsget-config and add more pub functions

### DIFF
--- a/deploy/bin/htsget-http-lambda.ts
+++ b/deploy/bin/htsget-http-lambda.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
-import { HtsgetHttpLambdaStack } from '../lib/htsget-http-lambda-stack';
+import {HtsgetHttpLambdaStack} from '../lib/htsget-http-lambda-stack';
 
 export const STACK_NAME = 'HtsgetHttpLambdaStack';
 const STACK_DESCRIPTION = 'An example stack for testing htsget-http-lambda with API gateway.';

--- a/deploy/lib/htsget-http-lambda-stack.ts
+++ b/deploy/lib/htsget-http-lambda-stack.ts
@@ -1,11 +1,11 @@
-import { Duration, Stack, StackProps, Tags } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
+import {Duration, Stack, StackProps, Tags} from 'aws-cdk-lib';
+import {Construct} from 'constructs';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import { RustFunction, Settings } from 'rust.aws-cdk-lambda';
-import { Architecture } from 'aws-cdk-lib/aws-lambda';
+import {RustFunction, Settings} from 'rust.aws-cdk-lambda';
+import {Architecture} from 'aws-cdk-lib/aws-lambda';
 import * as apigw from 'aws-cdk-lib/aws-apigateway';
-import { AuthorizationType } from 'aws-cdk-lib/aws-apigateway';
-import { STACK_NAME } from '../bin/htsget-http-lambda';
+import {AuthorizationType} from 'aws-cdk-lib/aws-apigateway';
+import {STACK_NAME} from '../bin/htsget-http-lambda';
 
 export class HtsgetHttpLambdaStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {

--- a/doc/img/ga4gh-logo.svg
+++ b/doc/img/ga4gh-logo.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 529.8 137.6" enable-background="new 0 0 529.8 137.6" xml:space="preserve">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
+     viewBox="0 0 529.8 137.6" enable-background="new 0 0 529.8 137.6" xml:space="preserve">
 <g>
 	<g>
 		<path fill="#4FAEDC" d="M59.8,21.9c2,1.8,4.1,3.5,6.3,5.1c2.7-0.3,5.4-0.8,8.1-1.4c-0.1-0.3-0.2-0.7-0.3-1

--- a/htsget-http-actix/src/lib.rs
+++ b/htsget-http-actix/src/lib.rs
@@ -7,7 +7,9 @@ use tracing::info;
 use tracing::instrument;
 use tracing_actix_web::TracingLogger;
 
-use htsget_config::config::{ServiceInfo, TicketServerConfig};
+pub use htsget_config::config::{
+  Config, DataServerConfig, ServiceInfo, StorageType, TicketServerConfig, USAGE,
+};
 use htsget_search::htsget::from_storage::HtsGetFromStorage;
 use htsget_search::htsget::HtsGet;
 use htsget_search::storage::local::LocalStorage;
@@ -103,7 +105,6 @@ mod tests {
   use async_trait::async_trait;
   use tempfile::TempDir;
 
-  use htsget_config::config::Config;
   use htsget_search::storage::data_server::HttpTicketFormatter;
   use htsget_test_utils::http_tests::{config_with_tls, default_test_config};
   use htsget_test_utils::http_tests::{
@@ -111,6 +112,8 @@ mod tests {
   };
   use htsget_test_utils::server_tests::formatter_and_expected_path;
   use htsget_test_utils::{cors_tests, server_tests};
+
+  use crate::Config;
 
   use super::*;
 

--- a/htsget-http-actix/src/main.rs
+++ b/htsget-http-actix/src/main.rs
@@ -3,8 +3,8 @@ use std::io::{Error, ErrorKind};
 
 use tokio::select;
 
-use htsget_config::config::{Config, StorageType, USAGE};
 use htsget_http_actix::run_server;
+use htsget_http_actix::{Config, StorageType, USAGE};
 use htsget_search::htsget::from_storage::HtsGetFromStorage;
 use htsget_search::storage::data_server::HttpTicketFormatter;
 

--- a/htsget-http-core/src/lib.rs
+++ b/htsget-http-core/src/lib.rs
@@ -2,6 +2,9 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 pub use error::{HtsGetError, Result};
+pub use htsget_config::config::{
+  Config, DataServerConfig, ServiceInfo as ConfigServiceInfo, StorageType, TicketServerConfig,
+};
 use htsget_search::htsget::{Query, Response};
 pub use http_core::{get_response_for_get_request, get_response_for_post_request};
 pub use post_request::{PostRequest, Region};

--- a/htsget-http-core/src/service_info.rs
+++ b/htsget-http-core/src/service_info.rs
@@ -4,9 +4,9 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 use tracing::instrument;
 
-use htsget_config::config::ServiceInfo as ConfigServiceInfo;
 use htsget_search::htsget::{Format, HtsGet};
 
+use crate::ConfigServiceInfo;
 use crate::{Endpoint, READS_FORMATS, VARIANTS_FORMATS};
 
 /// A struct representing the information that should be present in a service-info response.

--- a/htsget-http-lambda/src/handlers/service_info.rs
+++ b/htsget-http-lambda/src/handlers/service_info.rs
@@ -4,12 +4,12 @@ use lambda_http::http;
 use tracing::info;
 use tracing::instrument;
 
-use htsget_config::config::ServiceInfo;
 use htsget_http_core::get_service_info_json as get_base_service_info_json;
 use htsget_http_core::Endpoint;
 use htsget_search::htsget::HtsGet;
 
 use crate::handlers::FormatJson;
+use crate::ServiceInfo;
 use crate::{Body, Response};
 
 /// Service info endpoint.

--- a/htsget-http-lambda/src/lib.rs
+++ b/htsget-http-lambda/src/lib.rs
@@ -12,7 +12,9 @@ use lambda_runtime::Error;
 use tracing::instrument;
 use tracing::{debug, info};
 
-use htsget_config::config::ServiceInfo;
+pub use htsget_config::config::{
+  Config, DataServerConfig, ServiceInfo, StorageType, TicketServerConfig,
+};
 use htsget_http_core::{Endpoint, PostRequest};
 use htsget_search::htsget::HtsGet;
 use htsget_search::storage::configure_cors;
@@ -211,7 +213,6 @@ mod tests {
   use query_map::QueryMap;
   use tempfile::TempDir;
 
-  use htsget_config::config::Config;
   use htsget_http_core::Endpoint;
   use htsget_search::htsget::from_storage::HtsGetFromStorage;
   use htsget_search::htsget::{Class, HtsGet};
@@ -227,6 +228,7 @@ mod tests {
   };
   use htsget_test_utils::{cors_tests, server_tests};
 
+  use crate::Config;
   use crate::{service_fn, HtsgetMethod, Method, Route, RouteType, Router, ServiceBuilder};
 
   struct LambdaTestServer {

--- a/htsget-http-lambda/src/lib.rs
+++ b/htsget-http-lambda/src/lib.rs
@@ -219,12 +219,11 @@ mod tests {
   use htsget_search::storage::configure_cors;
   use htsget_search::storage::data_server::HttpTicketFormatter;
   use htsget_search::storage::local::LocalStorage;
-  use htsget_test_utils::http_tests::{
-    config_with_tls, default_test_config, formatter_from_config, get_test_file,
-  };
+  use htsget_test_utils::http_tests::{config_with_tls, default_test_config, get_test_file};
   use htsget_test_utils::http_tests::{Header, Response, TestRequest, TestServer};
   use htsget_test_utils::server_tests::{
-    expected_url_path, formatter_and_expected_path, test_response, test_response_service_info,
+    expected_url_path, formatter_and_expected_path, formatter_from_config, test_response,
+    test_response_service_info,
   };
   use htsget_test_utils::{cors_tests, server_tests};
 

--- a/htsget-http-lambda/src/main.rs
+++ b/htsget-http-lambda/src/main.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use lambda_http::Error;
 use tracing::instrument;
 
-use htsget_config::config::{Config, StorageType};
 use htsget_http_lambda::{handle_request, Router};
+use htsget_http_lambda::{Config, StorageType};
 use htsget_search::htsget::from_storage::HtsGetFromStorage;
 use htsget_search::storage::data_server::HttpTicketFormatter;
 use htsget_search::storage::local::LocalStorage;

--- a/htsget-search/benches/search_benchmarks.rs
+++ b/htsget-search/benches/search_benchmarks.rs
@@ -4,13 +4,13 @@ use criterion::measurement::WallTime;
 use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion};
 use tokio::runtime::Runtime;
 
-use htsget_config::regex_resolver::RegexResolver;
 use htsget_search::htsget::from_storage::HtsGetFromStorage;
 use htsget_search::htsget::Class::Header;
 use htsget_search::htsget::Format::{Bam, Bcf, Cram, Vcf};
 use htsget_search::htsget::HtsGet;
 use htsget_search::htsget::{HtsGetError, Query};
 use htsget_search::storage::data_server::HttpTicketFormatter;
+use htsget_search::RegexResolver;
 
 const BENCHMARK_DURATION_SECONDS: u64 = 15;
 const NUMBER_OF_SAMPLES: usize = 150;

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -190,7 +190,7 @@ where
     level = "trace",
     skip(self, interval, ref_seq_length, crai_index, predicate)
   )]
-  async fn bytes_ranges_from_index<F>(
+  pub async fn bytes_ranges_from_index<F>(
     &self,
     id: &str,
     format: &Format,
@@ -254,7 +254,7 @@ where
   }
 
   /// Gets bytes ranges for a specific index entry.
-  pub(crate) fn bytes_ranges_for_record(
+  pub fn bytes_ranges_for_record(
     ref_seq_length: Option<NonZeroUsize>,
     seq_range: Interval,
     record: &Record,

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -9,14 +9,13 @@ use tokio::io::AsyncRead;
 use tracing::debug;
 use tracing::instrument;
 
-use htsget_config::regex_resolver::RegexResolver;
-
 use crate::htsget::search::Search;
 use crate::htsget::Format;
 #[cfg(feature = "s3-storage")]
 use crate::storage::aws::AwsS3Storage;
 use crate::storage::local::LocalStorage;
 use crate::storage::UrlFormatter;
+use crate::RegexResolver;
 use crate::{
   htsget::bam_search::BamSearch,
   htsget::bcf_search::BcfSearch,

--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -241,7 +241,7 @@ impl Interval {
   const MIN_SEQ_POSITION: usize = 1;
 
   #[instrument(level = "trace", skip_all, ret)]
-  fn into_one_based<F>(self, max_seq_position: F) -> Result<impl Into<NoodlesInterval>>
+  pub fn into_one_based<F>(self, max_seq_position: F) -> Result<impl Into<NoodlesInterval>>
   where
     F: FnOnce() -> usize,
   {
@@ -259,7 +259,7 @@ impl Interval {
   }
 
   /// Convert between position types.
-  fn convert_position<D, F>(value: Option<u32>, default: D, convert_fn: F) -> Result<Position>
+  pub fn convert_position<D, F>(value: Option<u32>, default: D, convert_fn: F) -> Result<Position>
   where
     D: FnOnce() -> usize,
     F: FnOnce(u32) -> Result<u32>,

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -66,7 +66,7 @@ pub(crate) async fn find_first<T>(
 /// [Reader] is the format's reader type.
 /// [Header] is the format's header type.
 #[async_trait]
-pub(crate) trait SearchAll<S, ReaderType, ReferenceSequence, Index, Reader, Header>
+pub trait SearchAll<S, ReaderType, ReferenceSequence, Index, Reader, Header>
 where
   Index: Send + Sync,
 {
@@ -104,7 +104,7 @@ where
 /// [Reader] is the format's reader type.
 /// [Header] is the format's header type.
 #[async_trait]
-pub(crate) trait SearchReads<S, ReaderType, ReferenceSequence, Index, Reader, Header>:
+pub trait SearchReads<S, ReaderType, ReferenceSequence, Index, Reader, Header>:
   Search<S, ReaderType, ReferenceSequence, Index, Reader, Header>
 where
   S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
@@ -174,7 +174,7 @@ where
 /// [Reader] is the format's reader type.
 /// [Header] is the format's header type.
 #[async_trait]
-pub(crate) trait Search<S, ReaderType, ReferenceSequence, Index, Reader, Header>:
+pub trait Search<S, ReaderType, ReferenceSequence, Index, Reader, Header>:
   SearchAll<S, ReaderType, ReferenceSequence, Index, Reader, Header>
 where
   S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
@@ -352,7 +352,7 @@ where
 /// [Reader] is the format's reader type.
 /// [Header] is the format's header type.
 #[async_trait]
-pub(crate) trait BgzfSearch<S, ReaderType, ReferenceSequence, Index, Reader, Header>:
+pub trait BgzfSearch<S, ReaderType, ReferenceSequence, Index, Reader, Header>:
   Search<S, ReaderType, ReferenceSequence, Index, Reader, Header>
 where
   S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
@@ -584,7 +584,7 @@ where
 }
 
 /// Extension trait for binning indicies.
-pub(crate) trait BinningIndexExt {
+pub trait BinningIndexExt {
   /// Get all chunks associated with this index from the reference sequences.
   fn get_all_chunks(&self) -> Vec<&Chunk>;
 }

--- a/htsget-search/src/lib.rs
+++ b/htsget-search/src/lib.rs
@@ -1,2 +1,7 @@
+pub use htsget_config::config::{
+  Config, DataServerConfig, ServiceInfo, StorageType, TicketServerConfig,
+};
+pub use htsget_config::regex_resolver::{HtsGetIdResolver, RegexResolver};
+
 pub mod htsget;
 pub mod storage;

--- a/htsget-search/src/storage/aws.rs
+++ b/htsget-search/src/storage/aws.rs
@@ -15,13 +15,12 @@ use tokio_util::io::StreamReader;
 use tracing::debug;
 use tracing::instrument;
 
-use htsget_config::regex_resolver::RegexResolver;
-
 use crate::htsget::Url;
 use crate::storage::aws::Retrieval::{Delayed, Immediate};
 use crate::storage::StorageError::AwsS3Error;
 use crate::storage::{resolve_id, BytesPosition};
 use crate::storage::{BytesRange, Storage};
+use crate::RegexResolver;
 
 use super::{GetOptions, RangeUrlOptions, Result};
 
@@ -236,13 +235,12 @@ mod tests {
   use s3_server::storages::fs::FileSystem;
   use s3_server::{S3Service, SimpleAuth};
 
-  use htsget_config::regex_resolver::RegexResolver;
-
   use crate::htsget::Headers;
   use crate::storage::aws::AwsS3Storage;
   use crate::storage::local::tests::create_local_test_files;
   use crate::storage::StorageError;
   use crate::storage::{BytesPosition, GetOptions, RangeUrlOptions, Storage};
+  use crate::RegexResolver;
 
   async fn with_s3_test_server<F, Fut>(server_base_path: &Path, test: F)
   where

--- a/htsget-search/src/storage/aws.rs
+++ b/htsget-search/src/storage/aws.rs
@@ -61,7 +61,7 @@ impl AwsS3Storage {
     )
   }
 
-  async fn s3_presign_url<K: AsRef<str> + Send>(
+  pub async fn s3_presign_url<K: AsRef<str> + Send>(
     &self,
     key: K,
     range: BytesPosition,
@@ -138,7 +138,7 @@ impl AwsS3Storage {
     }
   }
 
-  async fn get_content<K: AsRef<str> + Send>(
+  pub async fn get_content<K: AsRef<str> + Send>(
     &self,
     key: K,
     options: GetOptions,

--- a/htsget-search/src/storage/data_server.rs
+++ b/htsget-search/src/storage/data_server.rs
@@ -27,10 +27,9 @@ use tower_http::trace::TraceLayer;
 use tracing::instrument;
 use tracing::{info, trace};
 
-use htsget_config::config::DataServerConfig;
-
 use crate::storage::StorageError::{DataServerError, IoError};
 use crate::storage::{configure_cors, UrlFormatter};
+use crate::DataServerConfig;
 
 use super::{Result, StorageError};
 
@@ -287,7 +286,6 @@ mod tests {
   use http::{HeaderMap, HeaderValue, Method};
   use reqwest::{Client, ClientBuilder, RequestBuilder};
 
-  use htsget_config::config::Config;
   use htsget_test_utils::cors_tests::{
     test_cors_preflight_request_uri, test_cors_simple_request_uri,
   };
@@ -297,6 +295,7 @@ mod tests {
   use htsget_test_utils::util::generate_test_certificates;
 
   use crate::storage::local::tests::create_local_test_files;
+  use crate::Config;
 
   use super::*;
 

--- a/htsget-search/src/storage/local.rs
+++ b/htsget-search/src/storage/local.rs
@@ -9,10 +9,9 @@ use tokio::fs::File;
 use tracing::debug;
 use tracing::instrument;
 
-use htsget_config::regex_resolver::RegexResolver;
-
 use crate::htsget::Url;
 use crate::storage::{resolve_id, Storage, UrlFormatter};
+use crate::RegexResolver;
 
 use super::{GetOptions, RangeUrlOptions, Result, StorageError};
 

--- a/htsget-search/src/storage/local.rs
+++ b/htsget-search/src/storage/local.rs
@@ -67,7 +67,7 @@ impl<T: UrlFormatter + Send + Sync> LocalStorage<T> {
       })
   }
 
-  async fn get<K: AsRef<str>>(&self, key: K) -> Result<File> {
+  pub async fn get<K: AsRef<str>>(&self, key: K) -> Result<File> {
     let path = self.get_path_from_key(&key)?;
     File::open(path)
       .await

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -15,11 +15,10 @@ use tokio::io::AsyncRead;
 use tower_http::cors::{AllowHeaders, AllowMethods, CorsLayer};
 use tracing::instrument;
 
-use htsget_config::regex_resolver::{HtsGetIdResolver, RegexResolver};
-
 use crate::htsget::{Class, Headers, Url};
 use crate::storage::data_server::CORS_MAX_AGE;
 use crate::storage::StorageError::DataServerError;
+use crate::{HtsGetIdResolver, RegexResolver};
 
 #[cfg(feature = "s3-storage")]
 pub mod aws;

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -182,8 +182,8 @@ pub struct BytesPosition {
 }
 
 /// A bytes range has an inclusive start and end value. This is analogous to http bytes ranges.
-#[derive(Clone, Debug, Default, PartialEq)]
-struct BytesRange {
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BytesRange {
   start: Option<u64>,
   end: Option<u64>,
 }

--- a/htsget-test-utils/src/http_tests.rs
+++ b/htsget-test-utils/src/http_tests.rs
@@ -5,8 +5,6 @@ use async_trait::async_trait;
 use http::HeaderMap;
 use serde::de;
 
-use htsget_search::storage::data_server::HttpTicketFormatter;
-
 use crate::util::generate_test_certificates;
 use crate::Config;
 
@@ -92,11 +90,6 @@ fn set_path(config: &mut Config) {
 fn set_addr_and_path(config: &mut Config) {
   set_path(config);
   config.data_server_config.data_server_addr = "127.0.0.1:0".parse().unwrap();
-}
-
-/// Get the [HttpTicketFormatter] from the config.
-pub fn formatter_from_config(config: &Config) -> HttpTicketFormatter {
-  HttpTicketFormatter::try_from(config.data_server_config.clone()).unwrap()
 }
 
 /// Default config with fixed port.

--- a/htsget-test-utils/src/http_tests.rs
+++ b/htsget-test-utils/src/http_tests.rs
@@ -5,10 +5,10 @@ use async_trait::async_trait;
 use http::HeaderMap;
 use serde::de;
 
-use htsget_config::config::Config;
 use htsget_search::storage::data_server::HttpTicketFormatter;
 
 use crate::util::generate_test_certificates;
+use crate::Config;
 
 /// Represents a http header.
 #[derive(Debug)]

--- a/htsget-test-utils/src/lib.rs
+++ b/htsget-test-utils/src/lib.rs
@@ -1,3 +1,7 @@
+pub use htsget_config::config::{
+  Config, DataServerConfig, ServiceInfo, StorageType, TicketServerConfig,
+};
+
 #[cfg(feature = "cors-tests")]
 pub mod cors_tests;
 #[cfg(feature = "http-tests")]

--- a/htsget-test-utils/src/lib.rs
+++ b/htsget-test-utils/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(any(feature = "cors-tests", feature = "server-tests"))]
 pub use htsget_config::config::{
   Config, DataServerConfig, ServiceInfo, StorageType, TicketServerConfig,
 };

--- a/htsget-test-utils/src/server_tests.rs
+++ b/htsget-test-utils/src/server_tests.rs
@@ -14,7 +14,7 @@ use htsget_search::htsget::Response as HtsgetResponse;
 use htsget_search::htsget::{Class, Format, Headers, JsonResponse, Url};
 use htsget_search::storage::data_server::HttpTicketFormatter;
 
-use crate::http_tests::{formatter_from_config, Header, Response, TestRequest, TestServer};
+use crate::http_tests::{Header, Response, TestRequest, TestServer};
 use crate::util::expected_bgzf_eof_data_url;
 use crate::Config;
 
@@ -159,6 +159,11 @@ pub async fn test_parameterized_post_class_header<T: TestRequest>(tester: &impl 
   );
   let response = tester.test_server(request).await;
   test_response(response, Class::Header).await;
+}
+
+/// Get the [HttpTicketFormatter] from the config.
+pub fn formatter_from_config(config: &Config) -> HttpTicketFormatter {
+  HttpTicketFormatter::try_from(config.data_server_config.clone()).unwrap()
 }
 
 /// A service info test.

--- a/htsget-test-utils/src/server_tests.rs
+++ b/htsget-test-utils/src/server_tests.rs
@@ -8,7 +8,6 @@ use noodles_bgzf as bgzf;
 use noodles_vcf as vcf;
 use reqwest::ClientBuilder;
 
-use htsget_config::config::Config;
 use htsget_http_core::{get_service_info_with, Endpoint};
 use htsget_search::htsget::Class::Body;
 use htsget_search::htsget::Response as HtsgetResponse;
@@ -17,6 +16,7 @@ use htsget_search::storage::data_server::HttpTicketFormatter;
 
 use crate::http_tests::{formatter_from_config, Header, Response, TestRequest, TestServer};
 use crate::util::expected_bgzf_eof_data_url;
+use crate::Config;
 
 /// Test response with with class.
 pub async fn test_response(response: Response, class: Class) {


### PR DESCRIPTION
Re-exports htsget-config for the other crates, and makes some htsget-search functions public for use as a dependency.