### PR TITLE
fix(search): add fs feature to tower-http dependency

### DIFF
--- a/htsget-actix/Cargo.toml
+++ b/htsget-actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-actix"
-version = "0.3.0"
+version = "0.4.0"
 rust-version = "1.64"
 authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"
@@ -24,10 +24,10 @@ rustls-pemfile = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 futures-util = { version = "0.3" }
-htsget-http = { version = "0.3.0", path = "../htsget-http", default-features = false }
-htsget-search = { version = "0.3.0", path = "../htsget-search", default-features = false }
-htsget-config = { version = "0.3.0", path = "../htsget-config", default-features = false }
-htsget-test = { version = "0.3.0", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
+htsget-http = { version = "0.4.0", path = "../htsget-http", default-features = false }
+htsget-search = { version = "0.4.0", path = "../htsget-search", default-features = false }
+htsget-config = { version = "0.4.0", path = "../htsget-config", default-features = false }
+htsget-test = { version = "0.4.0", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
 futures = { version = "0.3" }
 tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 

--- a/htsget-config/Cargo.toml
+++ b/htsget-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-config"
-version = "0.3.0"
+version = "0.4.0"
 rust-version = "1.64"
 authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"

--- a/htsget-http/Cargo.toml
+++ b/htsget-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-http"
-version = "0.3.0"
+version = "0.4.0"
 rust-version = "1.64"
 authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"
@@ -19,9 +19,9 @@ default = []
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 http = "0.2"
-htsget-search = { version = "0.3.0", path = "../htsget-search", default-features = false }
-htsget-config = { version = "0.3.0", path = "../htsget-config", default-features = false }
-htsget-test = { version = "0.3.0", path = "../htsget-test", default-features = false }
+htsget-search = { version = "0.4.0", path = "../htsget-search", default-features = false }
+htsget-config = { version = "0.4.0", path = "../htsget-config", default-features = false }
+htsget-test = { version = "0.4.0", path = "../htsget-test", default-features = false }
 futures = { version = "0.3" }
 tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"

--- a/htsget-lambda/Cargo.toml
+++ b/htsget-lambda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-lambda"
-version = "0.3.0"
+version = "0.4.0"
 rust-version = "1.64"
 authors = ["Marko Malenic <mmalenic1@gmail.com>", "Roman Valls Guimera <brainstorm@nopcode.org>"]
 edition = "2021"
@@ -20,10 +20,10 @@ tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.3", features = ["cors"] }
 lambda_http = { version = "0.7" }
 lambda_runtime = { version = "0.7" }
-htsget-config = { version = "0.3.0", path = "../htsget-config", default-features = false }
-htsget-search = { version = "0.3.0", path = "../htsget-search", default-features = false }
-htsget-http = { version = "0.3.0", path = "../htsget-http", default-features = false }
-htsget-test = { version = "0.3.0", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
+htsget-config = { version = "0.4.0", path = "../htsget-config", default-features = false }
+htsget-search = { version = "0.4.0", path = "../htsget-search", default-features = false }
+htsget-http = { version = "0.4.0", path = "../htsget-http", default-features = false }
+htsget-test = { version = "0.4.0", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
 serde = { version = "1.0" }
 serde_json = "1.0"
 mime = "0.3"

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 # Axum server
 url = "2.3"
 hyper = "0.14"
-tower-http = { version = "0.4", features = ["trace", "cors"] }
+tower-http = { version = "0.4", features = ["trace", "cors", "fs"] }
 http = "0.2"
 axum = "0.6"
 axum-extra = "0.7"
@@ -65,7 +65,6 @@ s3s-fs = { version = "0.5" }
 s3s-aws = { version = "0.5" }
 
 # Axum server
-tower-http = { version = "0.4.0", features = ["fs"] }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 
 criterion = { version = "0.4", features = ["async_tokio"] }

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-search"
-version = "0.3.0"
+version = "0.4.0"
 rust-version = "1.64"
 authors = ["Christian Perez Llamas <chrispz@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>", "Roman Valls Guimera <brainstorm@nopcode.org>"]
 edition = "2021"
@@ -48,8 +48,8 @@ reqwest = { version = "0.11", default-features = false, optional = true, feature
 
 # Error control, tracing, config
 thiserror = "1.0"
-htsget-config = { version = "0.3.0", path = "../htsget-config", default-features = false }
-htsget-test = { version = "0.3.0", path = "../htsget-test", features = ["cors-tests"], default-features = false }
+htsget-config = { version = "0.4.0", path = "../htsget-config", default-features = false }
+htsget-test = { version = "0.4.0", path = "../htsget-test", features = ["cors-tests"], default-features = false }
 tracing = "0.1"
 base64 = "0.21"
 serde = "1.0"

--- a/htsget-test/Cargo.toml
+++ b/htsget-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htsget-test"
-version = "0.3.0"
+version = "0.4.0"
 rust-version = "1.60"
 authors = ["Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"
@@ -35,7 +35,7 @@ default = []
 
 [dependencies]
 # Server tests dependencies
-htsget-config = { version = "0.3.0", path = "../htsget-config", default-features = false, optional = true }
+htsget-config = { version = "0.4.0", path = "../htsget-config", default-features = false, optional = true }
 
 noodles-vcf = { version = "0.24", features = ["async"], optional = true }
 noodles-bgzf = { version = "0.19", features = ["async"], optional = true }


### PR DESCRIPTION
### Changes
* Fixes `tower-http` not having the `fs` feature flag in `htsget-search`, which caused a build error.