### PR TITLE
Use explicit routes GET, POST with {proxy+} path

### DIFF
--- a/deploy/lib/htsget-lambda-stack.ts
+++ b/deploy/lib/htsget-lambda-stack.ts
@@ -130,8 +130,9 @@ export class HtsgetLambdaStack extends Stack {
       ),
     });
 
-    new apigwv2.HttpApi(this, id + 'ApiGw', {
-      defaultIntegration: httpIntegration,
+    const httpApi = new apigwv2.HttpApi(this, id + 'ApiGw', {
+      // Use explicit routes GET, POST with {proxy+} path
+      // defaultIntegration: httpIntegration,
       defaultAuthorizer: authorizer,
       defaultDomainMapping: {
         domainName: domainName,
@@ -145,6 +146,13 @@ export class HtsgetLambdaStack extends Stack {
         maxAge: config.maxAge,
       },
     });
+
+    httpApi.addRoutes(
+        {
+          path: '/{proxy+}',
+          methods: [apigwv2.HttpMethod.GET, apigwv2.HttpMethod.POST],
+          integration: httpIntegration,
+        });
   }
 
   /**


### PR DESCRIPTION
* The $default route protect/auth OPTIONS request that is made during browser CORS preflight request purpose. OPTIONS request should be reachable without auth. See https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-cors.html