### PR TITLE
fix: truncated header with larger files

### DIFF
--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -453,6 +453,25 @@ pub(crate) mod tests {
     .await
   }
 
+  #[tokio::test]
+  async fn get_header_end_offset() {
+    with_local_storage_fn(
+      |storage| async move {
+        let search = BamSearch::new(storage.clone());
+        let query =
+          Query::new_with_default_request("htsnexus_test_NA12878", Format::Bam).with_class(Header);
+
+        let index = search.read_index(&query).await.unwrap();
+        let response = search.get_header_end_offset(&index).await;
+
+        assert_eq!(response, Ok(256721));
+      },
+      DATA_LOCATION,
+      &[INDEX_FILE_LOCATION],
+    )
+    .await
+  }
+
   #[cfg(feature = "s3-storage")]
   #[tokio::test]
   async fn search_non_existent_id_reference_name_aws() {

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -64,6 +64,17 @@ where
       .with_end(self.position_at_eof(query).await?)
       .with_class(Body)])
   }
+
+  async fn read_bytes(header: &Header, reader: &mut AsyncReader<ReaderType>) -> Option<usize> {
+    reader
+      .read_record(header, &mut Default::default())
+      .await
+      .ok()
+  }
+
+  fn virtual_position(&self, reader: &AsyncReader<ReaderType>) -> VirtualPosition {
+    reader.virtual_position()
+  }
 }
 
 #[async_trait]
