### PR TITLE
fix: URL response headers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: build-cache
-          save-if: ${{ github.ref == 'refs/head/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build all features
         uses: actions-rs/cargo@v1
         with:

--- a/htsget-config/examples/config-files/url_storage.toml
+++ b/htsget-config/examples/config-files/url_storage.toml
@@ -3,8 +3,11 @@
 # `cargo run -p htsget-actix --features url-storage -- --config htsget-config/examples/config-files/url_storage.toml`
 # in the project directory.
 
-ticket_server_addr = "0.0.0.0:8080"
+ticket_server_addr = "127.0.0.1:8082"
 ticket_server_cors_allow_origins = "All"
+
+ticket_server_cert = "cert.pem"
+ticket_server_key = "key.pem"
 
 data_server_enabled = false
 
@@ -13,5 +16,6 @@ regex = ".*"
 substitution_string = "$0"
 
 [resolvers.storage]
-url = "http://localhost:3000"
-response_scheme = "http"
+url = "http://127.0.0.1:8081"
+response_scheme = "https"
+forward_headers = true

--- a/htsget-config/src/types.rs
+++ b/htsget-config/src/types.rs
@@ -843,6 +843,23 @@ mod tests {
   }
 
   #[test]
+  fn headers_extend() {
+    let mut headers = Headers::new(HashMap::new());
+    headers.insert("Range", "bytes=0-1023");
+
+    let mut extend_with = Headers::new(HashMap::new());
+    extend_with.insert("header", "value");
+
+    headers.extend(extend_with);
+
+    let result = headers.0.get("Range");
+    assert_eq!(result, Some(&"bytes=0-1023".to_string()));
+
+    let result = headers.0.get("header");
+    assert_eq!(result, Some(&"value".to_string()));
+  }
+
+  #[test]
   fn headers_multiple_values() {
     let headers = Headers::new(HashMap::new())
       .with_header("Range", "bytes=0-1023")
@@ -896,6 +913,25 @@ mod tests {
     let result = Url::new("data:application/vnd.ga4gh.bam;base64,QkFNAQ==")
       .with_headers(Headers::new(HashMap::new()));
     assert_eq!(result.headers, None);
+  }
+
+  #[test]
+  fn url_add_headers() {
+    let mut headers = Headers::new(HashMap::new());
+    headers.insert("Range", "bytes=0-1023");
+
+    let mut extend_with = Headers::new(HashMap::new());
+    extend_with.insert("header", "value");
+
+    let result = Url::new("data:application/vnd.ga4gh.bam;base64,QkFNAQ==")
+      .with_headers(headers)
+      .add_headers(extend_with);
+
+    let expected_headers = Headers::new(HashMap::new())
+      .with_header("Range", "bytes=0-1023")
+      .with_header("header", "value");
+
+    assert_eq!(result.headers, Some(expected_headers));
   }
 
   #[test]

--- a/htsget-config/src/types.rs
+++ b/htsget-config/src/types.rs
@@ -495,10 +495,17 @@ impl Headers {
     }
   }
 
+  /// Add to the headers.
+  pub fn extend(&mut self, headers: Headers) {
+    self.0.extend(headers.into_inner());
+  }
+
+  /// Get the inner HashMap.
   pub fn into_inner(self) -> HashMap<String, String> {
     self.0
   }
 
+  /// Get a reference to the inner HashMap.
   pub fn as_ref_inner(&self) -> &HashMap<String, String> {
     &self.0
   }
@@ -532,6 +539,7 @@ pub struct Url {
 }
 
 impl Url {
+  /// Create a new Url.
   pub fn new<S: Into<String>>(url: S) -> Self {
     Self {
       url: url.into(),
@@ -540,16 +548,31 @@ impl Url {
     }
   }
 
+  /// Add to the headers of the Url.
+  pub fn add_headers(mut self, headers: Headers) -> Self {
+    if !headers.is_empty() {
+      self
+        .headers
+        .get_or_insert_with(Headers::default)
+        .extend(headers);
+    }
+
+    self
+  }
+
+  /// Set the headers of the Url.
   pub fn with_headers(mut self, headers: Headers) -> Self {
     self.headers = Some(headers).filter(|h| !h.is_empty());
     self
   }
 
+  /// Set the class of the Url using an optional value.
   pub fn set_class(mut self, class: Option<Class>) -> Self {
     self.class = class;
     self
   }
 
+  /// Set the class of the Url.
   pub fn with_class(self, class: Class) -> Self {
     self.set_class(Some(class))
   }

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -956,6 +956,27 @@ mod tests {
   }
 
   #[test]
+  fn url_options_apply_with_headers() {
+    let result = RangeUrlOptions::new(
+      BytesPosition::new(Some(5), Some(11), Some(Class::Header)),
+      &Default::default(),
+    )
+    .apply(Url::new("").with_headers(Headers::default().with_header("header", "value")));
+    println!("{result:?}");
+
+    assert_eq!(
+      result,
+      Url::new("")
+        .with_headers(
+          Headers::new(HashMap::new())
+            .with_header("Range", "bytes=5-10")
+            .with_header("header", "value")
+        )
+        .with_class(Class::Header)
+    );
+  }
+
+  #[test]
   fn http_formatter_authority() {
     let formatter = ConfigLocalStorage::new(
       Scheme::Http,

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -459,11 +459,13 @@ impl<'a> RangeUrlOptions<'a> {
 
   pub fn apply(self, url: Url) -> Url {
     let range: String = String::from(&BytesRange::from(self.range()));
+
     let url = if range.is_empty() {
       url
     } else {
-      url.with_headers(Headers::default().with_header("Range", range))
+      url.add_headers(Headers::default().with_header("Range", range))
     };
+
     url.set_class(self.range().class)
   }
 

--- a/htsget-search/src/storage/url.rs
+++ b/htsget-search/src/storage/url.rs
@@ -50,7 +50,7 @@ impl UrlStorage {
       client: Client::builder().build(
         HttpsConnectorBuilder::new()
           .with_native_roots()
-          .https_only()
+          .https_or_http()
           .enable_all_versions()
           .build(),
       ),


### PR DESCRIPTION
### Changes
* Fix URL responses so that headers are correctly forwarded from the client.
* Fix cache creation on the main branch for the build workflow.