### PR TITLE
Refactor htsget-search to make better use of noodles

### DIFF
--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -297,6 +297,32 @@ pub(crate) mod tests {
   }
 
   #[tokio::test]
+  async fn search_reference_name_no_end_position() {
+    with_local_storage(|storage| async move {
+      let search = BamSearch::new(storage.clone());
+      let query = Query::new("htsnexus_test_NA12878", Format::Bam)
+        .with_reference_name("11")
+        .with_start(5015000);
+      let response = search.search(query).await;
+      println!("{:#?}", response);
+
+      let expected_response = Ok(Response::new(
+        Format::Bam,
+        vec![
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
+            .with_class(Header),
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=256721-996014")),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+        ],
+      ));
+      assert_eq!(response, expected_response)
+    })
+      .await;
+  }
+
+  #[tokio::test]
   async fn search_many_response_urls() {
     with_local_storage(|storage| async move {
       let search = BamSearch::new(storage.clone());

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -185,7 +185,7 @@ pub(crate) mod tests {
     with_local_storage as with_local_storage_path,
     with_local_storage_tmp as with_local_storage_tmp_path,
   };
-  use crate::htsget::{Class, Class::Body, Class::Header, Headers, Response, Url};
+  use crate::htsget::{Class::Body, Class::Header, Headers, Response, Url};
   use crate::storage::data_server::HttpTicketFormatter;
   use crate::storage::local::LocalStorage;
 
@@ -313,13 +313,14 @@ pub(crate) mod tests {
             .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
             .with_class(Header),
           Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=256721-996014")),
+            .with_headers(Headers::default().with_header("Range", "bytes=256721-996014"))
+            .with_class(Body),
           Url::new(expected_bgzf_eof_data_url()).with_class(Body),
         ],
       ));
       assert_eq!(response, expected_response)
     })
-      .await;
+    .await;
   }
 
   #[tokio::test]
@@ -386,7 +387,7 @@ pub(crate) mod tests {
   async fn search_header() {
     with_local_storage(|storage| async move {
       let search = BamSearch::new(storage.clone());
-      let query = Query::new("htsnexus_test_NA12878", Format::Bam).with_class(Class::Header);
+      let query = Query::new("htsnexus_test_NA12878", Format::Bam).with_class(Header);
       let response = search.search(query).await;
       println!("{:#?}", response);
 
@@ -394,7 +395,7 @@ pub(crate) mod tests {
         Format::Bam,
         vec![Url::new(expected_url())
           .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
-          .with_class(Class::Header)],
+          .with_class(Header)],
       ));
       assert_eq!(response, expected_response)
     })

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -19,7 +19,7 @@ use tracing::{instrument, trace};
 
 use crate::htsget::search::{BgzfSearch, BinningIndexExt, Search, SearchAll, SearchReads};
 use crate::htsget::Class::Body;
-use crate::htsget::{HtsGetError, ReferenceSequenceInfo};
+use crate::htsget::HtsGetError;
 use crate::{
   htsget::{Format, Query, Result},
   storage::{BytesPosition, Storage},
@@ -138,8 +138,8 @@ where
     &self,
     header: &'a Header,
     name: &str,
-  ) -> Option<ReferenceSequenceInfo> {
-    ReferenceSequenceInfo::try_from(name, header.reference_sequences())
+  ) -> Option<usize> {
+    Some(header.reference_sequences().get_index_of(name)?)
   }
 
   async fn get_byte_ranges_for_unmapped_reads(
@@ -154,12 +154,12 @@ where
 
   async fn get_byte_ranges_for_reference_sequence(
     &self,
-    ref_seq_info: ReferenceSequenceInfo,
+    ref_seq_id: usize,
     query: Query,
     index: &Index,
   ) -> Result<Vec<BytesPosition>> {
     self
-      .get_byte_ranges_for_reference_sequence_bgzf(query, ref_seq_info, index)
+      .get_byte_ranges_for_reference_sequence_bgzf(query, ref_seq_id, index)
       .await
   }
 }

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -16,9 +16,8 @@ use tokio::io::AsyncRead;
 use tracing::{instrument, trace};
 
 use crate::htsget::search::{find_first, BgzfSearch, BinningIndexExt, Search};
-use crate::htsget::ReferenceSequenceInfo;
 use crate::{
-  htsget::{vcf_search::VcfSearch, Format, Query, Result},
+  htsget::{Format, Query, Result},
   storage::{BytesPosition, Storage},
 };
 
@@ -100,9 +99,8 @@ where
     )
     .await?;
 
