### PR TITLE
fix(search): return empty response when reference name is in header

### DIFF
--- a/htsget-search/src/htsget/bam_search.rs
+++ b/htsget-search/src/htsget/bam_search.rs
@@ -424,34 +424,37 @@ pub(crate) mod tests {
   async fn search_header_with_no_mapped_reads() {
     with_local_storage(|storage| async move {
       let search = BamSearch::new(storage.clone());
-      let query =
-        Query::new_with_default_request("htsnexus_test_NA12878", Format::Bam).with_reference_name("22");
+      let query = Query::new_with_default_request("htsnexus_test_NA12878", Format::Bam)
+        .with_reference_name("22");
       let response = search.search(query).await;
       println!("{response:#?}");
 
       let expected_response = Ok(Response::new(
         Format::Bam,
-        vec![Url::new(expected_url())
-               .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
-               .with_class(Header), Url::new(expected_bgzf_eof_data_url()).with_class(Body)],
+        vec![
+          Url::new(expected_url())
+            .with_headers(Headers::default().with_header("Range", "bytes=0-4667"))
+            .with_class(Header),
+          Url::new(expected_bgzf_eof_data_url()).with_class(Body),
+        ],
       ));
       assert_eq!(response, expected_response);
     })
-      .await;
+    .await;
   }
 
   #[tokio::test]
   async fn search_header_with_non_existent_reference_name() {
     with_local_storage(|storage| async move {
       let search = BamSearch::new(storage.clone());
-      let query =
-        Query::new_with_default_request("htsnexus_test_NA12878", Format::Bam).with_reference_name("25");
+      let query = Query::new_with_default_request("htsnexus_test_NA12878", Format::Bam)
+        .with_reference_name("25");
       let response = search.search(query).await;
       println!("{response:#?}");
 
       assert!(matches!(response, Err(NotFound(_))));
     })
-      .await;
+    .await;
   }
 
   #[tokio::test]

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -128,6 +128,7 @@ mod tests {
   use crate::htsget::from_storage::tests::with_local_storage_fn;
   use crate::storage::local::LocalStorage;
   use crate::{Class::Header, Headers, HtsGetError::NotFound, Response, Url};
+  use crate::htsget::vcf_search::VcfSearch;
 
   use super::*;
 
@@ -271,6 +272,20 @@ mod tests {
       &[INDEX_FILE_LOCATION],
     )
     .await
+  }
+
+  #[tokio::test]
+  async fn search_header_with_non_existent_reference_name() {
+    with_local_storage(|storage| async move {
+      let search = VcfSearch::new(storage.clone());
+      let query =
+        Query::new_with_default_request("vcf-spec-v4.3", Format::Vcf).with_reference_name("chr1");
+      let response = search.search(query).await;
+      println!("{response:#?}");
+
+      assert!(matches!(response, Err(NotFound(_))));
+    })
+      .await;
   }
 
   #[cfg(feature = "s3-storage")]

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -135,7 +135,6 @@ mod tests {
   use crate::htsget::from_storage::tests::with_aws_storage_fn;
   use crate::htsget::from_storage::tests::with_local_storage_fn;
   use crate::htsget::search::SearchAll;
-  use crate::htsget::vcf_search::VcfSearch;
   use crate::storage::local::LocalStorage;
   use crate::{Class::Header, Headers, HtsGetError::NotFound, Response, Url};
 
@@ -286,9 +285,9 @@ mod tests {
   #[tokio::test]
   async fn search_header_with_non_existent_reference_name() {
     with_local_storage(|storage| async move {
-      let search = VcfSearch::new(storage.clone());
+      let search = BcfSearch::new(storage.clone());
       let query =
-        Query::new_with_default_request("vcf-spec-v4.3", Format::Vcf).with_reference_name("chr1");
+        Query::new_with_default_request("vcf-spec-v4.3", Format::Bcf).with_reference_name("chr1");
       let response = search.search(query).await;
       println!("{response:#?}");
 

--- a/htsget-search/src/htsget/bcf_search.rs
+++ b/htsget-search/src/htsget/bcf_search.rs
@@ -126,9 +126,9 @@ mod tests {
   #[cfg(feature = "s3-storage")]
   use crate::htsget::from_storage::tests::with_aws_storage_fn;
   use crate::htsget::from_storage::tests::with_local_storage_fn;
+  use crate::htsget::vcf_search::VcfSearch;
   use crate::storage::local::LocalStorage;
   use crate::{Class::Header, Headers, HtsGetError::NotFound, Response, Url};
-  use crate::htsget::vcf_search::VcfSearch;
 
   use super::*;
 
@@ -285,7 +285,7 @@ mod tests {
 
       assert!(matches!(response, Err(NotFound(_))));
     })
-      .await;
+    .await;
   }
 
   #[cfg(feature = "s3-storage")]

--- a/htsget-search/src/htsget/search.rs
+++ b/htsget-search/src/htsget/search.rs
@@ -417,13 +417,6 @@ where
         .query(ref_seq_id, query.interval().into_one_based()?)
         .map_err(|err| HtsGetError::InvalidRange(format!("querying range: {err}")))?;
 
-      if chunks.is_empty() {
-        return Err(HtsGetError::NotFound(
-          "could not find byte ranges for reference sequence".to_string(),
-        ));
-      }
-
-      trace!(id = ?query.id(), ref_seq_id = ?ref_seq_id, "sorting chunks");
       chunks.sort_unstable_by_key(|a| a.end().compressed());
 
       Ok(chunks)

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -265,8 +265,7 @@ pub(crate) mod tests {
     with_local_storage_fn(
       |storage| async move {
         let search = VcfSearch::new(storage.clone());
-        let query =
-          Query::new_with_default_request("spec-v4.3", Format::Vcf).with_class(Header);
+        let query = Query::new_with_default_request("spec-v4.3", Format::Vcf).with_class(Header);
         let response = search.search(query).await;
         assert!(matches!(response, Err(NotFound(_))));
       },
@@ -287,7 +286,7 @@ pub(crate) mod tests {
 
       assert!(matches!(response, Err(NotFound(_))));
     })
-      .await;
+    .await;
   }
 
   #[cfg(feature = "s3-storage")]
@@ -329,8 +328,7 @@ pub(crate) mod tests {
     with_aws_storage_fn(
       |storage| async move {
         let search = VcfSearch::new(storage);
-        let query =
-          Query::new_with_default_request("spec-v4.3", Format::Vcf).with_class(Header);
+        let query = Query::new_with_default_request("spec-v4.3", Format::Vcf).with_class(Header);
         let response = search.search(query).await;
         assert!(response.is_err());
       },

--- a/htsget-search/src/htsget/vcf_search.rs
+++ b/htsget-search/src/htsget/vcf_search.rs
@@ -234,7 +234,7 @@ pub(crate) mod tests {
     with_local_storage_fn(
       |storage| async move {
         let search = VcfSearch::new(storage.clone());
-        let query = Query::new_with_default_request("vcf-spec-v4.3", Format::Vcf);
+        let query = Query::new_with_default_request("spec-v4.3", Format::Vcf);
         let response = search.search(query).await;
         assert!(matches!(response, Err(NotFound(_))));
       },
@@ -250,7 +250,7 @@ pub(crate) mod tests {
       |storage| async move {
         let search = VcfSearch::new(storage.clone());
         let query =
-          Query::new_with_default_request("vcf-spec-v4.3", Format::Vcf).with_reference_name("chrM");
+          Query::new_with_default_request("spec-v4.3", Format::Vcf).with_reference_name("chrM");
         let response = search.search(query).await;
         assert!(matches!(response, Err(NotFound(_))));
       },
@@ -266,7 +266,7 @@ pub(crate) mod tests {
       |storage| async move {
         let search = VcfSearch::new(storage.clone());
         let query =
-          Query::new_with_default_request("vcf-spec-v4.3", Format::Vcf).with_class(Header);
+          Query::new_with_default_request("spec-v4.3", Format::Vcf).with_class(Header);
         let response = search.search(query).await;
         assert!(matches!(response, Err(NotFound(_))));
       },
@@ -276,13 +276,27 @@ pub(crate) mod tests {
     .await
   }
 
+  #[tokio::test]
+  async fn search_header_with_non_existent_reference_name() {
+    with_local_storage(|storage| async move {
+      let search = VcfSearch::new(storage.clone());
+      let query =
+        Query::new_with_default_request("spec-v4.3", Format::Vcf).with_reference_name("chr1");
+      let response = search.search(query).await;
+      println!("{response:#?}");
+
+      assert!(matches!(response, Err(NotFound(_))));
+    })
+      .await;
+  }
+
   #[cfg(feature = "s3-storage")]
   #[tokio::test]
   async fn search_non_existent_id_reference_name_aws() {
     with_aws_storage_fn(
       |storage| async move {
         let search = VcfSearch::new(storage);
-        let query = Query::new_with_default_request("vcf-spec-v4.3", Format::Vcf);
+        let query = Query::new_with_default_request("spec-v4.3", Format::Vcf);
         let response = search.search(query).await;
         assert!(response.is_err());
       },
@@ -299,7 +313,7 @@ pub(crate) mod tests {
       |storage| async move {
         let search = VcfSearch::new(storage);
         let query =
-          Query::new_with_default_request("vcf-spec-v4.3", Format::Vcf).with_reference_name("chrM");
+          Query::new_with_default_request("spec-v4.3", Format::Vcf).with_reference_name("chrM");
         let response = search.search(query).await;
         assert!(response.is_err());
       },
@@ -316,7 +330,7 @@ pub(crate) mod tests {
       |storage| async move {
         let search = VcfSearch::new(storage);
         let query =
-          Query::new_with_default_request("vcf-spec-v4.3", Format::Vcf).with_class(Header);
+          Query::new_with_default_request("spec-v4.3", Format::Vcf).with_class(Header);
         let response = search.search(query).await;
         assert!(response.is_err());
       },


### PR DESCRIPTION
Closes #201 

### Changes
* Return an empty response with header and EOF bytes when a reference name is found in the header but not the index, instead of returning an error.
    * Add tests for this case.
* Fix filename for VCF tests.