### PR TITLE
build(deploy): add resolvers environment variable to deploy example

### DIFF
--- a/deploy/lib/htsget-http-lambda-stack.ts
+++ b/deploy/lib/htsget-http-lambda-stack.ts
@@ -40,8 +40,7 @@ export class HtsgetHttpLambdaStack extends Stack {
       timeout: Duration.seconds(10),
       // Change environment variables passed to htsget-http-lambda.
       environment: {
-        HTSGET_S3_BUCKET: 'umccr-research-dev',
-        HTSGET_STORAGE_TYPE: 'AwsS3Storage',
+        HTSGET_RESOLVERS: '[{storage_type={type=S3, bucket=umccr-research-dev}}]',
         RUST_LOG: 'info,htsget_http_lambda=trace,htsget_config=trace,htsget_http_core=trace,htsget_search=trace'
       },
       architecture: Architecture.ARM_64,


### PR DESCRIPTION
Uses the new HTSGET_RESOLVERS environment variable in the deploy example