-    let ref_seq_info = ReferenceSequenceInfo::new(ref_seq_id, VcfSearch::<S>::MAX_SEQ_POSITION);
     let byte_ranges = self
-      .get_byte_ranges_for_reference_sequence_bgzf(query, ref_seq_info, index)
+      .get_byte_ranges_for_reference_sequence_bgzf(query, ref_seq_id, index)
       .await?;
     Ok(byte_ranges)
   }

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -201,6 +201,24 @@ mod tests {
   }
 
   #[tokio::test]
+  async fn search_reference_name_no_end_position() {
+    with_local_storage(
+      |storage| async move {
+        let search = BcfSearch::new(storage.clone());
+        let filename = "sample1-bcbio-cancer";
+        let query = Query::new(filename, Format::Bcf)
+          .with_reference_name("chrM")
+          .with_start(151);
+        let response = search.search(query).await;
+        println!("{:#?}", response);
+
+        let expected_response = Ok(expected_bcf_response(filename));
+        assert_eq!(response, expected_response)
+      },
+    ).await
+  }
+
+  #[tokio::test]
   async fn search_no_gzi() {
     with_local_storage_tmp(|storage| async move {
       test_reference_sequence_with_seq_range(storage).await

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -16,7 +16,7 @@ use tokio::io::AsyncRead;
 use tracing::{instrument, trace};
 
 use crate::htsget::search::{find_first, BgzfSearch, BinningIndexExt, Search};
-use crate::htsget::{HtsGetError, ReferenceSequenceInfo};
+use crate::htsget::ReferenceSequenceInfo;
 use crate::{
   htsget::{vcf_search::VcfSearch, Format, Query, Result},
   storage::{BytesPosition, Storage},
@@ -77,40 +77,28 @@ where
     reference_name: String,
     index: &Index,
     header: &Header,
-    mut query: Query,
+    query: Query,
   ) -> Result<Vec<BytesPosition>> {
     trace!("getting byte ranges for reference name");
     // We are assuming the order of the contigs in the header and the references sequences
     // in the index is the same
     let mut futures = FuturesOrdered::new();
-    for (ref_seq_index, (name, contig)) in header.contigs().iter().enumerate() {
-      let owned_contig = contig.clone();
+    for (ref_seq_index, (name, _)) in header.contigs().iter().enumerate() {
       let owned_name = name.to_owned();
       let owned_reference_name = reference_name.clone();
       futures.push_back(tokio::spawn(async move {
         if owned_name == owned_reference_name {
-          Some((ref_seq_index, (owned_name, owned_contig)))
+          Some((ref_seq_index, owned_name))
         } else {
           None
         }
       }));
     }
-    let (ref_seq_id, (_, contig)) = find_first(
-      &format!("reference name not found in header: {}", reference_name,),
+    let (ref_seq_id, _) = find_first(
+      &format!("reference name not found in header: {}", reference_name),
       futures,
     )
     .await?;
-
-    query.interval.end = match query.interval.end {
-      None => contig
-        .length()
-        .map(u32::try_from)
-        .transpose()
-        .map_err(|err| {
-          HtsGetError::invalid_input(format!("converting contig length to `u32`: {}", err))
-        })?,
-      value => value,
-    };
 
     let ref_seq_info = ReferenceSequenceInfo::new(ref_seq_id, VcfSearch::<S>::MAX_SEQ_POSITION);
     let byte_ranges = self
@@ -202,20 +190,19 @@ mod tests {
 
   #[tokio::test]
   async fn search_reference_name_no_end_position() {
-    with_local_storage(
-      |storage| async move {
-        let search = BcfSearch::new(storage.clone());
-        let filename = "sample1-bcbio-cancer";
-        let query = Query::new(filename, Format::Bcf)
-          .with_reference_name("chrM")
-          .with_start(151);
-        let response = search.search(query).await;
-        println!("{:#?}", response);
+    with_local_storage(|storage| async move {
+      let search = BcfSearch::new(storage.clone());
+      let filename = "sample1-bcbio-cancer";
+      let query = Query::new(filename, Format::Bcf)
+        .with_reference_name("chrM")
+        .with_start(151);
+      let response = search.search(query).await;
+      println!("{:#?}", response);
 
-        let expected_response = Ok(expected_bcf_response(filename));
-        assert_eq!(response, expected_response)
-      },
-    ).await
+      let expected_response = Ok(expected_bcf_response(filename));
+      assert_eq!(response, expected_response)
+    })
+    .await
   }
 
   #[tokio::test]

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -419,6 +419,22 @@ mod tests {
     .await;
   }
 
+  #[tokio::test]
+  async fn search_reference_name_with_no_end_position() {
+    with_local_storage(|storage| async move {
+      let search = CramSearch::new(storage.clone());
+      let query = Query::new("htsnexus_test_NA12878", Format::Cram)
+        .with_reference_name("11")
+        .with_start(5000000);
+      let response = search.search(query).await;
+      println!("{:#?}", response);
+
+      let expected_response = Ok(expected_response_with_start());
+      assert_eq!(response, expected_response)
+    })
+      .await;
+  }
+
   fn expected_response_with_start() -> Response {
     Response::new(
       Format::Cram,

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -18,7 +18,7 @@ use tracing::{instrument, trace};
 
 use crate::htsget::search::{Search, SearchAll, SearchReads};
 use crate::htsget::Class::Body;
-use crate::htsget::{Format, HtsGetError, Interval, Query, ReferenceSequenceInfo, Result};
+use crate::htsget::{Format, HtsGetError, Interval, Query, Result};
 use crate::storage::{BytesPosition, DataBlock, Storage};
 
 // § 9 End of file container <https://samtools.github.io/hts-specs/CRAMv3.pdf>.
@@ -92,8 +92,8 @@ where
     &self,
     header: &'a Header,
     name: &str,
-  ) -> Option<ReferenceSequenceInfo> {
-    ReferenceSequenceInfo::try_from(name, header.reference_sequences())
+  ) -> Option<usize> {
+    Some(header.reference_sequences().get_index_of(name)?)
   }
 
   async fn get_byte_ranges_for_unmapped_reads(
@@ -114,7 +114,7 @@ where
 
   async fn get_byte_ranges_for_reference_sequence(
     &self,
-    ref_seq_info: ReferenceSequenceInfo,
+    ref_seq_id: usize,
     query: Query,
     index: &Index,
   ) -> Result<Vec<BytesPosition>> {
@@ -124,7 +124,7 @@ where
       &query.format,
       &query.interval,
       index,
-      Arc::new(move |record: &Record| record.reference_sequence_id() == Some(ref_seq_info.id)),
+      Arc::new(move |record: &Record| record.reference_sequence_id() == Some(ref_seq_id)),
     )
     .await
   }

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -275,7 +275,7 @@ where
             HtsGetError::invalid_input("adding record alignment span to `Position`")
           })?;
 
-        let interval = seq_range.into_one_based(|| usize::from(length))?.into();
+        let interval = seq_range.into_one_based()?;
         let seq_start = interval.start().unwrap_or(Position::MIN);
         let seq_end = interval.end().unwrap_or(Position::MAX);
 
@@ -413,17 +413,21 @@ mod tests {
       let response = search.search(query).await;
       println!("{:#?}", response);
 
-      let expected_response = Ok(Response::new(
-        Format::Cram,
-        vec![
-          Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=0-604230")),
-          Url::new(expected_cram_eof_data_url()),
-        ],
-      ));
+      let expected_response = Ok(expected_response_with_start());
       assert_eq!(response, expected_response)
     })
     .await;
+  }
+
+  fn expected_response_with_start() -> Response {
+    Response::new(
+      Format::Cram,
+      vec![
+        Url::new(expected_url())
+          .with_headers(Headers::default().with_header("Range", "bytes=0-604230")),
+        Url::new(expected_cram_eof_data_url()),
+      ],
+    )
   }
 
   #[tokio::test]

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -2,7 +2,6 @@
 //!
 
 use std::marker::PhantomData;
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -107,7 +106,6 @@ where
       &query.id,
       &self.get_format(),
       &query.interval,
-      None,
       index,
       Arc::new(|record: &Record| record.reference_sequence_id().is_none()),
     )
@@ -125,7 +123,6 @@ where
       &query.id,
       &query.format,
       &query.interval,
-      Some(ref_seq_info.length),
       index,
       Arc::new(move |record: &Record| record.reference_sequence_id() == Some(ref_seq_info.id)),
     )
@@ -186,16 +183,12 @@ where
   }
 
   /// Get bytes ranges using the index.
-  #[instrument(
-    level = "trace",
-    skip(self, interval, ref_seq_length, crai_index, predicate)
-  )]
+  #[instrument(level = "trace", skip(self, interval, crai_index, predicate))]
   pub async fn bytes_ranges_from_index<F>(
     &self,
     id: &str,
     format: &Format,
     interval: &Interval,
-    ref_seq_length: Option<NonZeroUsize>,
     crai_index: &[Record],
     predicate: Arc<F>,
   ) -> Result<Vec<BytesPosition>>
