### PR TITLE
refactor!: refactor tests to avoid a circular dependency with htsget-search and htsget-http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,8 +1788,6 @@ dependencies = [
  "base64 0.21.0",
  "futures",
  "htsget-config",
- "htsget-http",
- "htsget-search",
  "http",
  "mime",
  "noodles-bgzf",
@@ -3262,6 +3260,7 @@ version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7434af0dc1cbd59268aa98b4c22c131c0584d2232f6fb166efb993e2832e896a"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a320103719de37b7b4da4c8eb629d4573f6bcfd3dfe80d3208806895ccf81d"
+checksum = "51227033e4d3acad15c879092ac8a228532707b5db5ff2628f638334f63e1b7a"
 dependencies = [
  "axum",
  "bytes",

--- a/htsget-actix/Cargo.toml
+++ b/htsget-actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-actix"
-version = "0.1.2"
+version = "0.1.3"
 rust-version = "1.64"
 authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"
@@ -20,9 +20,9 @@ actix-cors = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 futures-util = { version = "0.3" }
-htsget-http = { version = "0.1.2", path = "../htsget-http", default-features = false }
-htsget-search = { version = "0.1.2", path = "../htsget-search", default-features = false }
-htsget-config = { version = "0.1.2", path = "../htsget-config", default-features = false }
+htsget-http = { version = "0.1.3", path = "../htsget-http", default-features = false }
+htsget-search = { version = "0.1.3", path = "../htsget-search", default-features = false }
+htsget-config = { version = "0.1.3", path = "../htsget-config", default-features = false }
 futures = { version = "0.3" }
 tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 
@@ -30,7 +30,7 @@ tracing-actix-web = "0.7"
 tracing = "0.1"
 
 [dev-dependencies]
-htsget-test = { version = "0.1.2", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
+htsget-test = { version = "0.1.3", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
 async-trait = "0.1"
 
 criterion = { version = "0.4", features = ["async_tokio"] }

--- a/htsget-actix/Cargo.toml
+++ b/htsget-actix/Cargo.toml
@@ -30,7 +30,7 @@ tracing-actix-web = "0.7"
 tracing = "0.1"
 
 [dev-dependencies]
-htsget-test = { path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
+htsget-test = { version = "0.1.2", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
 async-trait = "0.1"
 
 criterion = { version = "0.4", features = ["async_tokio"] }

--- a/htsget-actix/src/lib.rs
+++ b/htsget-actix/src/lib.rs
@@ -236,6 +236,7 @@ mod tests {
       request: test::TestRequest,
       _formatter: HttpTicketFormatter,
     ) -> ServiceResponse<EitherBody<BoxBody>> {
+      println!("{:#?}", self.config);
       let app = test::init_service(
         App::new()
           .configure(|service_config: &mut web::ServiceConfig| {

--- a/htsget-actix/src/main.rs
+++ b/htsget-actix/src/main.rs
@@ -8,12 +8,12 @@ use htsget_search::storage::data_server::HttpTicketFormatter;
 async fn main() -> std::io::Result<()> {
   Config::setup_tracing()?;
 
-  if let Some(config) = Config::parse_args() {
-    let config = Config::from_config(config)?;
+  if let Some(path) = Config::parse_args() {
+    let config = Config::from_path(&path)?;
 
     if config.data_server().enabled() {
       let server = config.data_server().clone();
-      let mut formatter = HttpTicketFormatter::try_from(server.clone())?;
+      let mut formatter = HttpTicketFormatter::from(server.clone());
 
       let local_server = formatter.bind_data_server().await?;
       let local_server =

--- a/htsget-config/Cargo.toml
+++ b/htsget-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-config"
-version = "0.1.2"
+version = "0.1.3"
 rust-version = "1.64"
 authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"

--- a/htsget-http/Cargo.toml
+++ b/htsget-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-http"
-version = "0.1.2"
+version = "0.1.3"
 rust-version = "1.64"
 authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"
@@ -18,11 +18,11 @@ default = ["s3-storage"]
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 http = "0.2"
-htsget-search = { version = "0.1.2", path = "../htsget-search", default-features = false }
-htsget-config = { version = "0.1.2", path = "../htsget-config", default-features = false }
+htsget-search = { version = "0.1.3", path = "../htsget-search", default-features = false }
+htsget-config = { version = "0.1.3", path = "../htsget-config", default-features = false }
 futures = { version = "0.3" }
 tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 
 [dev-dependencies]
-htsget-test = { version = "0.1.2", path = "../htsget-test", default-features = false }
+htsget-test = { version = "0.1.3", path = "../htsget-test", default-features = false }

--- a/htsget-http/Cargo.toml
+++ b/htsget-http/Cargo.toml
@@ -25,4 +25,4 @@ tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 
 [dev-dependencies]
-htsget-test = { path = "../htsget-test", default-features = false }
+htsget-test = { version = "0.1.2", path = "../htsget-test", default-features = false }

--- a/htsget-http/src/service_info.rs
+++ b/htsget-http/src/service_info.rs
@@ -12,6 +12,7 @@ use crate::{Endpoint, READS_FORMATS, VARIANTS_FORMATS};
 
 /// A struct representing the information that should be present in a service-info response.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct ServiceInfo {
   pub id: String,
   pub name: String,
@@ -20,26 +21,22 @@ pub struct ServiceInfo {
   #[serde(rename = "type")]
   pub service_type: Type,
   pub htsget: Htsget,
-  // The next fields aren't in the HtsGet specification, but were added
-  // because they were present in the reference implementation and were deemed useful
-  #[serde(rename = "contactUrl")]
   pub contact_url: String,
-  #[serde(rename = "documentationUrl")]
   pub documentation_url: String,
-  #[serde(rename = "createdAt")]
   pub created_at: String,
-  #[serde(rename = "UpdatedAt")]
   pub updated_at: String,
   pub environment: String,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct Organisation {
   pub name: String,
   pub url: String,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct Type {
   pub group: String,
   pub artifact: String,
@@ -47,12 +44,11 @@ pub struct Type {
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct Htsget {
   pub datatype: String,
   pub formats: Vec<String>,
-  #[serde(rename = "fieldsParametersEffective")]
   pub fields_parameters_effective: bool,
-  #[serde(rename = "TagsParametersEffective")]
   pub tags_parameters_effective: bool,
 }
 

--- a/htsget-lambda/Cargo.toml
+++ b/htsget-lambda/Cargo.toml
@@ -31,7 +31,7 @@ tracing-subscriber = "0.3"
 bytes = "1.4"
 
 [dev-dependencies]
-htsget-test = { path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
+htsget-test = { version = "0.1.2", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
 async-trait = "0.1"
 query_map = { version = "0.6", features = ["url-query"] }
 tempfile = "3.3"

--- a/htsget-lambda/Cargo.toml
+++ b/htsget-lambda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-lambda"
-version = "0.1.2"
+version = "0.1.3"
 rust-version = "1.64"
 authors = ["Marko Malenic <mmalenic1@gmail.com>", "Roman Valls Guimera <brainstorm@nopcode.org>"]
 edition = "2021"
@@ -19,9 +19,9 @@ tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.3", features = ["cors"] }
 lambda_http = { version = "0.7" }
 lambda_runtime = { version = "0.7" }
-htsget-config = { version = "0.1.2", path = "../htsget-config", default-features = false }
-htsget-search = { version = "0.1.2", path = "../htsget-search", default-features = false }
-htsget-http = { version = "0.1.2", path = "../htsget-http", default-features = false }
+htsget-config = { version = "0.1.3", path = "../htsget-config", default-features = false }
+htsget-search = { version = "0.1.3", path = "../htsget-search", default-features = false }
+htsget-http = { version = "0.1.3", path = "../htsget-http", default-features = false }
 serde = { version = "1.0" }
 serde_json = "1.0"
 mime = "0.3"
@@ -31,7 +31,7 @@ tracing-subscriber = "0.3"
 bytes = "1.4"
 
 [dev-dependencies]
-htsget-test = { version = "0.1.2", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
+htsget-test = { version = "0.1.3", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
 async-trait = "0.1"
 query_map = { version = "0.6", features = ["url-query"] }
 tempfile = "3.3"

--- a/htsget-lambda/src/main.rs
+++ b/htsget-lambda/src/main.rs
@@ -8,8 +8,8 @@ use htsget_lambda::{handle_request, Router};
 async fn main() -> Result<(), Error> {
   Config::setup_tracing()?;
 
-  if let Some(config) = Config::parse_args() {
-    let config = Config::from_config(config)?;
+  if let Some(path) = Config::parse_args() {
+    let config = Config::from_path(&path)?;
 
     let service_info = config.ticket_server().service_info().clone();
     let cors = config.ticket_server().cors().clone();

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-search"
-version = "0.1.2"
+version = "0.1.3"
 rust-version = "1.64"
 authors = ["Christian Perez Llamas <chrispz@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>", "Roman Valls Guimera <brainstorm@nopcode.org>"]
 edition = "2021"
@@ -42,13 +42,13 @@ aws-config = { version = "0.54", optional = true }
 
 # Error control, tracing, config
 thiserror = "1.0"
-htsget-config = { version = "0.1.2", path = "../htsget-config", default-features = false }
+htsget-config = { version = "0.1.3", path = "../htsget-config", default-features = false }
 tracing = "0.1"
 base64 = "0.21"
 serde = "1.0"
 
 [dev-dependencies]
-htsget-test = { version = "0.1.2", path = "../htsget-test", features = ["cors-tests"], default-features = false }
+htsget-test = { version = "0.1.3", path = "../htsget-test", features = ["cors-tests"], default-features = false }
 tempfile = "3.3"
 data-url = "0.2"
 

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -20,7 +20,7 @@ hyper = "0.14"
 tower-http = { version = "0.3", features = ["trace", "cors"] }
 http = "0.2"
 axum = "0.6"
-axum-extra = { version = "0.4", features = ["spa"] }
+axum-extra = { version = "0.5", features = ["spa"] }
 rustls-pemfile = "1.0"
 tower = { version = "0.4", features = ["make"] }
 

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -48,7 +48,7 @@ base64 = "0.21"
 serde = "1.0"
 
 [dev-dependencies]
-htsget-test = { path = "../htsget-test", features = ["cors-tests"], default-features = false }
+htsget-test = { version = "0.1.2", path = "../htsget-test", features = ["cors-tests"], default-features = false }
 tempfile = "3.3"
 data-url = "0.2"
 

--- a/htsget-test/Cargo.toml
+++ b/htsget-test/Cargo.toml
@@ -9,7 +9,6 @@ description = "Common test functions and utilities used by htsget-rs"
 documentation = "https://github.com/umccr/htsget-rs/blob/main/htsget-test/README.md"
 homepage = "https://github.com/umccr/htsget-rs/blob/main/htsget-test/README.md"
 repository = "https://github.com/umccr/htsget-rs"
-publish = false
 
 [features]
 http-tests = [

--- a/htsget-test/Cargo.toml
+++ b/htsget-test/Cargo.toml
@@ -22,8 +22,6 @@ cors-tests = ["http-tests", "dep:htsget-config"]
 server-tests = [
     "http-tests",
     "dep:htsget-config",
-    "dep:htsget-search",
-    "dep:htsget-http",
     "dep:noodles-vcf",
     "dep:noodles-bgzf",
     "dep:reqwest",
@@ -32,14 +30,12 @@ server-tests = [
     "dep:mime",
     "dep:base64"
 ]
-s3-storage = ["htsget-config?/s3-storage", "htsget-search?/s3-storage", "htsget-http?/s3-storage"]
+s3-storage = ["htsget-config?/s3-storage"]
 default = ["s3-storage"]
 
 [dependencies]
 # Server tests dependencies
-htsget-http = { version = "0.1.2", path = "../htsget-http", default-features = false, optional = true }
 htsget-config = { version = "0.1.2", path = "../htsget-config", default-features = false, optional = true }
-htsget-search = { version = "0.1.2", path = "../htsget-search", default-features = false, optional = true }
 
 noodles-vcf = { version = "0.24", features = ["async"], optional = true }
 noodles-bgzf = { version = "0.19", features = ["async"], optional = true }
@@ -50,7 +46,7 @@ futures = { version = "0.3", optional = true }
 async-trait = { version = "0.1", optional = true }
 http = { version = "0.2", optional = true }
 mime = { version = "0.3", optional = true }
-serde_json = { version = "1.0", optional = true }
+serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
 serde = { version = "1.0", optional = true }
 base64 = { version = "0.21", optional = true }
 

--- a/htsget-test/Cargo.toml
+++ b/htsget-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-test"
-version = "0.1.2"
+version = "0.1.3"
 rust-version = "1.60"
 authors = ["Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"
@@ -34,7 +34,7 @@ default = ["s3-storage"]
 
 [dependencies]
 # Server tests dependencies
-htsget-config = { version = "0.1.2", path = "../htsget-config", default-features = false, optional = true }
+htsget-config = { version = "0.1.3", path = "../htsget-config", default-features = false, optional = true }
 
 noodles-vcf = { version = "0.24", features = ["async"], optional = true }
 noodles-bgzf = { version = "0.19", features = ["async"], optional = true }

--- a/htsget-test/src/http_tests.rs
+++ b/htsget-test/src/http_tests.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use async_trait::async_trait;
 use htsget_config::config::cors::{AllowType, CorsConfig};
-use htsget_config::config::{DataServerConfig, TicketServerConfig};
+use htsget_config::config::{CertificateKeyPair, DataServerConfig, TicketServerConfig};
 use htsget_config::regex_resolver::{LocalResolver, RegexResolver, Scheme, StorageType};
 use htsget_config::TaggedTypeAll;
 use http::uri::Authority;
@@ -106,7 +106,7 @@ pub fn default_test_resolver(addr: SocketAddr, scheme: Scheme) -> RegexResolver 
 pub fn default_config_fixed_port() -> Config {
   let addr = "127.0.0.1:8081".parse().unwrap();
 
-  default_test_config_params(addr, None, None, Scheme::Http)
+  default_test_config_params(addr, None, Scheme::Http)
 }
 
 fn get_dynamic_addr() -> SocketAddr {
@@ -128,8 +128,7 @@ pub fn default_cors_config() -> CorsConfig {
 
 fn default_test_config_params(
   addr: SocketAddr,
-  key: Option<PathBuf>,
-  cert: Option<PathBuf>,
+  tls: Option<CertificateKeyPair>,
   scheme: Scheme,
 ) -> Config {
   let cors = default_cors_config();
@@ -138,8 +137,7 @@ fn default_test_config_params(
     addr,
     default_dir_data(),
     PathBuf::from("/data"),
-    key,
-    cert,
+    tls,
     cors.clone(),
   );
 
@@ -154,7 +152,7 @@ fn default_test_config_params(
 pub fn default_test_config() -> Config {
   let addr = get_dynamic_addr();
 
-  default_test_config_params(addr, None, None, Scheme::Http)
+  default_test_config_params(addr, None, Scheme::Http)
 }
 
 /// Config with tls ticket server, using the current cargo manifest directory.
@@ -162,7 +160,11 @@ pub fn config_with_tls<P: AsRef<Path>>(path: P) -> Config {
   let addr = get_dynamic_addr();
   let (key_path, cert_path) = generate_test_certificates(path, "key.pem", "cert.pem");
 
-  default_test_config_params(addr, Some(key_path), Some(cert_path), Scheme::Https)
+  default_test_config_params(
+    addr,
+    Some(CertificateKeyPair::new(cert_path, key_path)),
+    Scheme::Https,
+  )
 }
 
 /// Get the event associated with the file.

--- a/htsget-test/src/server_tests.rs
+++ b/htsget-test/src/server_tests.rs
@@ -1,34 +1,39 @@
 use base64::engine::general_purpose;
 use base64::Engine;
-use std::collections::HashMap;
-use std::path::PathBuf;
+use std::fmt::Debug;
+use std::net::SocketAddr;
+use std::str::FromStr;
 
 use futures::future::join_all;
 use futures::TryStreamExt;
 use htsget_config::{Class, Format};
-use http::Method;
+use http::header::HeaderName;
+use http::{HeaderMap, HeaderValue, Method};
 use noodles_bgzf as bgzf;
 use noodles_vcf as vcf;
 use reqwest::ClientBuilder;
-
-use htsget_http::{get_service_info_with, Endpoint};
-use htsget_search::htsget::Response as HtsgetResponse;
-use htsget_search::htsget::{Headers, JsonResponse, Url};
-use htsget_search::storage::data_server::HttpTicketFormatter;
+use serde::Deserialize;
+use serde_json::{json, Value};
 
 use crate::http_tests::{Header, Response, TestRequest, TestServer};
 use crate::util::expected_bgzf_eof_data_url;
 use crate::Config;
 
 /// Test response with with class.
-pub async fn test_response(response: Response, class: Class) {
+pub async fn test_response<R>(response: Response, class: Class)
+where
+  R: for<'de> Deserialize<'de> + Eq + Debug,
+{
   println!("response: {response:?}");
   assert!(response.is_success());
-  let body = response.deserialize_body::<JsonResponse>().unwrap();
+  let body = response.deserialize_body::<R>().unwrap();
 
-  println!("{body:#?}");
+  // println!("{body:#?}");
   let expected_response = expected_response(class, response.expected_url_path);
-  assert_eq!(body, expected_response);
+  assert_eq!(
+    body,
+    serde_json::from_value(expected_response.clone()).unwrap()
+  );
 
   let client = ClientBuilder::new()
     .danger_accept_invalid_certs(true)
@@ -36,30 +41,51 @@ pub async fn test_response(response: Response, class: Class) {
     .build()
     .unwrap();
 
-  let merged_response = join_all(expected_response.htsget.urls.iter().map(|url| async {
-    if let Some(data_uri) = url.url.strip_prefix("data:;base64,") {
-      general_purpose::STANDARD.decode(data_uri).unwrap()
-    } else {
-      client
-        .get(&url.url)
-        .headers(
-          url
-            .headers
-            .as_ref()
-            .unwrap_or(&Headers::default())
-            .as_ref_inner()
-            .try_into()
-            .unwrap(),
-        )
-        .send()
-        .await
-        .unwrap()
-        .bytes()
-        .await
-        .unwrap()
-        .to_vec()
-    }
-  }))
+  let merged_response = join_all(
+    expected_response
+      .get("htsget")
+      .unwrap()
+      .get("urls")
+      .unwrap()
+      .as_array()
+      .unwrap()
+      .iter()
+      .map(|url| async {
+        if let Some(data_uri) = url
+          .get("url")
+          .unwrap()
+          .as_str()
+          .unwrap()
+          .strip_prefix("data:;base64,")
+        {
+          general_purpose::STANDARD.decode(data_uri).unwrap()
+        } else {
+          client
+            .get(url.get("url").unwrap().as_str().unwrap())
+            .headers(HeaderMap::from_iter(
+              url
+                .get("headers")
+                .unwrap()
+                .as_object()
+                .unwrap_or(&serde_json::Map::new())
+                .into_iter()
+                .map(|(key, value)| {
+                  (
+                    HeaderName::from_str(key).unwrap(),
+                    HeaderValue::from_str(value.as_str().unwrap()).unwrap(),
+                  )
+                }),
+            ))
+            .send()
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap()
+            .to_vec()
+        }
+      }),
+  )
   .await
   .into_iter()
   .reduce(|acc, x| [acc, x].concat())
@@ -76,46 +102,67 @@ pub async fn test_response(response: Response, class: Class) {
   }
 }
 
-/// Create the a [HttpTicketFormatter], spawn the ticket server, returning the expected path and the formatter.
-pub async fn formatter_and_expected_path(config: &Config) -> (String, HttpTicketFormatter) {
-  let mut formatter = formatter_from_config(config);
-  spawn_ticket_server(config.data_server().local_path().into(), &mut formatter).await;
-
-  (expected_url_path(&formatter), formatter)
-}
-
 /// Get the expected url path from the formatter.
-pub fn expected_url_path(formatter: &HttpTicketFormatter) -> String {
-  format!("{}://{}", formatter.get_scheme(), formatter.get_addr())
-}
-
-/// Spawn the [TicketServer] using the path and formatter.
-pub async fn spawn_ticket_server(path: PathBuf, formatter: &mut HttpTicketFormatter) {
-  let server = formatter.bind_data_server().await.unwrap();
-  tokio::spawn(async move { server.serve(path).await.unwrap() });
+pub fn expected_url_path(config: &Config, local_addr: SocketAddr) -> String {
+  let scheme = match config.data_server().tls() {
+    None => "http",
+    Some(_) => "https",
+  };
+  format!("{}://{}", scheme, local_addr)
 }
 
 /// Test response with with service info.
 pub fn test_response_service_info(response: &Response) {
-  let expected = get_service_info_with(
-    Endpoint::Variants,
-    &[Format::Vcf, Format::Bcf],
-    false,
-    false,
-  );
+  let expected = json!({
+    "id": "",
+    "name": "",
+    "version": "",
+    "organization": {
+      "name": "",
+      "url": "",
+    },
+    "type": {
+      "group": "",
+      "artifact": "",
+      "version": "",
+    },
+    "htsget": {
+      "datatype": "variants",
+      "formats": [
+        "VCF",
+        "BCF",
+      ],
+      "fieldsParametersEffective": false,
+      "tagsParametersEffective": false,
+    },
+    "contactUrl": "",
+    "documentationUrl": "",
+    "createdAt": "",
+    "updatedAt": "",
+    "environment": "",
+  });
+
+  println!("{:#?}", expected);
   assert!(response.is_success());
-  assert_eq!(expected, response.deserialize_body().unwrap());
+  assert_eq!(
+    expected,
+    response.deserialize_body::<Value>().unwrap()
+  );
 }
 
 /// A get test using the tester.
-pub async fn test_get<T: TestRequest>(tester: &impl TestServer<T>) {
+pub async fn test_get<R, T>(tester: &impl TestServer<T>)
+where
+  T: TestRequest,
+  R: for<'de> Deserialize<'de> + Eq + Debug,
+{
   let request = tester
     .get_request()
     .method(Method::GET.to_string())
     .uri("/variants/vcf/sample1-bcbio-cancer");
   let response = tester.test_server(request).await;
 
-  test_response(response, Class::Body).await;
+  test_response::<R>(response, Class::Body).await;
 }
 
 fn post_request<T: TestRequest>(tester: &impl TestServer<T>) -> T {
@@ -130,45 +177,56 @@ fn post_request<T: TestRequest>(tester: &impl TestServer<T>) -> T {
 }
 
 /// A post test using the tester.
-pub async fn test_post<T: TestRequest>(tester: &impl TestServer<T>) {
+pub async fn test_post<R, T>(tester: &impl TestServer<T>)
+where
+  T: TestRequest,
+  R: for<'de> Deserialize<'de> + Eq + Debug,
+{
   let request = post_request(tester).set_payload("{}");
   let response = tester.test_server(request).await;
 
-  test_response(response, Class::Body).await;
+  test_response::<R>(response, Class::Body).await;
 }
 
 /// A parameterized get test.
-pub async fn test_parameterized_get<T: TestRequest>(tester: &impl TestServer<T>) {
+pub async fn test_parameterized_get<R, T>(tester: &impl TestServer<T>)
+where
+  T: TestRequest,
+  R: for<'de> Deserialize<'de> + Eq + Debug,
+{
   let request = tester
     .get_request()
     .method(Method::GET.to_string())
     .uri("/variants/vcf/sample1-bcbio-cancer?format=VCF&class=header");
   let response = tester.test_server(request).await;
 
-  test_response(response, Class::Header).await;
+  test_response::<R>(response, Class::Header).await;
 }
 
 /// A parameterized post test.
-pub async fn test_parameterized_post<T: TestRequest>(tester: &impl TestServer<T>) {
+pub async fn test_parameterized_post<R, T>(tester: &impl TestServer<T>)
+where
+  T: TestRequest,
+  R: for<'de> Deserialize<'de> + Eq + Debug,
+{
   let request = post_request(tester)
     .set_payload("{\"format\": \"VCF\", \"regions\": [{\"referenceName\": \"chrM\"}]}");
   let response = tester.test_server(request).await;
 
-  test_response(response, Class::Body).await;
+  test_response::<R>(response, Class::Body).await;
 }
 
 /// A parameterized post test with header as the class.
-pub async fn test_parameterized_post_class_header<T: TestRequest>(tester: &impl TestServer<T>) {
+pub async fn test_parameterized_post_class_header<R, T>(tester: &impl TestServer<T>)
+where
+  T: TestRequest,
+  R: for<'de> Deserialize<'de> + Eq + Debug,
+{
   let request = post_request(tester).set_payload(
     "{\"format\": \"VCF\", \"class\": \"header\", \"regions\": [{\"referenceName\": \"chrM\"}]}",
   );
   let response = tester.test_server(request).await;
-  test_response(response, Class::Header).await;
-}
-
-/// Get the [HttpTicketFormatter] from the config.
-pub fn formatter_from_config(config: &Config) -> HttpTicketFormatter {
-  HttpTicketFormatter::try_from(config.data_server().clone()).unwrap()
+  test_response::<R>(response, Class::Header).await;
 }
 
 /// A service info test.
@@ -183,16 +241,32 @@ pub async fn test_service_info<T: TestRequest>(tester: &impl TestServer<T>) {
 }
 
 /// An example VCF search response.
-pub fn expected_response(class: Class, url_path: String) -> JsonResponse {
-  let mut headers = HashMap::new();
-  headers.insert("Range".to_string(), "bytes=0-3465".to_string());
+pub fn expected_response(class: Class, url_path: String) -> Value {
+  let url = format!("{url_path}/data/vcf/sample1-bcbio-cancer.vcf.gz");
+  let headers = vec!["Range", "bytes=0-3465"];
 
-  let http_url = Url::new(format!("{url_path}/data/vcf/sample1-bcbio-cancer.vcf.gz"))
-    .with_headers(Headers::new(headers));
   let urls = match class {
-    Class::Header => vec![http_url.with_class(Class::Header)],
-    Class::Body => vec![http_url, Url::new(expected_bgzf_eof_data_url())],
+    Class::Header => json!([{
+      "url": url,
+      "headers": {
+        headers[0]: headers[1]
+      },
+      "class": "header"
+    }]),
+    Class::Body => json!([{
+      "url": url,
+      "headers": {
+        headers[0]: headers[1]
+      },
+    }, {
+      "url": expected_bgzf_eof_data_url()
+    }]),
   };
 
-  JsonResponse::from(HtsgetResponse::new(Format::Vcf, urls))
+  json!({
+    "htsget": {
+      "format": Format::Vcf,
+      "urls": urls
+      }
+  })
 }

--- a/htsget-test/src/server_tests.rs
+++ b/htsget-test/src/server_tests.rs
@@ -144,10 +144,7 @@ pub fn test_response_service_info(response: &Response) {
 
   println!("{:#?}", expected);
   assert!(response.is_success());
-  assert_eq!(
-    expected,
-    response.deserialize_body::<Value>().unwrap()
-  );
+  assert_eq!(expected, response.deserialize_body::<Value>().unwrap());
 }
 
 /// A get test using the tester.


### PR DESCRIPTION
Closes #158 

This PR refactors `htsget-tests` to avoid a circular dependency with `htsget-search` and `htsget-http`.

### Implementation
* Use generic types in `http-tests` to avoid using the structs in `htsget-search` and `htsget-http`.
* Specify expected responses using `serde_json` [`Value`](https://docs.rs/serde_json/latest/serde_json/value/enum.Value.html). This also probably makes the tests more robust as they no longer dependent on the implementation of the `htsget-http` structs.
* Move `CertificateKeyPair` to config to avoid repeating the logic in `htsget-tests` and simplifying logic in `htsget-search`. This is a breaking change as it removes the `TryFrom<DataServerConfig> for HttpTicketFormatter` implementation. 