### PR TITLE
docs(deploy): make authorizer logic more clear

### DIFF
--- a/deploy/bin/settings.ts
+++ b/deploy/bin/settings.ts
@@ -12,8 +12,10 @@ export const SETTINGS: HtsgetSettings = {
     "arn:aws:s3:::org.umccr.demo.htsget-rs-data/*",
   ],
   lookupHostedZone: true,
-  authorizer: {
+  jwtAuthorizer: {
     // Set this to true if you want a public instance.
     public: false,
+    // jwtAudience: ["audience"],
+    // cogUserPoolId: "user-pool-id"
   },
 };

--- a/htsget-config/src/config/cors.rs
+++ b/htsget-config/src/config/cors.rs
@@ -92,7 +92,7 @@ impl<T> AllowType<T, TaggedTypeAll> {
   }
 }
 
-fn serialize_allow_types<S, T>(names: &Vec<T>, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_allow_types<S, T>(names: &[T], serializer: S) -> Result<S::Ok, S::Error>
 where
   T: Display,
   S: Serializer,


### PR DESCRIPTION
### Changes

* Update wording and naming slightly to make it clear that a JWT authorizer is being used.