@@ -236,7 +247,7 @@ pub(crate) mod tests {
         Format::Bam,
         vec![
           Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=0-256720"))
+            .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
             .with_class(Header),
           Url::new(expected_url())
             .with_headers(Headers::default().with_header("Range", "bytes=2060795-2596770"))
@@ -262,7 +273,7 @@ pub(crate) mod tests {
         Format::Bam,
         vec![
           Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=0-256720"))
+            .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
             .with_class(Header),
           Url::new(expected_url())
             .with_headers(Headers::default().with_header("Range", "bytes=977196-2128165"))
@@ -290,12 +301,18 @@ pub(crate) mod tests {
         Format::Bam,
         vec![
           Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=0-647345")),
+            .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
+            .with_class(Header),
           Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=824361-842100")),
+            .with_headers(Headers::default().with_header("Range", "bytes=256721-647345"))
+            .with_class(Body),
           Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=977196-996014")),
-          Url::new(expected_bgzf_eof_data_url()),
+            .with_headers(Headers::default().with_header("Range", "bytes=824361-842100"))
+            .with_class(Body),
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=977196-996014"))
+            .with_class(Body),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
         ],
       ));
       assert_eq!(response, expected_response)
@@ -317,8 +334,12 @@ pub(crate) mod tests {
         Format::Bam,
         vec![
           Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=0-996014")),
-          Url::new(expected_bgzf_eof_data_url()),
+            .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
+            .with_class(Header),
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=256721-996014"))
+            .with_class(Body),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
         ],
       ));
       assert_eq!(response, expected_response)
@@ -374,8 +395,12 @@ pub(crate) mod tests {
           Format::Bam,
           vec![
             Url::new(expected_url())
-              .with_headers(Headers::default().with_header("Range", "bytes=0-1065951")),
-            Url::new(expected_bgzf_eof_data_url()),
+              .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
+              .with_class(Header),
+            Url::new(expected_url())
+              .with_headers(Headers::default().with_header("Range", "bytes=256721-1065951"))
+              .with_class(Body),
+            Url::new(expected_bgzf_eof_data_url()).with_class(Body),
           ],
         ));
         assert_eq!(response, expected_response)
@@ -398,7 +423,7 @@ pub(crate) mod tests {
       let expected_response = Ok(Response::new(
         Format::Bam,
         vec![Url::new(expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=0-256720"))
+          .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
           .with_class(Header)],
       ));
       assert_eq!(response, expected_response)
@@ -464,7 +489,7 @@ pub(crate) mod tests {
         let index = search.read_index(&query).await.unwrap();
         let response = search.get_header_end_offset(&index).await;
 
-        assert_eq!(response, Ok(256721));
+        assert_eq!(response, Ok(70204));
       },
       DATA_LOCATION,
       &[INDEX_FILE_LOCATION],

--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -236,7 +236,7 @@ pub(crate) mod tests {
         Format::Bam,
         vec![
           Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
+            .with_headers(Headers::default().with_header("Range", "bytes=0-256720"))
             .with_class(Header),
           Url::new(expected_url())
             .with_headers(Headers::default().with_header("Range", "bytes=2060795-2596770"))
@@ -262,7 +262,7 @@ pub(crate) mod tests {
         Format::Bam,
         vec![
           Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
+            .with_headers(Headers::default().with_header("Range", "bytes=0-256720"))
             .with_class(Header),
           Url::new(expected_url())
             .with_headers(Headers::default().with_header("Range", "bytes=977196-2128165"))
@@ -290,18 +290,12 @@ pub(crate) mod tests {
         Format::Bam,
         vec![
           Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
-            .with_class(Header),
+            .with_headers(Headers::default().with_header("Range", "bytes=0-647345")),
           Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=256721-647345"))
-            .with_class(Body),
+            .with_headers(Headers::default().with_header("Range", "bytes=824361-842100")),
           Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=824361-842100"))
-            .with_class(Body),
-          Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=977196-996014"))
-            .with_class(Body),
-          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+            .with_headers(Headers::default().with_header("Range", "bytes=977196-996014")),
+          Url::new(expected_bgzf_eof_data_url()),
         ],
       ));
       assert_eq!(response, expected_response)
@@ -323,12 +317,8 @@ pub(crate) mod tests {
         Format::Bam,
         vec![
           Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
-            .with_class(Header),
-          Url::new(expected_url())
-            .with_headers(Headers::default().with_header("Range", "bytes=256721-996014"))
-            .with_class(Body),
-          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+            .with_headers(Headers::default().with_header("Range", "bytes=0-996014")),
+          Url::new(expected_bgzf_eof_data_url()),
         ],
       ));
       assert_eq!(response, expected_response)
@@ -384,12 +374,8 @@ pub(crate) mod tests {
           Format::Bam,
           vec![
             Url::new(expected_url())
-              .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
-              .with_class(Header),
-            Url::new(expected_url())
-              .with_headers(Headers::default().with_header("Range", "bytes=256721-1065951"))
-              .with_class(Body),
-            Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+              .with_headers(Headers::default().with_header("Range", "bytes=0-1065951")),
+            Url::new(expected_bgzf_eof_data_url()),
           ],
         ));
         assert_eq!(response, expected_response)
@@ -412,7 +398,7 @@ pub(crate) mod tests {
       let expected_response = Ok(Response::new(
         Format::Bam,
         vec![Url::new(expected_url())
-          .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
+          .with_headers(Headers::default().with_header("Range", "bytes=0-256720"))
           .with_class(Header)],
       ));
       assert_eq!(response, expected_response)

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -126,6 +126,7 @@ mod tests {
   #[cfg(feature = "s3-storage")]
   use crate::htsget::from_storage::tests::with_aws_storage_fn;
   use crate::htsget::from_storage::tests::with_local_storage_fn;
+  use crate::htsget::search::SearchAll;
   use crate::storage::local::LocalStorage;
   use crate::{Class::Header, Headers, HtsGetError::NotFound, Response, Url};
 
@@ -266,6 +267,25 @@ mod tests {
           Query::new_with_default_request("vcf-spec-v4.3", Format::Bcf).with_class(Header);
         let response = search.search(query).await;
         assert!(matches!(response, Err(NotFound(_))));
+      },
+      DATA_LOCATION,
+      &[INDEX_FILE_LOCATION],
+    )
+    .await
+  }
+
+  #[tokio::test]
+  async fn get_header_end_offset() {
+    with_local_storage_fn(
+      |storage| async move {
+        let search = BcfSearch::new(storage.clone());
+        let query =
+          Query::new_with_default_request("vcf-spec-v4.3", Format::Bcf).with_class(Header);
+
+        let index = search.read_index(&query).await.unwrap();
+        let response = search.get_header_end_offset(&index).await;
+
+        assert_eq!(response, Ok(950));
       },
       DATA_LOCATION,
       &[INDEX_FILE_LOCATION],

--- a/htsget-search/src/htsget/cram_search.rs
+++ b/htsget-search/src/htsget/cram_search.rs
@@ -16,6 +16,7 @@ use tokio::io::{AsyncRead, BufReader};
 use tokio::{io, select};
 use tracing::{instrument, trace};
 
+use htsget_config::types::Class::Header as HtsGetHeader;
 use htsget_config::types::Interval;
 
 use crate::htsget::search::{Search, SearchAll, SearchReads};
@@ -66,6 +67,20 @@ where
           self.get_format()
         ))
       })
+  }
+
+  async fn get_byte_ranges_for_header(
+    &self,
+    index: &Index,
+    _header: &Header,
+    _reader: &mut AsyncReader<ReaderType>,
+    _query: &Query,
+  ) -> Result<BytesPosition> {
+    Ok(
+      BytesPosition::default()
+        .with_end(self.get_header_end_offset(index).await?)
+        .with_class(HtsGetHeader),
+    )
   }
 
   fn get_eof_marker(&self) -> &[u8] {

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -5,7 +5,7 @@
 //! where the names of the types indicate their purpose.
 //!
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -369,9 +369,9 @@ where
   Header: Send + Sync,
 {
   #[instrument(level = "trace", skip_all)]
-  fn index_positions(index: &Index) -> Vec<u64> {
+  fn index_positions(index: &Index) -> BTreeSet<u64> {
     trace!("getting possible index positions");
-    let mut positions = HashSet::new();
+    let mut positions = BTreeSet::new();
 
     // Its probably most robust to search through all chunks in all reference sequences.
     // See https://github.com/samtools/htslib/issues/1482
@@ -397,9 +397,8 @@ where
         }),
     );
 
-    positions.remove(&0);
-    let mut positions: Vec<u64> = positions.into_iter().collect();
-    positions.sort_unstable();
+    positions.pop_first();
+
     positions
   }
 

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -587,6 +587,8 @@ where
           ))
         })?;
 
