### PR TITLE
ci: fix benchmark

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -46,5 +46,5 @@ jobs:
           output-file-path: search-benchmarks-output.json
           native-benchmark-data-dir-path: target/criterion
           fail-on-alert: false
-          github-token: ${{ secrets.HTSGET_RS_BENCHMARKS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         id: toolchain
@@ -33,7 +33,7 @@ jobs:
           shared-key: build-cache
           save-if: false
       - name: Install cargo-criterion
-        uses: baptiste0928/cargo-install@v1
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-criterion
       - name: Run search benchmarks

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,22 +30,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Build all features
-        uses: actions-rs/cargo@v1.0.1
-        with:
-          command: build
-          args: --all-targets --all-features
+        run: cargo build --all-targets --all-features
       - name: Build no default features
-        uses: actions-rs/cargo@v1.0.1
-        with:
-          command: build
-          args: --all-targets --no-default-features
+        run: cargo build --all-targets --no-default-features
       - name: Build s3-storage
-        uses: actions-rs/cargo@v1.0.1
-        with:
-          command: build
-          args: --all-targets --features s3-storage
+        run: cargo build --all-targets --features s3-storage
       - name: Build url-storage
-        uses: actions-rs/cargo@v1.0.1
-        with:
-          command: build
-          args: --all-targets --features url-storage
+        run: cargo build --all-targets --features url-storage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Rust
@@ -22,16 +22,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.HTSGET_RS_CRATES_IO_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to GHCR.io (GH's Container Registry)
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker GitHub release
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: deploy/Dockerfile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Cache
         uses: mozilla-actions/sccache-action@v0.0.3
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         id: toolchain

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,22 +31,10 @@ jobs:
           components: rustfmt, clippy
       - run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
       - name: Cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features  -- -D warnings
+        run: cargo clippy --all-targets --all-features  -- -D warnings
       - name: Run cargo tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+        run: cargo test --all-features
       - name: Run cargo tests with no default features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features
+        run: cargo test --no-default-features


### PR DESCRIPTION
### Changes
* Use GITHUB_TOKEN to authenticate the benchmark action.
* Update action versions and remove actions-rs as it is no longer maintained.