### PR TITLE
fix(search): enable http/1.1 ALPN on UrlStorage client

### DIFF
--- a/htsget-search/src/storage/url.rs
+++ b/htsget-search/src/storage/url.rs
@@ -51,7 +51,8 @@ impl UrlStorage {
         HttpsConnectorBuilder::new()
           .with_native_roots()
           .https_or_http()
-          .enable_all_versions()
+          .enable_http1()
+          .enable_http2()
           .build(),
       ),
       url,


### PR DESCRIPTION
### Changes
* Enables http/1.1 ALPN by using `enable_http1` and `enable_http2` instead of `enable_all_versions`.