@@ -212,7 +205,7 @@ where
       let range = interval.clone();
       futures.push_back(tokio::spawn(async move {
         if owned_predicate(&owned_record) {
-          Self::bytes_ranges_for_record(ref_seq_length, range, &owned_record, owned_next.offset())
+          Self::bytes_ranges_for_record(range, &owned_record, owned_next.offset())
         } else {
           Ok(None)
         }
@@ -239,7 +232,6 @@ where
       }
       Some(last) if predicate(last) => {
         if let Some(range) = Self::bytes_ranges_for_record(
-          ref_seq_length,
           interval.clone(),
           last,
           self.position_at_eof(id, format).await?,
@@ -255,41 +247,28 @@ where
 
   /// Gets bytes ranges for a specific index entry.
   pub fn bytes_ranges_for_record(
-    ref_seq_length: Option<NonZeroUsize>,
     seq_range: Interval,
     record: &Record,
     next: u64,
   ) -> Result<Option<BytesPosition>> {
-    match ref_seq_length {
-      None => Ok(Some(
+    let record_start = record.alignment_start().unwrap_or(Position::MIN);
+    let record_end = record_start
+      .checked_add(record.alignment_span())
+      .ok_or_else(|| HtsGetError::invalid_input("adding record alignment span to `Position`"))?;
+
+    let interval = seq_range.into_one_based()?;
+    let seq_start = interval.start().unwrap_or(Position::MIN);
+    let seq_end = interval.end().unwrap_or(Position::MAX);
+
+    if seq_start <= record_end && seq_end >= record_start {
+      Ok(Some(
         BytesPosition::default()
           .with_start(record.offset())
           .with_end(next)
           .with_class(Body),
-      )),
-      Some(length) => {
-        let record_start = record.alignment_start().unwrap_or(Position::MIN);
-        let record_end = record_start
-          .checked_add(record.alignment_span())
-          .ok_or_else(|| {
-            HtsGetError::invalid_input("adding record alignment span to `Position`")
-          })?;
-
-        let interval = seq_range.into_one_based()?;
-        let seq_start = interval.start().unwrap_or(Position::MIN);
-        let seq_end = interval.end().unwrap_or(Position::MAX);
-
-        if seq_start <= record_end && seq_end >= record_start {
-          Ok(Some(
-            BytesPosition::default()
-              .with_start(record.offset())
-              .with_end(next)
-              .with_class(Body),
-          ))
-        } else {
-          Ok(None)
-        }
-      }
+      ))
+    } else {
+      Ok(None)
     }
   }
 }
@@ -301,7 +280,7 @@ mod tests {
   use htsget_test_utils::util::expected_cram_eof_data_url;
 
   use crate::htsget::from_storage::tests::with_local_storage as with_local_storage_path;
-  use crate::htsget::{Class, Class::Body, Class::Header, Headers, Response, Url};
+  use crate::htsget::{Class::Body, Class::Header, Headers, Response, Url};
   use crate::storage::data_server::HttpTicketFormatter;
   use crate::storage::local::LocalStorage;
 
@@ -432,7 +411,7 @@ mod tests {
       let expected_response = Ok(expected_response_with_start());
       assert_eq!(response, expected_response)
     })
-      .await;
+    .await;
   }
 
   fn expected_response_with_start() -> Response {
@@ -450,7 +429,7 @@ mod tests {
   async fn search_header() {
     with_local_storage(|storage| async move {
       let search = CramSearch::new(storage.clone());
-      let query = Query::new("htsnexus_test_NA12878", Format::Cram).with_class(Class::Header);
+      let query = Query::new("htsnexus_test_NA12878", Format::Cram).with_class(Header);
       let response = search.search(query).await;
       println!("{:#?}", response);
 
@@ -458,7 +437,7 @@ mod tests {
         Format::Cram,
         vec![Url::new(expected_url())
           .with_headers(Headers::default().with_header("Range", "bytes=0-6086"))
-          .with_class(Class::Header)],
+          .with_class(Header)],
       ));
       assert_eq!(response, expected_response)
     })

--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -8,12 +8,10 @@ use std::collections::HashMap;
 use std::fmt::Formatter;
 use std::io;
 use std::io::ErrorKind;
-use std::num::NonZeroUsize;
 
 use async_trait::async_trait;
 use noodles::core::region::Interval as NoodlesInterval;
 use noodles::core::Position;
-use noodles::sam::header::ReferenceSequences;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::task::JoinError;
@@ -197,35 +195,6 @@ impl Query {
   pub fn with_no_tags(mut self, no_tags: Vec<impl Into<String>>) -> Self {
     self.no_tags = Some(no_tags.into_iter().map(|field| field.into()).collect());
     self
-  }
-}
-
-/// Contains the id and length of a reference sequence.
-#[derive(Debug)]
-pub struct ReferenceSequenceInfo {
-  id: usize,
-  length: NonZeroUsize,
-}
-
-impl ReferenceSequenceInfo {
-  pub fn new(id: usize, length: NonZeroUsize) -> Self {
-    Self { id, length }
-  }
-
-  pub fn try_from(
-    name: &str,
-    reference_sequences: &ReferenceSequences,
-  ) -> Option<ReferenceSequenceInfo> {
-    let (id, _, reference_sequence) = reference_sequences.get_full(name)?;
-    Some(Self::new(id, reference_sequence.length()))
-  }
-
-  pub fn id(&self) -> usize {
-    self.id
-  }
-
-  pub fn length(&self) -> NonZeroUsize {
-    self.length
   }
 }
 

--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -241,39 +241,40 @@ impl Interval {
   const MIN_SEQ_POSITION: usize = 1;
 
   #[instrument(level = "trace", skip_all, ret)]
-  pub fn into_one_based<F>(self, max_seq_position: F) -> Result<impl Into<NoodlesInterval>>
-  where
-    F: FnOnce() -> usize,
-  {
-    Ok(
-      Self::convert_position(
-        self.start,
-        || Self::MIN_SEQ_POSITION,
-        |value| {
-          value.checked_add(1).ok_or_else(|| {
-            HtsGetError::InvalidRange(format!("could not convert {} to 1-based position.", value))
-          })
-        },
-      )?..=Self::convert_position(self.end, max_seq_position, Ok)?,
-    )
+  pub fn into_one_based(self) -> Result<NoodlesInterval> {
+    Ok(match (self.start, self.end) {
+      (None, None) => NoodlesInterval::from(..),
+      (None, Some(end)) => NoodlesInterval::from(..=Self::convert_end(end)?),
+      (Some(start), None) => NoodlesInterval::from(Self::convert_start(start)?..),
+      (Some(start), Some(end)) => NoodlesInterval::from(Self::convert_start(start)?..=Self::convert_end(end)?),
+    })
   }
 
-  /// Convert between position types.
-  pub fn convert_position<D, F>(value: Option<u32>, default: D, convert_fn: F) -> Result<Position>
+  /// Convert a start position to a noodles Position.
+  pub fn convert_start(start: u32) -> Result<Position> {
+    Self::convert_position(start, |value| {
+      value.checked_add(1).ok_or_else(|| {
+        HtsGetError::InvalidRange(format!("could not convert {} to 1-based position.", value))
+      })
+    })
+  }
+
+  /// Convert an end position to a noodles Position.
+  pub fn convert_end(end: u32) -> Result<Position> {
+    Self::convert_position(end, Ok)
+  }
+
+  /// Convert a u32 position to a noodles Position.
+  pub fn convert_position<F>(value: u32, convert_fn: F) -> Result<Position>
   where
-    D: FnOnce() -> usize,
     F: FnOnce(u32) -> Result<u32>,
   {
-    let value = value
-      .map(convert_fn)
-      .transpose()?
+    let value = convert_fn(value)
       .map(|value| {
         usize::try_from(value).map_err(|err| {
           HtsGetError::InvalidRange(format!("could not convert `u32` to `usize`: {}", err))
         })
-      })
-      .transpose()?
-      .unwrap_or_else(default);
+      })??;
 
     Position::try_from(value).map_err(|err| {
       HtsGetError::InvalidRange(format!(

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -410,7 +410,7 @@ where
           ref_seq_info.id,
           query
             .interval
-            .into_one_based(|| usize::from(ref_seq_info.length))?,
+            .into_one_based()?,
         )
         .map_err(|err| HtsGetError::InvalidRange(format!("querying range: {}", err)))?;
 

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -23,7 +23,6 @@ use tokio::task::JoinHandle;
 use tracing::{instrument, trace, trace_span, Instrument};
 
 use crate::htsget::Class::Body;
-use crate::htsget::ReferenceSequenceInfo;
 use crate::storage::{DataBlock, GetOptions};
 use crate::{
   htsget::{Class, Format, HtsGetError, Query, Response, Result},
@@ -51,7 +50,7 @@ pub(crate) async fn find_first<T>(
         }
       },
       else => break
-    };
+    }
   }
   result.ok_or_else(|| HtsGetError::not_found(msg))
 }
@@ -119,7 +118,7 @@ where
     &self,
     header: &'b Header,
     name: &str,
-  ) -> Option<ReferenceSequenceInfo>;
+  ) -> Option<usize>;
 
   /// Get unplaced unmapped ranges.
   async fn get_byte_ranges_for_unmapped_reads(
@@ -131,7 +130,7 @@ where
   /// Get reads ranges for a reference sequence implementation.
   async fn get_byte_ranges_for_reference_sequence(
     &self,
-    ref_seq_info: ReferenceSequenceInfo,
+    ref_seq_id: usize,
     query: Query,
     index: &Index,
   ) -> Result<Vec<BytesPosition>>;
@@ -157,8 +156,8 @@ where
         "reference name not found: {}",
         reference_name
       ))),
