### PR TITLE
build: make htsget-test a regular dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,7 +1666,7 @@ dependencies = [
 
 [[package]]
 name = "htsget-actix"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "htsget-config"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "clap 4.1.6",
  "figment",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "htsget-http"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "futures",
  "htsget-config",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "htsget-lambda"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "htsget-search"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "htsget-test"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "base64 0.21.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,19 +292,20 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -555,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.54.2"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6831e34a636bb7a72758aae4cdf83c2f2163a2a1cddc0c4c87fbc012e3abb439"
+checksum = "00e8615bf58d144dec3fcdb5110941b84e904c68054cb74ed240b9588fc337a5"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -567,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.54.1"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55fe82d7463becdd632f8c6446cbdb2cbe34ad42a7d92c480d8fca08749d07a4"
+checksum = "9b614c060eed654410dd9dee81a74e05abf29b79f7bc04843a996a569555d769"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -588,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.54.1"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d44078855a64d757e5c1727df29ffa6679022c38cfc4ba4e63ee9567133141"
+checksum = "d8c1df4c1d03e1ce299ae4e24c19d0f4cd8bebceac60828530e579977d70289a"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -613,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.54.1"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "652a99272024770cbe33579dc0016914a09922b27f9a4d12f37472aacbbe71c1"
+checksum = "4a7813369d9f9cbdf46ba28559e0710e2f83e9cbd8edd4f79e47911627b05fa1"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -624,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.54.1"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bd86f48d7e36fb24ee922d04d79c8353e01724b1c38757ed92593179223aa7"
+checksum = "78abf16f8667b9176737cfffd1dd4ad07d350ef5dba01d01fdec5f31265f7134"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-types",
@@ -647,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.54.1"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8972d1b4ae3aba1a10e7106fed53a5a36bc8ef86170a84f6ddd33d36fac12ad"
+checksum = "d517ac2476efc1820228c2fdfdcb17d3bea8695558bd67584a62a47c12b41918"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -663,18 +664,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.54.1"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18973f12721e27b54891386497a57e1ba09975df1c6cfeccafaf541198962aef"
+checksum = "1a23cc091168c5d969b150d7cc11a5a202bfa88dc36494e6659d2499b0cf227b"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.54.1"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72e9ac0818d0016ced540ba0d06975299d27684ff514173b21c9976fd72062b"
+checksum = "51425d035725e1f029fb9ed76f190c939c99355a955308d3c5976578b5ffbbca"
 dependencies = [
  "assert-json-diff",
  "http",
@@ -687,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.54.1"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2881effde104a2b0619badaad9f30ae67805e86fbbdb99e5fcc176e8bfbc1a85"
+checksum = "92a1218021362bc1faa56648397b8cc4ac7631a3944e087d314d0187ef88d782"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -697,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.54.1"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7e499c4b15bab8eb6b234df31833cc83a1bdaa691ba72d5d81efc109d9d705"
+checksum = "ee8d2056dc5f10094d5e753ac5c649e8996869f0649b641e470950151596db73"
 dependencies = [
  "base64-simd 0.7.0",
  "itoa",
@@ -710,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types-convert"
-version = "0.54.1"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bbb74aa6624efd9c6d1a2c6e1740ea52d4ff57a3f1ab55c5e1f7015ebbe6298"
+checksum = "3802a968773fec834925ed95ccf45e6d2b382e5a72dcb87561704e904f81772e"
 dependencies = [
  "aws-smithy-types",
  "time",
@@ -720,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.54.1"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a73082f023f4a361fe811954da0061076709198792a3d2ad3a7498e10b606a0"
+checksum = "1a3029cbb4a49656456b3f2b34daee7f68dd93c61cc5d03fa90788cb1d25d5b4"
 dependencies = [
  "xmlparser",
 ]
@@ -763,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.4"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5694b64066a2459918d8074c2ce0d5a88f409431994c2356617c8ae0c4721fc"
+checksum = "2fb79c228270dcf2426e74864cabc94babb5dbab01a4314e702d2f16540e1591"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -1039,13 +1040,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
 dependencies = [
  "bitflags",
  "clap_derive",
- "clap_lex 0.3.1",
+ "clap_lex 0.3.2",
  "is-terminal",
  "once_cell",
  "strsim",
@@ -1076,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1256,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc831ee6a32dd495436e317595e639a587aa9907bef96fe6e6abc290ab6204e9"
+checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1268,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94331d54f1b1a8895cd81049f7eaaaef9d05a7dcb4d1fd08bf3ff0806246789d"
+checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1283,15 +1284,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dcd35ba14ca9b40d6e4b4b39961f23d835dbb8eed74565ded361d93e1feb8a"
+checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bbeb29798b407ccd82a3324ade1a7286e0d29851475990b612670f6f5124d2"
+checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1419,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -1634,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856b5cb0902c2b6d65d5fd97dfa30f9b70c7538e770b98eab5ed52d8db923e01"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -1665,7 +1666,7 @@ dependencies = [
 
 [[package]]
 name = "htsget-actix"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -1688,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "htsget-config"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
- "clap 4.1.4",
+ "clap 4.1.6",
  "figment",
  "http",
  "http-serde",
@@ -1699,14 +1700,14 @@ dependencies = [
  "serde",
  "serde_regex",
  "serde_with",
- "toml 0.7.1",
+ "toml 0.7.2",
  "tracing",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "htsget-http"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "futures",
  "htsget-config",
@@ -1721,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "htsget-lambda"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1745,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "htsget-search"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -1782,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "htsget-test"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "base64 0.21.0",
@@ -1801,9 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -1972,11 +1973,11 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
- "hermit-abi 0.3.0",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.45.0",
@@ -2286,14 +2287,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2304,15 +2305,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "nom8"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2547,9 +2539,9 @@ checksum = "cf70ee2d9b1737d1836c20d9f8f96ec3901b2bf92128439db13237ddce9173a5"
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -3082,9 +3074,9 @@ checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "s3s"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fe35088293918d4e58c662656d0d52651f91993dcafedd9d835632498c063f"
+checksum = "4020158a5c1250280240d327dc0d0f2b0ccf62a7938bbf245a1cd2637d64bcfe"
 dependencies = [
  "arrayvec",
  "ascii",
@@ -3108,6 +3100,7 @@ dependencies = [
  "quick-xml",
  "serde",
  "serde_urlencoded",
+ "sha1",
  "sha2",
  "smallvec",
  "thiserror",
@@ -3119,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "s3s-aws"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a1897e823c327c52fe74a11e211578e57546fe12080b752ee4c352a9bc5424"
+checksum = "e79f4605deb4310ac2dcdc7d4ba6a0fa50d0427deb157088522b912b7dcc964c"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -3139,9 +3132,9 @@ dependencies = [
 
 [[package]]
 name = "s3s-fs"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3b3d331b6fee5acd6b5971b0d445c9477df38596efad02cb4911b4f866560a"
+checksum = "b4000a09d36e9dfc997faf146c7e41243dbdb873344bac6d073235b5ed664dc7"
 dependencies = [
  "async-trait",
  "base64-simd 0.8.0",
@@ -3256,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7434af0dc1cbd59268aa98b4c22c131c0584d2232f6fb166efb993e2832e896a"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3367,9 +3360,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -3385,9 +3378,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -3434,9 +3427,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "d56e159d99e6c2b93995d171050271edb50ecc5288fbc7cc17de8fdce4e58c14"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3500,18 +3493,19 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
 dependencies = [
  "itoa",
  "serde",
@@ -3527,9 +3521,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
 dependencies = [
  "time-core",
 ]
@@ -3603,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3614,9 +3608,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3638,9 +3632,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772c1426ab886e7362aedf4abc9c0d1348a979517efedfc25862944d10137af0"
+checksum = "f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3659,15 +3653,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.2"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f35c303ea3e062b6131be4de16debe23860b9d3f2396658f13b7af1987fb473"
+checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
 dependencies = [
  "indexmap",
- "nom8",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4160,6 +4154,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
+name = "winnow"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efdd927d1a3d5d98abcfc4cf8627371862ee6abfe52a988050621c50c66b4493"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4215,9 +4218,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "6.0.3+zstd.1.5.2"
+version = "6.0.4+zstd.1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e4a3f57d13d0ab7e478665c60f35e2a613dcd527851c2c7287ce5c787e134a"
+checksum = "7afb4b54b8910cf5447638cb54bf4e8a65cbedd783af98b98c62ffe91f185543"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -4225,9 +4228,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.6+zstd.1.5.2"
+version = "2.0.7+zstd.1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a3f9792c0c3dc6c165840a75f47ae1f4da402c2d006881129579f6597e801b"
+checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
 dependencies = [
  "cc",
  "libc",

--- a/htsget-actix/Cargo.toml
+++ b/htsget-actix/Cargo.toml
@@ -23,6 +23,7 @@ futures-util = { version = "0.3" }
 htsget-http = { version = "0.1.3", path = "../htsget-http", default-features = false }
 htsget-search = { version = "0.1.3", path = "../htsget-search", default-features = false }
 htsget-config = { version = "0.1.3", path = "../htsget-config", default-features = false }
+htsget-test = { version = "0.1.3", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
 futures = { version = "0.3" }
 tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 
@@ -30,7 +31,6 @@ tracing-actix-web = "0.7"
 tracing = "0.1"
 
 [dev-dependencies]
-htsget-test = { version = "0.1.3", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
 async-trait = "0.1"
 
 criterion = { version = "0.4", features = ["async_tokio"] }

--- a/htsget-actix/Cargo.toml
+++ b/htsget-actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-actix"
-version = "0.1.3"
+version = "0.1.4"
 rust-version = "1.64"
 authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"
@@ -20,10 +20,10 @@ actix-cors = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 futures-util = { version = "0.3" }
-htsget-http = { version = "0.1.3", path = "../htsget-http", default-features = false }
-htsget-search = { version = "0.1.3", path = "../htsget-search", default-features = false }
-htsget-config = { version = "0.1.3", path = "../htsget-config", default-features = false }
-htsget-test = { version = "0.1.3", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
+htsget-http = { version = "0.1.4", path = "../htsget-http", default-features = false }
+htsget-search = { version = "0.1.4", path = "../htsget-search", default-features = false }
+htsget-config = { version = "0.1.4", path = "../htsget-config", default-features = false }
+htsget-test = { version = "0.1.4", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
 futures = { version = "0.3" }
 tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 

--- a/htsget-config/Cargo.toml
+++ b/htsget-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-config"
-version = "0.1.3"
+version = "0.1.4"
 rust-version = "1.64"
 authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"

--- a/htsget-http/Cargo.toml
+++ b/htsget-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-http"
-version = "0.1.3"
+version = "0.1.4"
 rust-version = "1.64"
 authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"
@@ -18,9 +18,9 @@ default = ["s3-storage"]
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 http = "0.2"
-htsget-search = { version = "0.1.3", path = "../htsget-search", default-features = false }
-htsget-config = { version = "0.1.3", path = "../htsget-config", default-features = false }
-htsget-test = { version = "0.1.3", path = "../htsget-test", default-features = false }
+htsget-search = { version = "0.1.4", path = "../htsget-search", default-features = false }
+htsget-config = { version = "0.1.4", path = "../htsget-config", default-features = false }
+htsget-test = { version = "0.1.4", path = "../htsget-test", default-features = false }
 futures = { version = "0.3" }
 tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"

--- a/htsget-http/Cargo.toml
+++ b/htsget-http/Cargo.toml
@@ -20,9 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 http = "0.2"
 htsget-search = { version = "0.1.3", path = "../htsget-search", default-features = false }
 htsget-config = { version = "0.1.3", path = "../htsget-config", default-features = false }
+htsget-test = { version = "0.1.3", path = "../htsget-test", default-features = false }
 futures = { version = "0.3" }
 tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
-
-[dev-dependencies]
-htsget-test = { version = "0.1.3", path = "../htsget-test", default-features = false }

--- a/htsget-lambda/Cargo.toml
+++ b/htsget-lambda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-lambda"
-version = "0.1.3"
+version = "0.1.4"
 rust-version = "1.64"
 authors = ["Marko Malenic <mmalenic1@gmail.com>", "Roman Valls Guimera <brainstorm@nopcode.org>"]
 edition = "2021"
@@ -19,10 +19,10 @@ tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.3", features = ["cors"] }
 lambda_http = { version = "0.7" }
 lambda_runtime = { version = "0.7" }
-htsget-config = { version = "0.1.3", path = "../htsget-config", default-features = false }
-htsget-search = { version = "0.1.3", path = "../htsget-search", default-features = false }
-htsget-http = { version = "0.1.3", path = "../htsget-http", default-features = false }
-htsget-test = { version = "0.1.3", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
+htsget-config = { version = "0.1.4", path = "../htsget-config", default-features = false }
+htsget-search = { version = "0.1.4", path = "../htsget-search", default-features = false }
+htsget-http = { version = "0.1.4", path = "../htsget-http", default-features = false }
+htsget-test = { version = "0.1.4", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
 serde = { version = "1.0" }
 serde_json = "1.0"
 mime = "0.3"

--- a/htsget-lambda/Cargo.toml
+++ b/htsget-lambda/Cargo.toml
@@ -22,6 +22,7 @@ lambda_runtime = { version = "0.7" }
 htsget-config = { version = "0.1.3", path = "../htsget-config", default-features = false }
 htsget-search = { version = "0.1.3", path = "../htsget-search", default-features = false }
 htsget-http = { version = "0.1.3", path = "../htsget-http", default-features = false }
+htsget-test = { version = "0.1.3", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
 serde = { version = "1.0" }
 serde_json = "1.0"
 mime = "0.3"
@@ -31,7 +32,6 @@ tracing-subscriber = "0.3"
 bytes = "1.4"
 
 [dev-dependencies]
-htsget-test = { version = "0.1.3", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
 async-trait = "0.1"
 query_map = { version = "0.6", features = ["url-query"] }
 tempfile = "3.3"

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-search"
-version = "0.1.3"
+version = "0.1.4"
 rust-version = "1.64"
 authors = ["Christian Perez Llamas <chrispz@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>", "Roman Valls Guimera <brainstorm@nopcode.org>"]
 edition = "2021"
@@ -42,8 +42,8 @@ aws-config = { version = "0.54", optional = true }
 
 # Error control, tracing, config
 thiserror = "1.0"
-htsget-config = { version = "0.1.3", path = "../htsget-config", default-features = false }
-htsget-test = { version = "0.1.3", path = "../htsget-test", features = ["cors-tests"], default-features = false }
+htsget-config = { version = "0.1.4", path = "../htsget-config", default-features = false }
+htsget-test = { version = "0.1.4", path = "../htsget-test", features = ["cors-tests"], default-features = false }
 tracing = "0.1"
 base64 = "0.21"
 serde = "1.0"

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -43,12 +43,12 @@ aws-config = { version = "0.54", optional = true }
 # Error control, tracing, config
 thiserror = "1.0"
 htsget-config = { version = "0.1.3", path = "../htsget-config", default-features = false }
+htsget-test = { version = "0.1.3", path = "../htsget-test", features = ["cors-tests"], default-features = false }
 tracing = "0.1"
 base64 = "0.21"
 serde = "1.0"
 
 [dev-dependencies]
-htsget-test = { version = "0.1.3", path = "../htsget-test", features = ["cors-tests"], default-features = false }
 tempfile = "3.3"
 data-url = "0.2"
 

--- a/htsget-test/Cargo.toml
+++ b/htsget-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-test"
-version = "0.1.3"
+version = "0.1.4"
 rust-version = "1.60"
 authors = ["Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"
@@ -34,7 +34,7 @@ default = ["s3-storage"]
 
 [dependencies]
 # Server tests dependencies
-htsget-config = { version = "0.1.3", path = "../htsget-config", default-features = false, optional = true }
+htsget-config = { version = "0.1.4", path = "../htsget-config", default-features = false, optional = true }
 
 noodles-vcf = { version = "0.24", features = ["async"], optional = true }
 noodles-bgzf = { version = "0.19", features = ["async"], optional = true }


### PR DESCRIPTION
Makes htsget-test a regular dependency rather than a dev-dependency to address issues in publishing crates.