+    // The header can only extend past the first index position by the maximum BGZF block size
+    // because otherwise the first index position wouldn't be representing the first reference.
     Ok(first_index_position + MAX_BGZF_ISIZE)
   }
 

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::StreamExt;
 use futures_util::stream::FuturesOrdered;
-use noodles::bgzf::gzi;
+use noodles::bgzf::{gzi, VirtualPosition};
 use noodles::csi::index::reference_sequence::bin::Chunk;
 use noodles::csi::index::ReferenceSequence;
 use noodles::csi::Index;
@@ -20,6 +20,8 @@ use tokio::io::{AsyncRead, BufReader};
 use tokio::select;
 use tokio::task::JoinHandle;
 use tracing::{instrument, trace, trace_span, Instrument};
+
+use htsget_config::types::Class::Header;
 
 use crate::htsget::ConcurrencyError;
 use crate::storage::{BytesPosition, HeadOptions, RangeUrlOptions, Storage};
@@ -31,6 +33,8 @@ pub(crate) static BGZF_EOF: &[u8] = &[
   0x1f, 0x8b, 0x08, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x06, 0x00, 0x42, 0x43, 0x02, 0x00,
   0x1b, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 ];
+
+pub(crate) const MAX_BGZF_ISIZE: u64 = 1 << 16;
 
 /// Helper function to find the first non-none value from a set of futures.
 pub(crate) async fn find_first<T>(
@@ -73,15 +77,13 @@ where
   async fn get_header_end_offset(&self, index: &Index) -> Result<u64>;
 
   /// Returns the header bytes range.
-  #[instrument(level = "trace", skip_all)]
-  async fn get_byte_ranges_for_header(&self, index: &Index) -> Result<BytesPosition> {
-    trace!("getting byte ranges for header");
-    Ok(
-      BytesPosition::default()
-        .with_end(self.get_header_end_offset(index).await?)
-        .with_class(Class::Header),
-    )
-  }
+  async fn get_byte_ranges_for_header(
+    &self,
+    index: &Index,
+    header: &Header,
+    reader: &mut Reader,
+    query: &Query,
+  ) -> Result<BytesPosition>;
 
   /// Get the eof marker for this format.
   fn get_eof_marker(&self) -> &[u8];
@@ -246,7 +248,9 @@ where
           None => self.get_byte_ranges_for_all(&query).await?,
           Some(reference_name) => {
             let index = self.read_index(&query).await?;
-            let header = self.get_header(&query, &index).await?;
+
+            let header_end = self.get_header_end_offset(&index).await?;
+            let (header, mut reader) = self.get_header(&query, header_end).await?;
 
             let mut byte_ranges = self
               .get_byte_ranges_for_reference_name(
@@ -256,7 +260,12 @@ where
                 &query,
               )
               .await?;
-            byte_ranges.push(self.get_byte_ranges_for_header(&index).await?);
+
+            byte_ranges.push(
+              self
+                .get_byte_ranges_for_header(&index, &header, &mut reader, &query)
+                .await?,
+            );
 
             byte_ranges
           }
@@ -280,7 +289,13 @@ where
           .await?;
 
         let index = self.read_index(&query).await?;
-        let header_byte_ranges = self.get_byte_ranges_for_header(&index).await?;
+
+        let header_end = self.get_header_end_offset(&index).await?;
+        let (header, mut reader) = self.get_header(&query, header_end).await?;
+
+        let header_byte_ranges = self
+          .get_byte_ranges_for_header(&index, &header, &mut reader, &query)
+          .await?;
 
         self
           .build_response(
@@ -300,6 +315,7 @@ where
     for block in DataBlock::update_classes(byte_ranges) {
       match block {
         DataBlock::Range(range) => {
+          println!("range: {:#?}", range);
           let storage = self.get_storage();
           let query_owned = query.clone();
 
@@ -330,11 +346,11 @@ where
   }
 
   /// Get the header from the file specified by the id and format.
-  #[instrument(level = "trace", skip(self, index))]
-  async fn get_header(&self, query: &Query, index: &Index) -> Result<Header> {
+  #[instrument(level = "trace", skip(self))]
+  async fn get_header(&self, query: &Query, offset: u64) -> Result<(Header, Reader)> {
     trace!("getting header");
     let get_options = GetOptions::new(
-      self.get_byte_ranges_for_header(index).await?,
+      BytesPosition::default().with_end(offset),
       query.request().headers(),
     );
 
@@ -344,9 +360,12 @@ where
       .await?;
     let mut reader = Self::init_reader(reader_type);
 
-    Self::read_header(&mut reader).await.map_err(|err| {
-      HtsGetError::io_error(format!("reading `{}` header: {}", self.get_format(), err))
-    })
+    Ok((
+      Self::read_header(&mut reader).await.map_err(|err| {
+        HtsGetError::io_error(format!("reading `{}` header: {}", self.get_format(), err))
+      })?,
+      reader,
+    ))
   }
 }
 
@@ -396,8 +415,6 @@ where
           ]
         }),
     );