-      Some(ref_seq_info) => {
-        Self::get_byte_ranges_for_reference_sequence(self, ref_seq_info, query, index).await
+      Some(ref_seq_id) => {
+        Self::get_byte_ranges_for_reference_sequence(self, ref_seq_id, query, index).await
       }
     }?;
     Ok(byte_ranges)
@@ -400,13 +399,13 @@ where
   async fn get_byte_ranges_for_reference_sequence_bgzf(
     &self,
     query: Query,
-    ref_seq_info: ReferenceSequenceInfo,
+    ref_seq_id: usize,
     index: &Index,
   ) -> Result<Vec<BytesPosition>> {
     let chunks: Result<Vec<Chunk>> = trace_span!("querying chunks").in_scope(|| {
-      trace!(id = ?query.id.as_str(), ref_seq_id = ?ref_seq_info.id, "querying chunks");
+      trace!(id = ?query.id.as_str(), ref_seq_id = ?ref_seq_id, "querying chunks");
       let mut chunks = index
-        .query(ref_seq_info.id, query.interval.into_one_based()?)
+        .query(ref_seq_id, query.interval.into_one_based()?)
         .map_err(|err| HtsGetError::InvalidRange(format!("querying range: {}", err)))?;
 
       if chunks.is_empty() {
@@ -415,7 +414,7 @@ where
         ));
       }
 
-      trace!(id = ?query.id.as_str(), ref_seq_id = ?ref_seq_info.id, "sorting chunks");
+      trace!(id = ?query.id.as_str(), ref_seq_id = ?ref_seq_id, "sorting chunks");
       chunks.sort_unstable_by_key(|a| a.end().compressed());
 
       Ok(chunks)

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -406,12 +406,7 @@ where
     let chunks: Result<Vec<Chunk>> = trace_span!("querying chunks").in_scope(|| {
       trace!(id = ?query.id.as_str(), ref_seq_id = ?ref_seq_info.id, "querying chunks");
       let mut chunks = index
-        .query(
-          ref_seq_info.id,
-          query
-            .interval
-            .into_one_based()?,
-        )
+        .query(ref_seq_info.id, query.interval.into_one_based()?)
         .map_err(|err| HtsGetError::InvalidRange(format!("querying range: {}", err)))?;
 
       if chunks.is_empty() {

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -215,6 +215,23 @@ pub(crate) mod tests {
   }
 
   #[tokio::test]
+  async fn search_reference_name_no_end_position() {
+    with_local_storage(|storage| async move {
+      let search = VcfSearch::new(storage.clone());
+      let filename = "sample1-bcbio-cancer";
+      let query = Query::new(filename, Format::Vcf)
+        .with_reference_name("chrM")
+        .with_start(151)
+        .with_end(153);
+      let response = search.search(query).await;
+      println!("{:#?}", response);
+
+      let expected_response = Ok(expected_vcf_response(filename));
+      assert_eq!(response, expected_response);
+    }).await;
+  }
+
+  #[tokio::test]
   async fn search_no_gzi() {
     with_local_storage_tmp(
       |storage| async move { test_reference_name_with_seq_range(storage).await },


### PR DESCRIPTION
Refactors htsget-search to better use the noodles [`Interval`](https://docs.rs/noodles/latest/noodles/core/region/struct.Interval.html). Removes `ReferenceSequenceInfo`, and simplifies some logic when converting the start and end positions to noodles [`Position`](https://docs.rs/noodles/latest/noodles/core/struct.Position.html).