### PR TITLE
refactor: dependencies

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -30,17 +30,7 @@ jobs:
             override: true
             components: rustfmt, clippy
       - name: Cargo cache
-        uses: actions/cache@v3
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-cache3-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-cargo-cache3-
+        uses: Swatinem/rust-cache@v2
       - name: Install cargo-criterion
         uses: baptiste0928/cargo-install@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,9 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: ${{ matrix.rust }}
+            # Todo: remove this when clippy introduces https://github.com/rust-lang/rust-clippy/pull/10865 in nightly or stable.
+            toolchain: 1.69
+            # toolchain: ${{ matrix.rust }}
             override: true
             components: rustfmt, clippy
       - name: Cargo cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,16 @@ jobs:
         with:
           command: build
           args: --all-targets --no-default-features
+      - name: Build s3-storage
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-targets --features s3-storage
+      - name: Build url-storage
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-targets --features url-storage
       - name: Clippy
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,17 +25,7 @@ jobs:
             override: true
             components: rustfmt, clippy
       - name: Cargo cache
-        uses: actions/cache@v3
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-cache3-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-cargo-cache3-
+        uses: Swatinem/rust-cache@v2
       - name: Cargo fmt
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
  "futures-core",
  "log",
  "pin-project-lite",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-util",
  "webpki-roots",
 ]
@@ -683,7 +683,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "lazy_static",
  "pin-project-lite",
  "rustls 0.20.8",
