### PR TITLE
ci: swap out toolchain actions

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -22,10 +22,11 @@ jobs:
       - name: Check out
         uses: actions/checkout@v3
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
+        id: toolchain
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
+      - run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,11 @@ jobs:
       - name: Check out
         uses: actions/checkout@v3
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
+        id: toolchain
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
+      - run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@main
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,11 +17,12 @@ jobs:
       - name: Check out
         uses: actions/checkout@v3
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
+        id: toolchain
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt, clippy
+      - run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
### Changes
* Use dtolnay/rust-toolchain instead of actions-rs/toolchain.