-
-    positions.pop_first();
 
     positions
   }
@@ -532,6 +549,12 @@ where
   ) -> Result<Vec<BytesPosition>> {
     Ok(Vec::new())
   }
+
+  /// Get the virtual position of the underlying reader.
+  async fn read_bytes(header: &Header, reader: &mut Reader) -> Option<usize>;
+
+  /// Get the virtual position of the underlying reader.
+  fn virtual_position(&self, reader: &Reader) -> VirtualPosition;
 }
 
 #[async_trait]
@@ -553,15 +576,68 @@ where
 
   #[instrument(level = "trace", skip_all, ret)]
   async fn get_header_end_offset(&self, index: &Index) -> Result<u64> {
-    Self::index_positions(index)
-      .into_iter()
-      .next()
-      .ok_or_else(|| {
-        HtsGetError::io_error(format!(
-          "finding header offset in `{}` index",
-          self.get_format()
-        ))
-      })
+    let first_index_position =
+      Self::index_positions(index)
+        .into_iter()
+        .next()
+        .ok_or_else(|| {
+          HtsGetError::io_error(format!(
+            "finding header offset in `{}` index",
+            self.get_format()
+          ))
+        })?;
+
+    Ok(first_index_position + MAX_BGZF_ISIZE)
+  }
+
+  async fn get_byte_ranges_for_header(
+    &self,
+    index: &Index,
+    header: &Header,
+    reader: &mut Reader,
+    query: &Query,
+  ) -> Result<BytesPosition> {
+    let current_block_index = self.virtual_position(reader);
+
+    let mut next_block_index = if current_block_index.uncompressed() == 0 {
+      current_block_index.compressed()
+    } else {
+      loop {
+        let bytes_read = Self::read_bytes(header, reader).await;
+        let actual_block_index = self.virtual_position(reader).compressed();
+
+        if bytes_read == Some(0)
+          || bytes_read.is_none()
+          || actual_block_index > current_block_index.compressed()
+        {
+          break actual_block_index;
+        }
+      }
+    };
+
+    next_block_index = if next_block_index == 0 {
+      // if for some reason that fails, get the second position from the index.
+      let mut positions = Self::index_positions(index);
+
+      positions.pop_first();
+
+      let position = positions.into_iter().next().unwrap_or_default();
+
+      if position == 0 {
+        self.position_at_eof(query).await?
+      } else {
+        position
+      }
+    } else {
+      next_block_index
+    };
+
+    Ok(
+      BytesPosition::default()
+        .with_start(0)
+        .with_end(next_block_index)
+        .with_class(Header),
+    )
   }
 
   fn get_eof_marker(&self) -> &[u8] {

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -315,7 +315,7 @@ where
     for block in DataBlock::update_classes(byte_ranges) {
       match block {
         DataBlock::Range(range) => {
-          println!("range: {:#?}", range);
+          trace!(range = ?range, "range");
           let storage = self.get_storage();
           let query_owned = query.clone();
 

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -603,13 +603,10 @@ where
       current_block_index.compressed()
     } else {
       loop {
-        let bytes_read = Self::read_bytes(header, reader).await;
+        let bytes_read = Self::read_bytes(header, reader).await.unwrap_or_default();
         let actual_block_index = self.virtual_position(reader).compressed();
 
-        if bytes_read == Some(0)
-          || bytes_read.is_none()
-          || actual_block_index > current_block_index.compressed()
-        {
+        if bytes_read == 0 || actual_block_index > current_block_index.compressed() {
           break actual_block_index;
         }
       }

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures_util::stream::FuturesOrdered;
 use noodles::bgzf;
+use noodles::bgzf::VirtualPosition;
 use noodles::csi::index::ReferenceSequence;
 use noodles::csi::Index;
 use noodles::tabix;
@@ -34,6 +35,16 @@ where
   S: Storage<Streamable = ReaderType> + Send + Sync + 'static,
   ReaderType: AsyncRead + Unpin + Send + Sync,
 {
+  async fn read_bytes(header: &Header, reader: &mut AsyncReader<ReaderType>) -> Option<usize> {
+    reader
+      .read_record(header, &mut Default::default())
+      .await
+      .ok()
+  }
+
+  fn virtual_position(&self, reader: &AsyncReader<ReaderType>) -> VirtualPosition {
+    reader.virtual_position()
+  }
 }
 
 #[async_trait]
@@ -286,7 +297,7 @@ pub(crate) mod tests {
         let index = search.read_index(&query).await.unwrap();
         let response = search.get_header_end_offset(&index).await;
 
-        assert_eq!(response, Ok(823));
+        assert_eq!(response, Ok(65536));
       },
       VCF_LOCATION,
       &[INDEX_FILE_LOCATION],


### PR DESCRIPTION
Closes #200 

### Changes
* Ensure that valid header bytes are always returned by parsing and reading the header, and then determining the start of the next BGZF block.
* Add some tests for the header end offset.