### PR TITLE
Make search structs public

### DIFF
--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -27,7 +27,8 @@ use crate::{
 
 type AsyncReader<ReaderType> = bam::AsyncReader<bgzf::AsyncReader<ReaderType>>;
 
-pub(crate) struct BamSearch<S> {
+/// Allows searching through bam files.
+pub struct BamSearch<S> {
   storage: Arc<S>,
 }
 

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -23,7 +23,8 @@ use crate::{
 
 type AsyncReader<ReaderType> = bcf::AsyncReader<bgzf::AsyncReader<ReaderType>>;
 
-pub(crate) struct BcfSearch<S> {
+/// Allows searching through bcf files.
+pub struct BcfSearch<S> {
   storage: Arc<S>,
 }
 

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -30,7 +30,8 @@ static CRAM_EOF: &[u8] = &[
 
 type AsyncReader<ReaderType> = cram::AsyncReader<BufReader<ReaderType>>;
 
-pub(crate) struct CramSearch<S> {
+/// Allows searching through cram files.
+pub struct CramSearch<S> {
   storage: Arc<S>,
 }
 

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -25,7 +25,8 @@ use crate::{
 
 type AsyncReader<ReaderType> = vcf::AsyncReader<bgzf::AsyncReader<ReaderType>>;
 
-pub(crate) struct VcfSearch<S> {
+/// Allows searching through vcf files.
+pub struct VcfSearch<S> {
   storage: Arc<S>,
 }
 


### PR DESCRIPTION
Makes the search structs public for use as a dependency. This was meant to be included in #121.