@@ -1811,6 +1811,7 @@ dependencies = [
  "htsget-test",
  "http",
  "hyper",
+ "hyper-rustls 0.24.0",
  "mockito",
  "noodles",
  "reqwest",
@@ -1822,7 +1823,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -1934,7 +1935,22 @@ dependencies = [
  "rustls 0.20.8",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+dependencies = [
+ "http",
+ "hyper",
+ "log",
+ "rustls 0.21.1",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.24.0",
 ]
 
 [[package]]
@@ -2985,7 +3001,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "ipnet",
  "js-sys",
  "log",
@@ -2999,13 +3015,11 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
- "tokio-util",
+ "tokio-rustls 0.23.4",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -3648,6 +3662,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls 0.21.1",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4081,19 +4105,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
-
-[[package]]
-name = "wasm-streams"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,7 +1749,6 @@ dependencies = [
  "toml 0.7.3",
  "tracing",
  "tracing-subscriber",
- "url",
 ]
 
 [[package]]
@@ -3972,7 +3971,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,28 +877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-extra"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "febf23ab04509bd7672e6abe76bd8277af31b679e89fa5ffc6087dc289a448a3"
-dependencies = [
- "axum",
- "axum-core",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "mime",
- "pin-project-lite",
- "serde",
- "tokio",
- "tower",
- "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "data-url"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5"
+checksum = "41b319d1b62ffbd002e057f36bebd1f42b9f97927c9577461d855f3513c4289f"
 
 [[package]]
 name = "derive_more"
@@ -1719,7 +1697,6 @@ dependencies = [
  "http",
  "noodles",
  "reqwest",
- "rustls 0.21.1",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -1799,7 +1776,6 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-s3",
  "axum",
- "axum-extra",
  "base64 0.21.0",
  "bytes",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,12 +348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
-name = "ascii"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,19 +355,6 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "async-compression"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
-dependencies = [
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -483,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb57ac6088805821f78d282c0ba8aec809f11cbee10dda19a97b03ab040ccc2"
+checksum = "1fcdb2f7acbc076ff5ad05e7864bdb191ca70a6fd07668dc3a1a8bcd051de5ae"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -497,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "aws-endpoint"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5f6f84a4f46f95a9bb71d9300b73cd67eb868bc43ae84f66ad34752299f4ac"
+checksum = "8cce1c41a6cfaa726adee9ebb9a56fcd2bbfd8be49fd8a04c5e20fd968330b04"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -511,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a754683c322f7dc5167484266489fdebdcd04d26e53c162cad1f3f949f2c5671"
+checksum = "aadbc44e7a8f3e71c8b374e03ecd972869eb91dd2bc89ed018954a52ba84bc44"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -530,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c77060408d653d3efa6ea7b66c1389bc35a0342352984c8bf8bcb814a8fc27"
+checksum = "fba197193cbb4bcb6aad8d99796b2291f36fa89562ded5d4501363055b0de89f"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -614,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84dc92a63ede3c2cbe43529cb87ffa58763520c96c6a46ca1ced80417afba845"
+checksum = "3b94acb10af0c879ecd5c7bdf51cda6679a0a4f4643ce630905a77673bfa3c61"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -629,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392fefab9d6fcbd76d518eb3b1c040b84728ab50f58df0c3c53ada4bea9d327e"
+checksum = "9d2ce6f507be68e968a33485ced670111d1cbad161ddbbab1e313c03d37d8f4c"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http",
@@ -650,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae23b9fe7a07d0919000116c4c5c0578303fbce6fc8d32efca1f7759d4c20faf"
+checksum = "13bda3996044c202d75b91afeb11a9afae9db9a721c6a7a427410018e286b880"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -662,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6367acbd6849b8c7c659e166955531274ae147bf83ab4312885991f6b6706cb"
+checksum = "07ed8b96d95402f3f6b8b57eb4e0e45ee365f78b1a924faf20ff6e97abf1eae6"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -683,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5230d25d244a51339273b8870f0f77874cd4449fb4f8f629b21188ae10cfc0ba"
+checksum = "0a86aa6e21e86c4252ad6a0e3e74da9617295d8d6e374d552be7d3059c41cedd"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -707,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22d2a2bcc16e5c4d949ffd2b851da852b9bbed4bb364ed4ae371b42137ca06d9"
+checksum = "460c8da5110835e3d9a717c61f5556b20d03c32a1dec57f8fc559b360f733bb8"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -718,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60e2133beb9fe6ffe0b70deca57aaeff0a35ad24a9c6fab2fd3b4f45b99fdb5"
+checksum = "2b3b693869133551f135e1f2c77cb0b8277d9e3e17feaf2213f735857c4f0d28"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-types",
@@ -741,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4d94f556c86a0dd916a5d7c39747157ea8cb909ca469703e20fee33e448b67"
+checksum = "3ae4f6c5798a247fac98a867698197d9ac22643596dc3777f0c76b91917616b9"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -757,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3d6e6ebb00b2cce379f079ad5ec508f9bcc3a9510d9b9c1840ed1d6f8af39"
+checksum = "23f9f42fbfa96d095194a632fbac19f60077748eba536eb0b9fecc28659807f8"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -776,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58db46fc1f4f26be01ebdb821751b4e2482cd43aa2b64a0348fb89762defaffa"
+checksum = "16a3d0bf4f324f4ef9793b86a1701d9700fbcdbd12a846da45eed104c634c6e8"
 dependencies = [
  "base64-simd",
  "itoa",
@@ -789,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types-convert"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641f27a35715504a92eb27e27b1cd0f4f864ec4c441c48922911aa10affa5e2b"
+checksum = "08d826bceaef81b3a8435f99b5da0e7e9ad3379bc91c8893e87cd3daa63c4423"
 dependencies = [
  "aws-smithy-types",
  "time",
@@ -799,18 +786,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb557fe4995bd9ec87fb244bbb254666a971dc902a783e9da8b7711610e9664c"
+checksum = "b1b9d12875731bd07e767be7baad95700c3137b56730ec9ddeedb52a5e5ca63b"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0869598bfe46ec44ffe17e063ed33336e59df90356ca8ff0e8da6f7c1d994b"
+checksum = "6dd209616cc8d7bfb82f87811a5c655dc97537f592689b18743bddf5dc5c4829"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -906,7 +893,7 @@ dependencies = [
  "serde",
  "tokio",
  "tower",
- "tower-http 0.4.0",
+ "tower-http",
  "tower-layer",
  "tower-service",
 ]
@@ -1065,12 +1052,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
- "num-integer",
  "num-traits",
  "serde",
  "winapi",
@@ -1105,21 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "bitflags 1.3.2",
- "clap_lex 0.2.4",
- "indexmap",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
-version = "4.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+checksum = "b4ed2379f8603fa2b7509891660e802b88c70a79a6427a70abb5968054de2c28"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1128,23 +1103,23 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.7"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
 dependencies = [
  "anstream",
  "anstyle",
  "bitflags 1.3.2",
- "clap_lex 0.4.1",
+ "clap_lex",
  "once_cell",
  "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "59e9ef9a08ee1c0e1f2e162121665ac45ac3783b0f897db7244ae75ad9a8f65b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1154,18 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "codespan-reporting"
@@ -1256,20 +1222,20 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
  "anes",
- "atty",
  "cast",
  "ciborium",
- "clap 3.2.25",
+ "clap",
  "criterion-plot",
  "futures",
+ "is-terminal",
  "itertools",
- "lazy_static",
  "num-traits",
+ "once_cell",
  "oorandom",
  "plotters",
  "rayon",
@@ -1751,8 +1717,7 @@ dependencies = [
  "htsget-search",
  "htsget-test",
  "http",
- "noodles 0.34.0",
- "noodles 0.40.0",
+ "noodles",
  "reqwest",
  "rustls 0.21.1",
  "rustls-pemfile",
@@ -1769,11 +1734,11 @@ name = "htsget-config"
 version = "0.5.0"
 dependencies = [
  "async-trait",
- "clap 4.2.7",
+ "clap",
  "figment",
  "http",
  "http-serde",
- "noodles 0.40.0",
+ "noodles",
  "regex",
  "serde",
  "serde_json",
@@ -1821,7 +1786,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "tower-http 0.3.5",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1847,7 +1812,7 @@ dependencies = [
  "http",
  "hyper",
  "mockito",
- "noodles 0.40.0",
+ "noodles",
  "reqwest",
  "rustls-pemfile",
  "s3s",
@@ -1860,7 +1825,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http 0.4.0",
+ "tower-http",
  "tracing",
  "url",
 ]
@@ -1875,7 +1840,7 @@ dependencies = [
  "htsget-config",
  "http",
  "mime",
- "noodles 0.40.0",
+ "noodles",
  "rcgen",
  "reqwest",
  "serde",
@@ -2102,14 +2067,15 @@ dependencies = [
 
 [[package]]
 name = "lambda_http"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16fd842ce9fc6908f1688030cf8b6841e2009bd874eb21244f124570ac06264f"
+checksum = "b2f580d0cf5364705314779cded5f8a4a9c856b104361ce18254e05969793933"
 dependencies = [
  "aws_lambda_events",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
+ "futures",
  "http",
  "http-body",
  "hyper",
@@ -2124,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd32d5799db2155ae4d47116bb3e169b59f531ced4d5762a10c2125bdd2bf134"
+checksum = "124a7d502e26b1ae9645bafd964d299d9c0d882cc8b3e228604d02bf0e13fc87"
 dependencies = [
  "async-stream",
  "bytes",
@@ -2144,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime_api_client"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7210012be904051520f0dc502140ba599bae3042b65b3737b87727f1aa88a7d6"
+checksum = "690c5ae01f3acac8c9c3348b556fc443054e9b7f1deaf53e9ebab716282bf0ed"
 dependencies = [
  "http",
  "hyper",
@@ -2413,58 +2379,21 @@ dependencies = [
 
 [[package]]
 name = "noodles"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a338361a01ec3ba68f4ebb5a1594444ba126478798d024d6fe8de35db108a5"
-dependencies = [
- "noodles-bam 0.28.0",
- "noodles-bcf 0.22.0",
- "noodles-bgzf 0.20.0",
- "noodles-core",
- "noodles-cram 0.25.0",
- "noodles-csi 0.14.0",
- "noodles-fasta 0.20.0",
- "noodles-fastq 0.6.0",
- "noodles-sam 0.25.0",
- "noodles-tabix 0.17.0",
- "noodles-vcf 0.26.0",
-]
-
-[[package]]
-name = "noodles"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc887b6b9f871fe07e545828e7400e547ad84ae8c3cef9a66cf63841dcea79f9"
 dependencies = [
- "noodles-bam 0.34.0",
- "noodles-bcf 0.28.0",
- "noodles-bgzf 0.22.0",
+ "noodles-bam",
+ "noodles-bcf",
+ "noodles-bgzf",
  "noodles-core",
- "noodles-cram 0.31.0",
- "noodles-csi 0.19.0",
- "noodles-fasta 0.23.0",
- "noodles-fastq 0.8.0",
- "noodles-sam 0.31.0",
- "noodles-tabix 0.22.0",
- "noodles-vcf 0.31.0",
-]
-
-[[package]]
-name = "noodles-bam"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b100df8df462cf3197ce770c241614e68799ee3b557f85bd11779225bd27896"
-dependencies = [
- "bit-vec",
- "byteorder",
- "bytes",
- "futures",
- "noodles-bgzf 0.20.0",
- "noodles-core",
- "noodles-csi 0.14.0",
- "noodles-fasta 0.20.0",
- "noodles-sam 0.25.0",
- "tokio",
+ "noodles-cram",
+ "noodles-csi",
+ "noodles-fasta",
+ "noodles-fastq",
+ "noodles-sam",
+ "noodles-tabix",
+ "noodles-vcf",
 ]
 
 [[package]]
@@ -2477,27 +2406,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "futures",
- "noodles-bgzf 0.22.0",
+ "noodles-bgzf",
  "noodles-core",
- "noodles-csi 0.19.0",
- "noodles-fasta 0.23.0",
- "noodles-sam 0.31.0",
- "tokio",
-]
-
-[[package]]
-name = "noodles-bcf"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1984f2b1c676c2652ff03e9002f50774be35fbbcd29ffee337f1e372db047a2"
-dependencies = [
- "byteorder",
- "futures",
- "indexmap",
- "noodles-bgzf 0.20.0",
- "noodles-core",
- "noodles-csi 0.14.0",
- "noodles-vcf 0.26.0",
+ "noodles-csi",
+ "noodles-fasta",
+ "noodles-sam",
  "tokio",
 ]
 
@@ -2510,27 +2423,11 @@ dependencies = [
  "byteorder",
  "futures",
  "indexmap",
- "noodles-bgzf 0.22.0",
+ "noodles-bgzf",
  "noodles-core",
- "noodles-csi 0.19.0",
- "noodles-vcf 0.31.0",
+ "noodles-csi",
+ "noodles-vcf",
  "tokio",
-]
-
-[[package]]
-name = "noodles-bgzf"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bff155a5362c61d9b977648d874aa84aea88f7de032e43df908c7cd26b22b6d"
-dependencies = [
- "byteorder",
- "bytes",
- "crossbeam-channel",
- "flate2",
- "futures",
- "pin-project-lite",
- "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -2557,34 +2454,11 @@ checksum = "72f9ab09e13392e71797e7502109575d2aae5cb2002bd2304647f7746215c2fe"
 
 [[package]]
 name = "noodles-cram"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2259b516050b54a980bff6f6dd0fc4690699e5fda3f792db603222e81e1f60b6"
-dependencies = [
- "async-compression 0.3.15",
- "bitflags 1.3.2",
- "byteorder",
- "bytes",
- "bzip2",
- "flate2",
- "futures",
- "md-5",
- "noodles-bam 0.28.0",
- "noodles-core",
- "noodles-fasta 0.20.0",
- "noodles-sam 0.25.0",
- "pin-project-lite",
- "tokio",
- "xz2",
-]
-
-[[package]]
-name = "noodles-cram"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ad9e48f976e3589764f382a399b1fd4ae637356e4013f70c721e830d7456d3"
 dependencies = [
- "async-compression 0.4.0",
+ "async-compression",
  "bitflags 2.3.1",
  "byteorder",
  "bytes",
@@ -2592,26 +2466,13 @@ dependencies = [
  "flate2",
  "futures",
  "md-5",
- "noodles-bam 0.34.0",
+ "noodles-bam",
  "noodles-core",
- "noodles-fasta 0.23.0",
- "noodles-sam 0.31.0",
+ "noodles-fasta",
+ "noodles-sam",
  "pin-project-lite",
  "tokio",
  "xz2",
-]
-
-[[package]]
-name = "noodles-csi"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201d5278cb875d3b4a8e338a21fa5b43f6dd56547447006dbad4638e6c952e"
-dependencies = [
- "bit-vec",
- "byteorder",
- "noodles-bgzf 0.20.0",
- "noodles-core",
- "tokio",
 ]
 
 [[package]]
@@ -2623,20 +2484,7 @@ dependencies = [
  "bit-vec",
  "byteorder",
  "indexmap",
- "noodles-bgzf 0.22.0",
- "noodles-core",
- "tokio",
-]
-
-[[package]]
-name = "noodles-fasta"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cbcf02af0f440981cef550db3e078b588591e68abd791ab0767c599945b4b93"
-dependencies = [
- "bytes",
- "memchr",
- "noodles-bgzf 0.20.0",
+ "noodles-bgzf",
  "noodles-core",
  "tokio",
 ]
@@ -2649,18 +2497,8 @@ checksum = "642d6f9e977a202d7efee2ee061944af786f5bced0eec977321f5b16bade80ca"
 dependencies = [
  "bytes",
  "memchr",
- "noodles-bgzf 0.22.0",
+ "noodles-bgzf",
  "noodles-core",
- "tokio",
-]
-
-[[package]]
-name = "noodles-fastq"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c7d065ab7c0814ea9df05624a1be1410d2039b091213ac1cb5281866c3fdfb"
-dependencies = [
- "futures",
  "tokio",
 ]
 
@@ -2677,24 +2515,6 @@ dependencies = [
 
 [[package]]
 name = "noodles-sam"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca67089a8f2bedf0bfcce06758cde48fe8fc04d2a33b02aa445cdc05c798051f"
-dependencies = [
- "bitflags 1.3.2",
- "futures",
- "indexmap",
- "lexical-core",
- "memchr",
- "noodles-bgzf 0.20.0",
- "noodles-core",
- "noodles-csi 0.14.0",
- "noodles-fasta 0.20.0",
- "tokio",
-]
-
-[[package]]
-name = "noodles-sam"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaa33250687c537cc88ae573f264ea9b3352770209134cfa1f047c05c352e724"
@@ -2704,25 +2524,10 @@ dependencies = [
  "indexmap",
  "lexical-core",
  "memchr",
- "noodles-bgzf 0.22.0",
+ "noodles-bgzf",
  "noodles-core",
- "noodles-csi 0.19.0",
- "noodles-fasta 0.23.0",
- "tokio",
-]
-
-[[package]]
-name = "noodles-tabix"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b4c6ad670431f0d3981080621f6e64037280916bf1638c373a1b941449e4ba"
-dependencies = [
- "bit-vec",
- "byteorder",
- "indexmap",
- "noodles-bgzf 0.20.0",
- "noodles-core",
- "noodles-csi 0.14.0",
+ "noodles-csi",
+ "noodles-fasta",
  "tokio",
 ]
 
@@ -2734,27 +2539,9 @@ checksum = "a775d5b16637bbfa0d6bd2a1ff06d4eba409235a5ca9df727a060b785c0f28c5"
 dependencies = [
  "bit-vec",
  "byteorder",
- "noodles-bgzf 0.22.0",
+ "noodles-bgzf",
  "noodles-core",
- "noodles-csi 0.19.0",
- "tokio",
-]
-
-[[package]]
-name = "noodles-vcf"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa196d6d6ad22277390e2cc588d6999a00fd73bd1ca4a5f68e8fda710c8e8364"
-dependencies = [
- "futures",
- "indexmap",
- "memchr",
- "nom",
- "noodles-bgzf 0.20.0",
- "noodles-core",
- "noodles-csi 0.14.0",
- "noodles-tabix 0.17.0",
- "percent-encoding",
+ "noodles-csi",
  "tokio",
 ]
 
@@ -2768,10 +2555,10 @@ dependencies = [
  "indexmap",
  "memchr",
  "nom",
- "noodles-bgzf 0.22.0",
+ "noodles-bgzf",
  "noodles-core",
- "noodles-csi 0.19.0",
- "noodles-tabix 0.22.0",
+ "noodles-csi",
+ "noodles-tabix",
  "percent-encoding",
  "tokio",
 ]
@@ -2784,6 +2571,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "nugine-rust-utils"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dcd9cfa92246a9c7ca0671e00733c4e9d77ee1fa0ae08c9a181b7c8802aea2"
+dependencies = [
+ "simdutf8",
 ]
 
 [[package]]
@@ -2840,12 +2636,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
-
-[[package]]
 name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2888,18 +2678,18 @@ checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "path-absolutize"
-version = "3.0.14"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1d4993b16f7325d90c18c3c6a3327db7808752db8d208cea0acee0abd52c52"
+checksum = "43eb3595c63a214e1b37b44f44b0a84900ef7ae0b4c5efce59e123d246d7a0de"
 dependencies = [
  "path-dedot",
 ]
 
 [[package]]
 name = "path-dedot"
-version = "3.0.18"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a81540d94551664b72b72829b12bd167c73c9d25fbac0e04fafa8023f7e4901"
+checksum = "9d55e486337acb9973cdea3ec5638c1b3bcb22e573b2b7b41969e0c744d5a15e"
 dependencies = [
  "once_cell",
 ]
@@ -3328,12 +3118,11 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "s3s"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3167b9fe816cc2c2155bebc43b6434cd1f0420722f293400cbfbedc0f978337e"
+checksum = "015de5f1f3aa25018f2285ceeea6265723a104f054a636686ae60419ec3cf805"
 dependencies = [
  "arrayvec",
- "ascii",
  "async-trait",
  "atoi",
  "base64-simd",
@@ -3350,6 +3139,7 @@ dependencies = [
  "memchr",
  "mime",
  "nom",
+ "nugine-rust-utils",
  "pin-project-lite",
  "quick-xml",
  "serde",
@@ -3367,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "s3s-aws"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0201e5aa8efcdade53dc80f053e38d8b88621a608cf048779e72469e80433b4"
+checksum = "83585b01fd830ff650f5911bf264db3e952fffb8c4bfcfaaf961799e72c9f861"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -3387,9 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "s3s-fs"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9df08c839de8e9939c2909a30227ad0414cb9a900c4c662b8fcff59537e8d54"
+checksum = "9e0c2234e06226d5e31a7120187d9a56cd4ddcd8504c31dc4bc25290f20b4f86"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -3399,6 +3189,7 @@ dependencies = [
  "hex-simd",
  "md-5",
  "mime",
+ "nugine-rust-utils",
  "numeric_cast",
  "path-absolutize",
  "s3s",
@@ -3484,18 +3275,18 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3556,11 +3347,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+checksum = "9f02d8aa6e3c385bf084924f660ce2a3a6bd333ba55b35e8590b321f35d88513"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "chrono",
  "hex",
  "indexmap",
@@ -3572,9 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.3.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+checksum = "edc7d5d3932fb12ce722ee5e64dd38c504efba37567f0c402f6ca728c3b8b070"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3621,6 +3412,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "similar"
@@ -3728,12 +3525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3765,9 +3556,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
  "serde",
@@ -3777,15 +3568,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -3817,9 +3608,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3939,24 +3730,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
-dependencies = [
- "bitflags 1.3.2",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -4192,9 +3965,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 dependencies = [
  "getrandom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -47,7 +47,7 @@ dependencies = [
  "actix-utils",
  "ahash 0.8.3",
  "base64 0.21.0",
- "bitflags",
+ "bitflags 1.3.2",
  "brotli",
  "bytes",
  "bytestring",
@@ -362,6 +362,19 @@ name = "async-compression"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0122885821398cc923ece939e24d1056a2384ee719432397fa9db87230ff11"
 dependencies = [
  "flate2",
  "futures-core",
@@ -835,7 +848,7 @@ checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http",
@@ -931,6 +944,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
 
 [[package]]
 name = "block-buffer"
@@ -1090,7 +1109,7 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex 0.2.4",
  "indexmap",
  "textwrap",
@@ -1115,7 +1134,7 @@ checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex 0.4.1",
  "once_cell",
  "strsim",
@@ -1732,6 +1751,8 @@ dependencies = [
  "htsget-search",
  "htsget-test",
  "http",
+ "noodles 0.34.0",
+ "noodles 0.40.0",
  "reqwest",
  "rustls 0.21.1",
  "rustls-pemfile",
@@ -1752,7 +1773,7 @@ dependencies = [
  "figment",
  "http",
  "http-serde",
- "noodles",
+ "noodles 0.40.0",
  "regex",
  "serde",
  "serde_json",
@@ -1826,7 +1847,7 @@ dependencies = [
  "http",
  "hyper",
  "mockito",
- "noodles",
+ "noodles 0.40.0",
  "reqwest",
  "rustls-pemfile",
  "s3s",
@@ -1854,8 +1875,7 @@ dependencies = [
  "htsget-config",
  "http",
  "mime",
- "noodles-bgzf",
- "noodles-vcf",
+ "noodles 0.40.0",
  "rcgen",
  "reqwest",
  "serde",
@@ -2393,62 +2413,131 @@ dependencies = [
 
 [[package]]
 name = "noodles"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d8a52c91a7fb516482ebae88106109900f65308915900a95049c994e58deb5"
+checksum = "47a338361a01ec3ba68f4ebb5a1594444ba126478798d024d6fe8de35db108a5"
 dependencies = [
- "noodles-bam",
- "noodles-bcf",
- "noodles-bgzf",
+ "noodles-bam 0.28.0",
+ "noodles-bcf 0.22.0",
+ "noodles-bgzf 0.20.0",
  "noodles-core",
- "noodles-cram",
- "noodles-csi",
- "noodles-fasta",
- "noodles-fastq",
- "noodles-sam",
- "noodles-tabix",
- "noodles-vcf",
+ "noodles-cram 0.25.0",
+ "noodles-csi 0.14.0",
+ "noodles-fasta 0.20.0",
+ "noodles-fastq 0.6.0",
+ "noodles-sam 0.25.0",
+ "noodles-tabix 0.17.0",
+ "noodles-vcf 0.26.0",
+]
+
+[[package]]
+name = "noodles"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc887b6b9f871fe07e545828e7400e547ad84ae8c3cef9a66cf63841dcea79f9"
+dependencies = [
+ "noodles-bam 0.34.0",
+ "noodles-bcf 0.28.0",
+ "noodles-bgzf 0.22.0",
+ "noodles-core",
+ "noodles-cram 0.31.0",
+ "noodles-csi 0.19.0",
+ "noodles-fasta 0.23.0",
+ "noodles-fastq 0.8.0",
+ "noodles-sam 0.31.0",
+ "noodles-tabix 0.22.0",
+ "noodles-vcf 0.31.0",
 ]
 
 [[package]]
 name = "noodles-bam"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a5d3990c4cde117936769f9b3ea3f0beaf13e0b7d8850247c931e90af26955"
+checksum = "5b100df8df462cf3197ce770c241614e68799ee3b557f85bd11779225bd27896"
 dependencies = [
  "bit-vec",
  "byteorder",
  "bytes",
  "futures",
- "noodles-bgzf",
+ "noodles-bgzf 0.20.0",
  "noodles-core",
- "noodles-csi",
- "noodles-fasta",
- "noodles-sam",
+ "noodles-csi 0.14.0",
+ "noodles-fasta 0.20.0",
+ "noodles-sam 0.25.0",
+ "tokio",
+]
+
+[[package]]
+name = "noodles-bam"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f8776cf0ea855608b33c7fb57519dcfe1e6400887cdb98ffef9ad9d195f98c"
+dependencies = [
+ "bit-vec",
+ "byteorder",
+ "bytes",
+ "futures",
+ "noodles-bgzf 0.22.0",
+ "noodles-core",
+ "noodles-csi 0.19.0",
+ "noodles-fasta 0.23.0",
+ "noodles-sam 0.31.0",
  "tokio",
 ]
 
 [[package]]
 name = "noodles-bcf"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b5979fec9d28d2d4552e85a04f289e26daad63dd6a4693d9c128d2a457c1c7"
+checksum = "f1984f2b1c676c2652ff03e9002f50774be35fbbcd29ffee337f1e372db047a2"
 dependencies = [
  "byteorder",
  "futures",
  "indexmap",
- "noodles-bgzf",
+ "noodles-bgzf 0.20.0",
  "noodles-core",
- "noodles-csi",
- "noodles-vcf",
+ "noodles-csi 0.14.0",
+ "noodles-vcf 0.26.0",
+ "tokio",
+]
+
+[[package]]
+name = "noodles-bcf"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeafbede29abef465759b6557797a33cbe2a8bc17294285817ee6eab2d40342f"
+dependencies = [
+ "byteorder",
+ "futures",
+ "indexmap",
+ "noodles-bgzf 0.22.0",
+ "noodles-core",
+ "noodles-csi 0.19.0",
+ "noodles-vcf 0.31.0",
  "tokio",
 ]
 
 [[package]]
 name = "noodles-bgzf"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d6971da2c55bdd0ed57058348ba52b11dedf0c33180ac6d0853c9ecde5bbdf"
+checksum = "2bff155a5362c61d9b977648d874aa84aea88f7de032e43df908c7cd26b22b6d"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "crossbeam-channel",
+ "flate2",
+ "futures",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "noodles-bgzf"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2985a96e0306878a47e223f1bc8b5c988de6ef1516797796e05349dac0a727b2"
 dependencies = [
  "byteorder",
  "bytes",
@@ -2462,28 +2551,51 @@ dependencies = [
 
 [[package]]
 name = "noodles-core"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f52f0dbc792f4d76e94e3ccaee57237b649ad1e4b64a97ad037d6b3b8f6909"
+checksum = "72f9ab09e13392e71797e7502109575d2aae5cb2002bd2304647f7746215c2fe"
 
 [[package]]
 name = "noodles-cram"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d83ba5b9eb0161c7fe4385aaa99aac720f216b7115a8856d8dca075244ad803"
+checksum = "2259b516050b54a980bff6f6dd0fc4690699e5fda3f792db603222e81e1f60b6"
 dependencies = [
- "async-compression",
- "bitflags",
+ "async-compression 0.3.15",
+ "bitflags 1.3.2",
  "byteorder",
  "bytes",
  "bzip2",
  "flate2",
  "futures",
  "md-5",
- "noodles-bam",
+ "noodles-bam 0.28.0",
  "noodles-core",
- "noodles-fasta",
- "noodles-sam",
+ "noodles-fasta 0.20.0",
+ "noodles-sam 0.25.0",
+ "pin-project-lite",
+ "tokio",
+ "xz2",
+]
+
+[[package]]
+name = "noodles-cram"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ad9e48f976e3589764f382a399b1fd4ae637356e4013f70c721e830d7456d3"
+dependencies = [
+ "async-compression 0.4.0",
+ "bitflags 2.3.1",
+ "byteorder",
+ "bytes",
+ "bzip2",
+ "flate2",
+ "futures",
+ "md-5",
+ "noodles-bam 0.34.0",
+ "noodles-core",
+ "noodles-fasta 0.23.0",
+ "noodles-sam 0.31.0",
  "pin-project-lite",
  "tokio",
  "xz2",
@@ -2491,26 +2603,53 @@ dependencies = [
 
 [[package]]
 name = "noodles-csi"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4797afdb8fc80e7ddc0d6a3fa33163c2473fec431c4838e67d7f957f68ede527"
+checksum = "56201d5278cb875d3b4a8e338a21fa5b43f6dd56547447006dbad4638e6c952e"
 dependencies = [
  "bit-vec",
  "byteorder",
- "noodles-bgzf",
+ "noodles-bgzf 0.20.0",
+ "noodles-core",
+ "tokio",
+]
+
+[[package]]
+name = "noodles-csi"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdb6d7fc962544e61761f95bd6e86e370f3fd2d7c0e76a0d27f56595c9d784b"
+dependencies = [
+ "bit-vec",
+ "byteorder",
+ "indexmap",
+ "noodles-bgzf 0.22.0",
  "noodles-core",
  "tokio",
 ]
 
 [[package]]
 name = "noodles-fasta"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3264d8ce30f2959a84339366548afca3fb5d4043a9f8853ca448411f305958"
+checksum = "0cbcf02af0f440981cef550db3e078b588591e68abd791ab0767c599945b4b93"
 dependencies = [
  "bytes",
  "memchr",
- "noodles-bgzf",
+ "noodles-bgzf 0.20.0",
+ "noodles-core",
+ "tokio",
+]
+
+[[package]]
+name = "noodles-fasta"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642d6f9e977a202d7efee2ee061944af786f5bced0eec977321f5b16bade80ca"
+dependencies = [
+ "bytes",
+ "memchr",
+ "noodles-bgzf 0.22.0",
  "noodles-core",
  "tokio",
 ]
@@ -2526,52 +2665,113 @@ dependencies = [
 ]
 
 [[package]]
-name = "noodles-sam"
-version = "0.23.0"
+name = "noodles-fastq"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647b9f1b0b3815ee21aef82823bd9062c40706c6d9148935aef3e2b7a9c572f6"
+checksum = "e1763486d2d1a1e39a86676a47aa05728c75f73f0f883415e36439711ead2641"
 dependencies = [
- "bitflags",
+ "futures",
+ "memchr",
+ "tokio",
+]
+
+[[package]]
+name = "noodles-sam"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca67089a8f2bedf0bfcce06758cde48fe8fc04d2a33b02aa445cdc05c798051f"
+dependencies = [
+ "bitflags 1.3.2",
  "futures",
  "indexmap",
  "lexical-core",
  "memchr",
- "noodles-bgzf",
+ "noodles-bgzf 0.20.0",
  "noodles-core",
- "noodles-csi",
- "noodles-fasta",
+ "noodles-csi 0.14.0",
+ "noodles-fasta 0.20.0",
+ "tokio",
+]
+
+[[package]]
+name = "noodles-sam"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa33250687c537cc88ae573f264ea9b3352770209134cfa1f047c05c352e724"
+dependencies = [
+ "bitflags 2.3.1",
+ "futures",
+ "indexmap",
+ "lexical-core",
+ "memchr",
+ "noodles-bgzf 0.22.0",
+ "noodles-core",
+ "noodles-csi 0.19.0",
+ "noodles-fasta 0.23.0",
  "tokio",
 ]
 
 [[package]]
 name = "noodles-tabix"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74c56094217a32748db1d8457f39f07b6695b5c23e71919fba9784bd6f929f4"
+checksum = "76b4c6ad670431f0d3981080621f6e64037280916bf1638c373a1b941449e4ba"
 dependencies = [
  "bit-vec",
  "byteorder",
  "indexmap",
- "noodles-bgzf",
+ "noodles-bgzf 0.20.0",
  "noodles-core",
- "noodles-csi",
+ "noodles-csi 0.14.0",
+ "tokio",
+]
+
+[[package]]
+name = "noodles-tabix"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a775d5b16637bbfa0d6bd2a1ff06d4eba409235a5ca9df727a060b785c0f28c5"
+dependencies = [
+ "bit-vec",
+ "byteorder",
+ "noodles-bgzf 0.22.0",
+ "noodles-core",
+ "noodles-csi 0.19.0",
  "tokio",
 ]
 
 [[package]]
 name = "noodles-vcf"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008dc218516a5363d7f55add28866c20463f14ffcb661cbfc4863343e1486a20"
+checksum = "fa196d6d6ad22277390e2cc588d6999a00fd73bd1ca4a5f68e8fda710c8e8364"
 dependencies = [
  "futures",
  "indexmap",
  "memchr",
  "nom",
- "noodles-bgzf",
+ "noodles-bgzf 0.20.0",
  "noodles-core",
- "noodles-csi",
- "noodles-tabix",
+ "noodles-csi 0.14.0",
+ "noodles-tabix 0.17.0",
+ "percent-encoding",
+ "tokio",
+]
+
+[[package]]
+name = "noodles-vcf"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31dbdd18b80ce1918e8862af5b2a303f381a36479d56fd6a3b1df5e5f639ad5"
+dependencies = [
+ "futures",
+ "indexmap",
+ "memchr",
+ "nom",
+ "noodles-bgzf 0.22.0",
+ "noodles-core",
+ "noodles-csi 0.19.0",
+ "noodles-tabix 0.22.0",
  "percent-encoding",
  "tokio",
 ]
@@ -2936,7 +3136,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2945,7 +3145,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3051,7 +3251,7 @@ version = "0.37.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -3259,7 +3459,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3747,7 +3947,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3765,7 +3965,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 [workspace]
+resolver = "2"
+
 members = [
     "htsget-config",
     "htsget-actix",

--- a/htsget-actix/Cargo.toml
+++ b/htsget-actix/Cargo.toml
@@ -16,6 +16,9 @@ url-storage = ["htsget-config/url-storage", "htsget-search/url-storage", "htsget
 default = []
 
 [dependencies]
+noodles = { version = "0.40", features = ["async", "core", "bgzf", "bam", "bcf", "cram", "csi", "sam", "tabix", "vcf"] }
+noodles_old = { package = "noodles", version = "0.34", features = ["async", "core", "bgzf", "bam", "bcf", "cram", "csi", "sam", "tabix", "vcf"] }
+
 actix-web = { version = "4.3", features = ["rustls"] }
 actix-cors = "0.6"
 http = "0.2"

--- a/htsget-actix/Cargo.toml
+++ b/htsget-actix/Cargo.toml
@@ -17,7 +17,6 @@ default = []
 
 [dependencies]
 noodles = { version = "0.40", features = ["async", "core", "bgzf", "bam", "bcf", "cram", "csi", "sam", "tabix", "vcf"] }
-noodles_old = { package = "noodles", version = "0.34", features = ["async", "core", "bgzf", "bam", "bcf", "cram", "csi", "sam", "tabix", "vcf"] }
 
 actix-web = { version = "4.3", features = ["rustls"] }
 actix-cors = "0.6"
@@ -32,7 +31,7 @@ htsget-search = { version = "0.4.1", path = "../htsget-search", default-features
 htsget-config = { version = "0.5.0", path = "../htsget-config", default-features = false }
 htsget-test = { version = "0.4.1", path = "../htsget-test", features = ["server-tests", "cors-tests"], default-features = false }
 futures = { version = "0.3" }
-tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.28", features = ["macros", "rt-multi-thread"] }
 
 tracing-actix-web = "0.7"
 tracing = "0.1"
@@ -40,9 +39,9 @@ tracing = "0.1"
 [dev-dependencies]
 async-trait = "0.1"
 
-criterion = { version = "0.4", features = ["async_tokio"] }
+criterion = { version = "0.5", features = ["async_tokio"] }
 reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "rustls-tls"] }
-tempfile = "3.3"
+tempfile = "3.5"
 
 [[bench]]
 name = "request-benchmarks"

--- a/htsget-actix/Cargo.toml
+++ b/htsget-actix/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "htsget-actix"
 version = "0.4.1"
-rust-version = "1.64"
+rust-version = "1.65"
 authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -21,7 +21,6 @@ noodles = { version = "0.40", features = ["async", "core", "bgzf", "bam", "bcf",
 actix-web = { version = "4.3", features = ["rustls"] }
 actix-cors = "0.6"
 http = "0.2"
-rustls = "0.21"
 rustls-pemfile = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/htsget-config/Cargo.toml
+++ b/htsget-config/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 [dependencies]
 thiserror = "1.0"
 async-trait = "0.1"
-noodles = { version = "0.32", features = ["core"] }
+noodles = { version = "0.40", features = ["core"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "2.2"
 serde_regex = "1.1"

--- a/htsget-config/Cargo.toml
+++ b/htsget-config/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/umccr/htsget-rs"
 
 [features]
 s3-storage = []
-url-storage = ["dep:url"]
+url-storage = []
 default = []
 
 [dependencies]
@@ -30,7 +30,6 @@ tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "a
 toml = "0.7"
 http = "0.2"
 http-serde = "1.1"
-url = { version = "2.3", optional = true, features = ["serde"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/htsget-config/Cargo.toml
+++ b/htsget-config/Cargo.toml
@@ -20,11 +20,11 @@ thiserror = "1.0"
 async-trait = "0.1"
 noodles = { version = "0.40", features = ["core"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_with = "2.2"
+serde_with = "3.0"
 serde_regex = "1.1"
-regex = "1.7"
+regex = "1.8"
 figment = { version = "0.10", features = ["env", "toml"] }
-clap = { version = "4.1", features = ["derive", "env", "cargo"] }
+clap = { version = "4.3", features = ["derive", "env", "cargo"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "ansi", "json"] }
 toml = "0.7"
@@ -35,4 +35,4 @@ url = { version = "2.3", optional = true, features = ["serde"] }
 [dev-dependencies]
 serde_json = "1.0"
 figment = { version = "0.10", features = ["test"] }
-tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.28", features = ["macros", "rt-multi-thread"] }

--- a/htsget-config/src/config/cors.rs
+++ b/htsget-config/src/config/cors.rs
@@ -281,6 +281,6 @@ mod tests {
   fn tagged_any_allow_type_err_on_mirror() {
     let allow_type_method = "expose_headers = \"Mirror\"";
     let config: Result<CorsConfig, Error> = toml::from_str(allow_type_method);
-    assert!(matches!(config, Err(_)));
+    assert!(config.is_err());
   }
 }

--- a/htsget-config/src/resolver.rs
+++ b/htsget-config/src/resolver.rs
@@ -409,8 +409,8 @@ mod tests {
 
   #[cfg(feature = "url-storage")]
   use {
-    crate::storage::url::UrlStorage, crate::types::Scheme::Https, std::str::FromStr,
-    url::Url as InnerUrl,
+    crate::storage::url::UrlStorage, crate::types::Scheme::Https, http::Uri as InnerUrl,
+    std::str::FromStr,
   };
 
   use crate::config::tests::{test_config_from_env, test_config_from_file};
@@ -441,7 +441,7 @@ mod tests {
     async fn from_url(url_storage: &UrlStorage, _: &Query) -> Result<Response> {
       Ok(Response::new(
         Bam,
-        vec![Url::new(url_storage.url().as_str())],
+        vec![Url::new(url_storage.url().to_string())],
       ))
     }
   }

--- a/htsget-config/src/storage/url.rs
+++ b/htsget-config/src/storage/url.rs
@@ -1,45 +1,50 @@
 use std::str::FromStr;
 
+use http::Uri as InnerUrl;
 use serde::{Deserialize, Serialize};
-use url::Url as InnerUrl;
 
 use crate::error::Error::ParseError;
 use crate::error::{Error, Result};
 use crate::storage::local::default_authority;
 use crate::types::Scheme;
 
-fn default_url() -> Url {
-  Url(InnerUrl::from_str(&format!("https://{}", default_authority())).expect("expected valid url"))
+fn default_url() -> ValidatedUrl {
+  ValidatedUrl(Url(
+    InnerUrl::from_str(&format!("https://{}", default_authority())).expect("expected valid url"),
+  ))
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(default)]
 pub struct UrlStorage {
-  url: Url,
+  url: ValidatedUrl,
   response_scheme: Scheme,
   forward_headers: bool,
 }
 
-/// A new type struct on top of `url::Url` which only allows http or https schemes when deserializing.
+/// A wrapper around `http::Uri` type which implements serialize and deserialize.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(try_from = "InnerUrl")]
-pub struct Url(InnerUrl);
+struct Url(#[serde(with = "http_serde::uri")] InnerUrl);
 
-impl Url {
+/// A new type struct on top of `http::Uri` which only allows http or https schemes when deserializing.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(try_from = "Url")]
+pub struct ValidatedUrl(Url);
+
+impl ValidatedUrl {
   /// Get the inner url.
   pub fn into_inner(self) -> InnerUrl {
-    self.0
+    self.0 .0
   }
 }
 
-impl TryFrom<InnerUrl> for Url {
+impl TryFrom<Url> for ValidatedUrl {
   type Error = Error;
 
-  fn try_from(url: InnerUrl) -> Result<Self> {
-    if url.scheme() == "http" || url.scheme() == "https" {
-      Ok(Self(url))
-    } else {
-      Err(ParseError("url scheme must be http or https".to_string()))
+  fn try_from(url: Url) -> Result<Self> {
+    match url.0.scheme() {
+      Some(scheme) if scheme == "http" || scheme == "https" => Ok(Self(url)),
+      _ => Err(ParseError("url scheme must be http or https".to_string())),
     }
   }
 }
@@ -48,7 +53,7 @@ impl UrlStorage {
   /// Create a new url storage.
   pub fn new(url: InnerUrl, response_scheme: Scheme, forward_headers: bool) -> Self {
     Self {
-      url: Url(url),
+      url: ValidatedUrl(Url(url)),
       response_scheme,
       forward_headers,
     }
@@ -61,7 +66,7 @@ impl UrlStorage {
 
   /// Get the url called when resolving the query.
   pub fn url(&self) -> &InnerUrl {
-    &self.url.0
+    &self.url.0 .0
   }
 
   /// Whether headers received in a query request should be
@@ -78,5 +83,34 @@ impl Default for UrlStorage {
       response_scheme: Scheme::Https,
       forward_headers: true,
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::config::tests::test_config_from_file;
+  use crate::storage::Storage;
+  use crate::types::Scheme;
+
+  #[test]
+  fn config_storage_url_file() {
+    test_config_from_file(
+      r#"
+        [[resolvers]]
+        regex = "regex"
+
+        [resolvers.storage]
+        url = "https://example.com/"
+        response_scheme = "Http"
+        forward_headers = false
+        "#,
+      |config| {
+        println!("{:?}", config.resolvers().first().unwrap().storage());
+        assert!(matches!(
+            config.resolvers().first().unwrap().storage(),
+            Storage::Url { url_storage } if *url_storage.url() == "https://example.com/" && url_storage.response_scheme() == Scheme::Http && !url_storage.forward_headers()
+        ));
+      },
+    );
   }
 }

--- a/htsget-http/Cargo.toml
+++ b/htsget-http/Cargo.toml
@@ -23,5 +23,5 @@ htsget-search = { version = "0.4.1", path = "../htsget-search", default-features
 htsget-config = { version = "0.5.0", path = "../htsget-config", default-features = false }
 htsget-test = { version = "0.4.1", path = "../htsget-test", default-features = false }
 futures = { version = "0.3" }
-tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.28", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"

--- a/htsget-http/Cargo.toml
+++ b/htsget-http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "htsget-http"
 version = "0.4.1"
-rust-version = "1.64"
+rust-version = "1.65"
 authors = ["Daniel del Castillo de la Rosa <delcastillodelarosadaniel@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/htsget-lambda/Cargo.toml
+++ b/htsget-lambda/Cargo.toml
@@ -16,10 +16,10 @@ url-storage = ["htsget-config/url-storage", "htsget-search/url-storage", "htsget
 default = []
 
 [dependencies]
-tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
-tower-http = { version = "0.3", features = ["cors"] }
-lambda_http = { version = "0.7" }
-lambda_runtime = { version = "0.7" }
+tokio = { version = "1.28", features = ["macros", "rt-multi-thread"] }
+tower-http = { version = "0.4", features = ["cors"] }
+lambda_http = { version = "0.8" }
+lambda_runtime = { version = "0.8" }
 htsget-config = { version = "0.5.0", path = "../htsget-config", default-features = false }
 htsget-search = { version = "0.4.1", path = "../htsget-search", default-features = false }
 htsget-http = { version = "0.4.1", path = "../htsget-http", default-features = false }
@@ -27,7 +27,7 @@ htsget-test = { version = "0.4.1", path = "../htsget-test", features = ["server-
 serde = { version = "1.0" }
 serde_json = "1.0"
 mime = "0.3"
-regex = "1.7"
+regex = "1.8"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 bytes = "1.4"
@@ -35,4 +35,4 @@ bytes = "1.4"
 [dev-dependencies]
 async-trait = "0.1"
 query_map = { version = "0.6", features = ["url-query"] }
-tempfile = "3.3"
+tempfile = "3.5"

--- a/htsget-lambda/Cargo.toml
+++ b/htsget-lambda/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "htsget-lambda"
 version = "0.4.1"
-rust-version = "1.64"
+rust-version = "1.65"
 authors = ["Marko Malenic <mmalenic1@gmail.com>", "Roman Valls Guimera <brainstorm@nopcode.org>"]
 edition = "2021"
 license = "MIT"

--- a/htsget-lambda/src/lib.rs
+++ b/htsget-lambda/src/lib.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use lambda_http::ext::RequestExt;
 use lambda_http::http::{Method, StatusCode, Uri};
 use lambda_http::tower::ServiceBuilder;
-use lambda_http::{http, service_fn, Body, Request, Response};
+use lambda_http::{http, service_fn, Body, Request, RequestPayloadExt, Response};
 use lambda_runtime::Error;
 use tracing::instrument;
 use tracing::{debug, info};

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "htsget-search"
 version = "0.4.1"
-rust-version = "1.64"
+rust-version = "1.65"
 authors = ["Christian Perez Llamas <chrispz@gmail.com>", "Marko Malenic <mmalenic1@gmail.com>", "Roman Valls Guimera <brainstorm@nopcode.org>"]
 edition = "2021"
 description = "The primary mechanism by which htsget-rs interacts with, and processes bioinformatics files. It does this by using noodles to query files and their indices."
@@ -18,11 +18,10 @@ default = []
 [dependencies]
 # Axum server
 url = "2.3"
-hyper = { version = "0.14", features = ["http2", "server"] }
+hyper = { version = "0.14", features = ["http1", "http2", "server"] }
 tower-http = { version = "0.4", features = ["trace", "cors", "fs"] }
 http = "0.2"
 axum = "0.6"
-axum-extra = "0.7"
 rustls-pemfile = "1.0"
 tower = { version = "0.4", features = ["make"] }
 
@@ -39,12 +38,11 @@ noodles = { version = "0.40", features = ["async", "core", "bgzf", "bam", "bcf",
 
 # Amazon S3
 bytes = { version = "1.4", optional = true }
-aws-sdk-s3 = { version = "0.28", optional = true, features = ["test-util"] }
+aws-sdk-s3 = { version = "0.28", optional = true }
 aws-config = { version = "0.55", optional = true }
-aws-credential-types = { version = "0.55", features = ["test-util"] }
 
 # Url storage
-hyper-rustls = { version = "0.24", features = ["rustls-native-certs", "http2"], optional = true }
+hyper-rustls = { version = "0.24", features = ["rustls-native-certs", "http2", "http1"], optional = true }
 
 # Error control, tracing, config
 thiserror = "1.0"
@@ -56,13 +54,14 @@ serde = "1.0"
 
 [dev-dependencies]
 tempfile = "3.5"
-data-url = "0.2"
+data-url = "0.3"
 mockito = "1.0"
 
 # S3 storage testing
 s3s = { version = "0.6" }
 s3s-fs = { version = "0.6" }
 s3s-aws = { version = "0.6" }
+aws-credential-types = { version = "0.55", features = ["test-util"] }
 
 # Axum server
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -28,7 +28,7 @@ tower = { version = "0.4", features = ["make"] }
 
 # Async
 tokio-rustls = "0.23"
-tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.28", features = ["macros", "rt-multi-thread"] }
 tokio-util = { version = "0.7", features = ["io", "compat"] }
 futures = { version = "0.3" }
 futures-util = "0.3"
@@ -39,7 +39,7 @@ noodles = { version = "0.40", features = ["async", "core", "bgzf", "bam", "bcf",
 
 # Amazon S3
 bytes = { version = "1.4", optional = true }
-aws-sdk-s3 = { version = "0.27", optional = true, features = ["test-util"] }
+aws-sdk-s3 = { version = "0.28", optional = true, features = ["test-util"] }
 aws-config = { version = "0.55", optional = true }
 aws-credential-types = { version = "0.55", features = ["test-util"] }
 
@@ -55,19 +55,19 @@ base64 = "0.21"
 serde = "1.0"
 
 [dev-dependencies]
-tempfile = "3.3"
+tempfile = "3.5"
 data-url = "0.2"
 mockito = "1.0"
 
 # S3 storage testing
-s3s = { version = "0.5" }
-s3s-fs = { version = "0.5" }
-s3s-aws = { version = "0.5" }
+s3s = { version = "0.6" }
+s3s-fs = { version = "0.6" }
+s3s-aws = { version = "0.6" }
 
 # Axum server
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 
-criterion = { version = "0.4", features = ["async_tokio"] }
+criterion = { version = "0.5", features = ["async_tokio"] }
 
 [[bench]]
 name = "search-benchmarks"

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -12,13 +12,13 @@ repository = "https://github.com/umccr/htsget-rs"
 
 [features]
 s3-storage = ["dep:bytes", "dep:aws-sdk-s3", "dep:aws-config", "htsget-config/s3-storage", "htsget-test/s3-storage"]
-url-storage = ["dep:bytes", "dep:reqwest", "htsget-config/url-storage", "htsget-test/url-storage"]
+url-storage = ["dep:bytes", "dep:hyper-rustls", "hyper/client", "htsget-config/url-storage", "htsget-test/url-storage"]
 default = []
 
 [dependencies]
 # Axum server
 url = "2.3"
-hyper = "0.14"
+hyper = { version = "0.14", features = ["http2", "server"] }
 tower-http = { version = "0.4", features = ["trace", "cors", "fs"] }
 http = "0.2"
 axum = "0.6"
@@ -44,7 +44,7 @@ aws-config = { version = "0.55", optional = true }
 aws-credential-types = { version = "0.55", features = ["test-util"] }
 
 # Url storage
-reqwest = { version = "0.11", default-features = false, optional = true, features = ["rustls-tls", "stream"] }
+hyper-rustls = { version = "0.24", features = ["rustls-native-certs", "http2"], optional = true }
 
 # Error control, tracing, config
 thiserror = "1.0"

--- a/htsget-search/Cargo.toml
+++ b/htsget-search/Cargo.toml
@@ -35,7 +35,7 @@ futures-util = "0.3"
 async-trait = "0.1"
 
 # Noodles
-noodles = { version = "0.32", features = ["async", "core", "bgzf", "bam", "bcf", "cram", "csi", "sam", "tabix", "vcf"] }
+noodles = { version = "0.40", features = ["async", "core", "bgzf", "bam", "bcf", "cram", "csi", "sam", "tabix", "vcf"] }
 
 # Amazon S3
 bytes = { version = "1.4", optional = true }

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -475,7 +475,7 @@ pub(crate) mod tests {
         let search = BamSearch::new(storage);
         let query = Query::new_with_default_request("htsnexus_test_NA12878", Format::Bam);
         let response = search.search(query).await;
-        assert!(matches!(response, Err(_)));
+        assert!(response.is_err());
       },
       DATA_LOCATION,
       &[INDEX_FILE_LOCATION],
@@ -492,7 +492,7 @@ pub(crate) mod tests {
         let query = Query::new_with_default_request("htsnexus_test_NA12878", Format::Bam)
           .with_reference_name("20");
         let response = search.search(query).await;
-        assert!(matches!(response, Err(_)));
+        assert!(response.is_err());
       },
       DATA_LOCATION,
       &[INDEX_FILE_LOCATION],
@@ -509,7 +509,7 @@ pub(crate) mod tests {
         let query =
           Query::new_with_default_request("htsnexus_test_NA12878", Format::Bam).with_class(Header);
         let response = search.search(query).await;
-        assert!(matches!(response, Err(_)));
+        assert!(response.is_err());
       },
       DATA_LOCATION,
       &[INDEX_FILE_LOCATION],

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -281,7 +281,7 @@ mod tests {
         let search = BcfSearch::new(storage);
         let query = Query::new_with_default_request("vcf-spec-v4.3", Format::Bcf);
         let response = search.search(query).await;
-        assert!(matches!(response, Err(_)));
+        assert!(response.is_err());
       },
       DATA_LOCATION,
       &[INDEX_FILE_LOCATION],
@@ -298,7 +298,7 @@ mod tests {
         let query =
           Query::new_with_default_request("vcf-spec-v4.3", Format::Bcf).with_reference_name("chrM");
         let response = search.search(query).await;
-        assert!(matches!(response, Err(_)));
+        assert!(response.is_err());
       },
       DATA_LOCATION,
       &[INDEX_FILE_LOCATION],
@@ -315,7 +315,7 @@ mod tests {
         let query =
           Query::new_with_default_request("vcf-spec-v4.3", Format::Bcf).with_class(Header);
         let response = search.search(query).await;
-        assert!(matches!(response, Err(_)));
+        assert!(response.is_err());
       },
       DATA_LOCATION,
       &[INDEX_FILE_LOCATION],

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -6,16 +6,16 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures_util::stream::FuturesOrdered;
 use noodles::bcf;
-use noodles::csi::index::reference_sequence::bin::Chunk;
 use noodles::csi::index::ReferenceSequence;
-use noodles::csi::{BinningIndex, Index};
+use noodles::csi::Index;
 use noodles::vcf::Header;
 use noodles::{bgzf, csi};
 use tokio::io;
 use tokio::io::AsyncRead;
 use tracing::{instrument, trace};
 
-use crate::htsget::search::{find_first, BgzfSearch, BinningIndexExt, Search};
+use crate::htsget::search::{find_first, BgzfSearch, Search};
+use crate::htsget::ParsedHeader;
 use crate::storage::{BytesPosition, Storage};
 use crate::{Format, Query, Result};
 
@@ -26,23 +26,8 @@ pub struct BcfSearch<S> {
   storage: Arc<S>,
 }
 
-impl BinningIndexExt for Index {
-  #[instrument(level = "trace", skip_all)]
-  fn get_all_chunks(&self) -> Vec<&Chunk> {
-    trace!("getting vec of chunks");
-    self
-      .reference_sequences()
-      .iter()
-      .flat_map(|ref_seq| ref_seq.bins())
-      .flat_map(|bin| bin.chunks())
-      .collect()
-  }
-}
-
 #[async_trait]
-impl<S, ReaderType>
-  BgzfSearch<S, ReaderType, ReferenceSequence, Index, AsyncReader<ReaderType>, Header>
-  for BcfSearch<S>
+impl<S, ReaderType> BgzfSearch<S, ReaderType, AsyncReader<ReaderType>, Header> for BcfSearch<S>
 where
   S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
   ReaderType: AsyncRead + Unpin + Send + Sync,
@@ -60,9 +45,16 @@ where
     AsyncReader::new(inner)
   }
 
-  async fn read_raw_header(reader: &mut AsyncReader<ReaderType>) -> io::Result<String> {
+  async fn read_header(reader: &mut AsyncReader<ReaderType>) -> io::Result<Header> {
     reader.read_file_format().await?;
-    reader.read_header().await
+
+    Ok(
+      reader
+        .read_header()
+        .await?
+        .parse::<ParsedHeader<Header>>()?
+        .into_inner(),
+    )
   }
 
   async fn read_index_inner<T: AsyncRead + Unpin + Send>(inner: T) -> io::Result<Index> {

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -506,7 +506,7 @@ mod tests {
         let search = CramSearch::new(storage);
         let query = Query::new_with_default_request("htsnexus_test_NA12878", Format::Cram);
         let response = search.search(query).await;
-        assert!(matches!(response, Err(_)));
+        assert!(response.is_err());
       },
       DATA_LOCATION,
       &[INDEX_FILE_LOCATION],
@@ -523,7 +523,7 @@ mod tests {
         let query = Query::new_with_default_request("htsnexus_test_NA12878", Format::Cram)
           .with_reference_name("20");
         let response = search.search(query).await;
-        assert!(matches!(response, Err(_)));
+        assert!(response.is_err());
       },
       DATA_LOCATION,
       &[INDEX_FILE_LOCATION],
@@ -540,7 +540,7 @@ mod tests {
         let query =
           Query::new_with_default_request("htsnexus_test_NA12878", Format::Cram).with_class(Header);
         let response = search.search(query).await;
-        assert!(matches!(response, Err(_)));
+        assert!(response.is_err());
       },
       DATA_LOCATION,
       &[INDEX_FILE_LOCATION],

--- a/htsget-search/src/htsget/from_storage.rs
+++ b/htsget-search/src/htsget/from_storage.rs
@@ -15,7 +15,6 @@ use {crate::storage::s3::S3Storage, htsget_config::storage::s3::S3Storage as S3S
 #[cfg(feature = "url-storage")]
 use {
   crate::storage::url::UrlStorage, htsget_config::storage::url::UrlStorage as UrlStorageConfig,
-  http::Uri, std::str::FromStr,
 };
 
 use crate::htsget::search::Search;
@@ -100,8 +99,7 @@ impl<S> ResolveResponse for HtsGetFromStorage<S> {
   #[cfg(feature = "url-storage")]
   async fn from_url(url_storage_config: &UrlStorageConfig, query: &Query) -> Result<Response> {
     let searcher = HtsGetFromStorage::new(UrlStorage::new_with_default_client(
-      Uri::from_str(url_storage_config.url().as_ref())
-        .map_err(|err| HtsGetError::internal_error(format!("failed converting to Uri: {}", err)))?,
+      url_storage_config.url().clone(),
       url_storage_config.response_scheme(),
       url_storage_config.forward_headers(),
     ));

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -6,18 +6,18 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures_util::stream::FuturesOrdered;
 use noodles::bgzf;
-use noodles::csi::index::reference_sequence::bin::Chunk;
-use noodles::csi::BinningIndex;
+use noodles::csi::index::ReferenceSequence;
+use noodles::csi::Index;
 use noodles::tabix;
-use noodles::tabix::index::ReferenceSequence;
-use noodles::tabix::Index;
 use noodles::vcf;
 use noodles::vcf::Header;
 use tokio::io;
 use tokio::io::AsyncRead;
 use tracing::{instrument, trace};
 
-use crate::htsget::search::{find_first, BgzfSearch, BinningIndexExt, Search};
+use htsget_config::types::HtsGetError;
+
+use crate::htsget::search::{find_first, BgzfSearch, Search};
 use crate::storage::{BytesPosition, Storage};
 use crate::{Format, Query, Result};
 
@@ -28,23 +28,8 @@ pub struct VcfSearch<S> {
   storage: Arc<S>,
 }
 
-impl BinningIndexExt for Index {
-  #[instrument(level = "trace", skip_all)]
-  fn get_all_chunks(&self) -> Vec<&Chunk> {
-    trace!("getting vec of chunks");
-    self
-      .reference_sequences()
-      .iter()
-      .flat_map(|ref_seq| ref_seq.bins())
-      .flat_map(|bin| bin.chunks())
-      .collect()
-  }
-}
-
 #[async_trait]
-impl<S, ReaderType>
-  BgzfSearch<S, ReaderType, ReferenceSequence, Index, AsyncReader<ReaderType>, Header>
-  for VcfSearch<S>
+impl<S, ReaderType> BgzfSearch<S, ReaderType, AsyncReader<ReaderType>, Header> for VcfSearch<S>
 where
   S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
   ReaderType: AsyncRead + Unpin + Send + Sync,
@@ -62,7 +47,7 @@ where
     AsyncReader::new(bgzf::AsyncReader::new(inner))
   }
 
-  async fn read_raw_header(reader: &mut AsyncReader<ReaderType>) -> io::Result<String> {
+  async fn read_header(reader: &mut AsyncReader<ReaderType>) -> io::Result<Header> {
     reader.read_header().await
   }
 
@@ -82,7 +67,13 @@ where
     // We are assuming the order of the names and the references sequences
     // in the index is the same
     let mut futures = FuturesOrdered::new();
-    for (index, name) in index.header().reference_sequence_names().iter().enumerate() {
+    for (index, name) in index
+      .header()
+      .ok_or_else(|| HtsGetError::parse_error("no tabix header found in index"))?
+      .reference_sequence_names()
+      .iter()
+      .enumerate()
+    {
       let owned_name = name.to_owned();
       let owned_reference_name = reference_name.clone();
       futures.push_back(tokio::spawn(async move {

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -284,7 +284,7 @@ pub(crate) mod tests {
         let search = VcfSearch::new(storage);
         let query = Query::new_with_default_request("vcf-spec-v4.3", Format::Vcf);
         let response = search.search(query).await;
-        assert!(matches!(response, Err(_)));
+        assert!(response.is_err());
       },
       VCF_LOCATION,
       &[INDEX_FILE_LOCATION],
@@ -301,7 +301,7 @@ pub(crate) mod tests {
         let query =
           Query::new_with_default_request("vcf-spec-v4.3", Format::Vcf).with_reference_name("chrM");
         let response = search.search(query).await;
-        assert!(matches!(response, Err(_)));
+        assert!(response.is_err());
       },
       VCF_LOCATION,
       &[INDEX_FILE_LOCATION],
@@ -318,7 +318,7 @@ pub(crate) mod tests {
         let query =
           Query::new_with_default_request("vcf-spec-v4.3", Format::Vcf).with_class(Header);
         let response = search.search(query).await;
-        assert!(matches!(response, Err(_)));
+        assert!(response.is_err());
       },
       VCF_LOCATION,
       &[INDEX_FILE_LOCATION],

--- a/htsget-search/src/storage/local.rs
+++ b/htsget-search/src/storage/local.rs
@@ -207,7 +207,7 @@ pub(crate) mod tests {
         GetOptions::new_with_default_range(&Default::default()),
       )
       .await;
-      assert!(matches!(result, Ok(_)));
+      assert!(result.is_ok());
     })
     .await;
   }

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -861,7 +861,7 @@ mod tests {
         DataBlock::Range(pos) => pos.class,
         DataBlock::Data(_, class) => class,
       };
-      assert!(matches!(class, Some(_)));
+      assert!(class.is_some());
     }
   }
 
@@ -876,7 +876,7 @@ mod tests {
         DataBlock::Range(pos) => pos.class,
         DataBlock::Data(_, class) => class,
       };
-      assert!(matches!(class, None));
+      assert!(class.is_none());
     }
   }
 

--- a/htsget-search/src/storage/s3.rs
+++ b/htsget-search/src/storage/s3.rs
@@ -340,7 +340,7 @@ pub(crate) mod tests {
           GetOptions::new_with_default_range(&Default::default()),
         )
         .await;
-      assert!(matches!(result, Ok(_)));
+      assert!(result.is_ok());
     })
     .await;
   }

--- a/htsget-test/Cargo.toml
+++ b/htsget-test/Cargo.toml
@@ -21,8 +21,7 @@ cors-tests = ["http-tests", "dep:htsget-config"]
 server-tests = [
     "http-tests",
     "dep:htsget-config",
-    "dep:noodles-vcf",
-    "dep:noodles-bgzf",
+    "dep:noodles",
     "dep:reqwest",
     "dep:tokio",
     "dep:futures",
@@ -37,8 +36,7 @@ default = []
 # Server tests dependencies
 htsget-config = { version = "0.5.0", path = "../htsget-config", default-features = false, optional = true }
 
-noodles-vcf = { version = "0.24", features = ["async"], optional = true }
-noodles-bgzf = { version = "0.19", features = ["async"], optional = true }
+noodles = { version = "0.40", optional = true, features = ["async", "bgzf", "vcf"] }
 
 reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "rustls-tls"], optional = true }
 tokio = { version = "1.25", features = ["rt-multi-thread"], optional = true }

--- a/htsget-test/Cargo.toml
+++ b/htsget-test/Cargo.toml
@@ -39,7 +39,7 @@ htsget-config = { version = "0.5.0", path = "../htsget-config", default-features
 noodles = { version = "0.40", optional = true, features = ["async", "bgzf", "vcf"] }
 
 reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "rustls-tls"], optional = true }
-tokio = { version = "1.25", features = ["rt-multi-thread"], optional = true }
+tokio = { version = "1.28", features = ["rt-multi-thread"], optional = true }
 futures = { version = "0.3", optional = true }
 async-trait = { version = "0.1", optional = true }
 http = { version = "0.2", optional = true }

--- a/htsget-test/Cargo.toml
+++ b/htsget-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "htsget-test"
 version = "0.4.1"
-rust-version = "1.60"
+rust-version = "1.65"
 authors = ["Marko Malenic <mmalenic1@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/htsget-test/src/server_tests.rs
+++ b/htsget-test/src/server_tests.rs
@@ -8,8 +8,8 @@ use futures::future::join_all;
 use futures::TryStreamExt;
 use http::header::HeaderName;
 use http::{HeaderMap, HeaderValue, Method};
-use noodles_bgzf as bgzf;
-use noodles_vcf as vcf;
+use noodles::bgzf;
+use noodles::vcf;
 use reqwest::ClientBuilder;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -96,7 +96,7 @@ where
   .unwrap();
 
   let mut reader = vcf::AsyncReader::new(bgzf::AsyncReader::new(merged_response.as_slice()));
-  let header = reader.read_header().await.unwrap().parse().unwrap();
+  let header = reader.read_header().await.unwrap();
   println!("{header}");
 
   let mut records = reader.records(&header);


### PR DESCRIPTION
### Changes
* Update noodles to latest version and remove some unused code in `htsget-search`.
* Use a `hyper::Client` instead of `reqwest::Client` for `UrlStorage`.
* Update dependencies to latest versions and update MSRV