### PR TITLE
docs: docker minio example

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,4 @@ jobs:
           context: .
           file: deploy/Dockerfile
           push: true
-          tags: |
-            ghcr.io/umccr/htsget-rs:dev-latest
-            ghcr.io/umccr/htsget-rs:dev-${{ github.run_number }}
+          tags: ghcr.io/umccr/htsget-rs:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-      - docs/docker-minio-example
-
-env:
-  LATEST_TAG: ghcr.io/umccr/htsget-rs:latest
 
 jobs:
   release:
@@ -20,11 +16,11 @@ jobs:
           fetch-depth: 0
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-      #      - name: Run release-plz
-      #        uses: MarcoIeni/release-plz-action@main
-      #        env:
-      #          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #          CARGO_REGISTRY_TOKEN: ${{ secrets.HTSGET_RS_CRATES_IO_TOKEN }}
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.HTSGET_RS_CRATES_IO_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR.io (GH's Container Registry)
@@ -33,23 +29,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and export to Docker
+      - name: Docker GitHub release
         uses: docker/build-push-action@v5
         with:
           context: .
           file: deploy/Dockerfile
-          load: true
-          tags: ${{ env.LATEST_TAG }}
-      - name: Test running image
-        run: |
-          docker run --rm ${{ env.LATEST_TAG }}
-
-#      - name: Docker GitHub release
-#        id: docker_build
-#        uses: docker/build-push-action@v5
-#        with:
-#          context: .
-#          file: deploy/Dockerfile
-#          push: true
-#          tags: |
-#            ${{ env.LATEST_TAG }}
+          push: true
+          tags: |
+            ghcr.io/umccr/htsget-rs:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
           fetch-depth: 0
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-      - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.HTSGET_RS_CRATES_IO_TOKEN }}
+      #      - name: Run release-plz
+      #        uses: MarcoIeni/release-plz-action@main
+      #        env:
+      #          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #          CARGO_REGISTRY_TOKEN: ${{ secrets.HTSGET_RS_CRATES_IO_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR.io (GH's Container Registry)
@@ -38,6 +38,7 @@ jobs:
         with:
           context: .
           file: deploy/Dockerfile
+          load: true
           tags: ${{ env.LATEST_TAG }}
       - name: Test running image
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+      - docs/docker-minio-example
+
+env:
+  LATEST_TAG: ghcr.io/umccr/htsget-rs:latest
 
 jobs:
   release:
@@ -29,11 +33,22 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker GitHub release
-        id: docker_build
+      - name: Build and export to Docker
         uses: docker/build-push-action@v5
         with:
           context: .
           file: deploy/Dockerfile
-          push: true
-          tags: ghcr.io/umccr/htsget-rs:latest
+          tags: ${{ env.LATEST_TAG }}
+      - name: Test running image
+        run: |
+          docker run --rm ${{ env.LATEST_TAG }}
+
+#      - name: Docker GitHub release
+#        id: docker_build
+#        uses: docker/build-push-action@v5
+#        with:
+#          context: .
+#          file: deploy/Dockerfile
+#          push: true
+#          tags: |
+#            ${{ env.LATEST_TAG }}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.74.0 AS builder
+FROM rust:1.76-slim AS builder
 
 WORKDIR /build
 
@@ -6,20 +6,14 @@ RUN cargo install cargo-strip
 
 COPY . .
 
-RUN cargo build --features url-storage --release && \
+RUN cargo build --all-features --release && \
     cargo strip
 
-FROM debian:stable-slim
+FROM gcr.io/distroless/cc-debian12
 
-RUN apt update && apt install -y libc6-dev && rm -rf /var/lib/apt/lists/*
-
-COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs/
 COPY --from=builder /build/target/release/htsget-actix /usr/local/bin/htsget-actix
 
 ENV HTSGET_TICKET_SERVER_ADDR 0.0.0.0:8080
 ENV HTSGET_DATA_SERVER_ADDR 0.0.0.0:8081
-
-EXPOSE 8080
-EXPOSE 8081
 
 CMD [ "htsget-actix" ]

--- a/deploy/Dockerfile.dockerignore
+++ b/deploy/Dockerfile.dockerignore
@@ -1,0 +1,15 @@
+*
+
+!/htsget-actix
+!/htsget-config
+!/htsget-http
+!/htsget-lambda
+!/htsget-search
+!/htsget-test
+!/Cargo.toml
+!/Cargo.lock
+
+**/benches
+**/examples
+**/LICENSE
+**/*.md

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -137,21 +137,12 @@ Examples of different Lambda events are located in the [`data/events`][data-even
 
 ## Docker
 
-There is a [`compose.yml`][compose-yml] which allows using htsget with docker:
+There are example deployments using Docker under the [examples] directory. These include a [`LocalStorage`][local] deployment
+and a [MinIO][minio] deployment.
 
-```
-docker compose up
-```
-
-This launches a `LocalStorage` htsget-actix server serving data from the [`data`][data] directory
-
-### Local with MinIO (S3) backend
-
-See instructions [inside htsget-config][minio] for an example with docker and MinIO.
-
-[compose-yml]: compose.yml
-[data]: ../data
-[minio]: ../htsget-config/README.md#minio
+[local]: examples/local_storage/README.md
+[examples]: examples
+[minio]: examples/minio/README.md
 [htsget-lambda-bin]: bin/htsget-lambda.ts
 [htsget-lambda-stack]: lib/htsget-lambda-stack.ts
 [htsget-settings]: bin/settings.ts

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -137,33 +137,21 @@ Examples of different Lambda events are located in the [`data/events`][data-even
 
 ## Docker
 
-There are multiple options to use docker containers with htsget-rs:
-
-### Local
+There is a [`compose.yml`][compose-yml] which allows using htsget with docker:
 
 ```
-$ docker build . -f deploy/Dockerfile -t htsget-rs-actix
-$ docker run -p 8080:8080 -p 8081:8081 htsget-rs-actix
-2023-10-25T01:01:38.412471Z  INFO bind_addr{addr=0.0.0.0:8081 cors=CorsConfig { allow_credentials: false, allow_origins: List([HeaderValue("http://localhost:8080")]), allow_headers: Tagged(All), allow_methods: Tagged(All), max_age: 86400, expose_headers: List([]) }}: htsget_search::storage::data_server: data server address bound to address=0.0.0.0:8081
-2023-10-25T01:01:38.412710Z  INFO run_server: htsget_actix: using non-TLS ticket server
-2023-10-25T01:01:38.412805Z  INFO run_server: htsget_actix: htsget query server addresses bound addresses=[0.0.0.0:8080]
-2023-10-25T01:01:38.412837Z  INFO run_server: actix_server::builder: starting 8 workers
-2023-10-25T01:01:38.412892Z  INFO actix_server::server: Actix runtime found; starting in Actix runtime
+docker compose up
 ```
 
-### Local with LocalStack (local AWS)
-
-```
-$ cd deploy
-$ docker compose up --wait -d
-$ npx cdklocal bootstrap
-$ npx cdklocal deploy
-```
+This launches a `LocalStorage` htsget-actix server serving data from the [`data`][data] directory
 
 ### Local with MinIO (S3) backend
 
-TBD, fetch instructions from [NBIS Sweden usecase, test and document them here properly](https://github.com/NBISweden/htsget-rs/tree/docker-testing/deploy).
+See instructions [inside htsget-config][minio] for an example with docker and MinIO.
 
+[compose-yml]: compose.yml
+[data]: ../data
+[minio]: ../htsget-config/README.md#minio
 [htsget-lambda-bin]: bin/htsget-lambda.ts
 [htsget-lambda-stack]: lib/htsget-lambda-stack.ts
 [htsget-settings]: bin/settings.ts

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  htsget-rs:
+    build:
+      context: ../
+      dockerfile: deploy/Dockerfile
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+    volumes:
+      - ./../data:/data

--- a/deploy/config/dev_umccr.toml
+++ b/deploy/config/dev_umccr.toml
@@ -26,27 +26,34 @@ environment = "dev"
 [[resolvers]]
 regex = '^(umccr-10c-data-dev)/(?P<key>.*)$'
 substitution_string = '$key'
+storage = 'S3'
 
 [[resolvers]]
 regex = '^(umccr-10f-data-dev)/(?P<key>.*)$'
 substitution_string = '$key'
+storage = 'S3'
 
 [[resolvers]]
 regex = '^(umccr-10g-data-dev)/(?P<key>.*)$'
 substitution_string = '$key'
+storage = 'S3'
 
 [[resolvers]]
 regex = '^(umccr-agha-test-dev)/(?P<key>.*)$'
 substitution_string = '$key'
+storage = 'S3'
 
 [[resolvers]]
 regex = '^(umccr-research-dev)/(?P<key>.*)$'
 substitution_string = '$key'
+storage = 'S3'
 
 [[resolvers]]
 regex = '^(umccr-primary-data-dev)/(?P<key>.*)$'
 substitution_string = '$key'
+storage = 'S3'
 
 [[resolvers]]
 regex = '^(umccr-validation-prod)/(?P<key>.*)$'
 substitution_string = '$key'
+storage = 'S3'

--- a/deploy/config/prod_umccr.toml
+++ b/deploy/config/prod_umccr.toml
@@ -22,11 +22,14 @@ environment = "prod"
 [[resolvers]]
 regex = '^(umccr-research-dev)/(?P<key>.*)$'
 substitution_string = '$key'
+storage = 'S3'
 
 [[resolvers]]
 regex = '^(umccr-validation-prod)/(?P<key>.*)$'
 substitution_string = '$key'
+storage = 'S3'
 
 [[resolvers]]
 regex = '^(umccr-primary-data-prod)/(?P<key>.*)$'
 substitution_string = '$key'
+storage = 'S3'

--- a/deploy/config/public_umccr.toml
+++ b/deploy/config/public_umccr.toml
@@ -1,19 +1,19 @@
 data_server_enabled = false
 
-name = "umccr-htsget-rs"
-version = "0.1"
-organization_name = "UMCCR"
-organization_url = "https://umccr.org/"
-contact_url = "https://umccr.org/"
-documentation_url = "https://github.com/umccr/htsget-rs"
-environment = "public"
+name = 'umccr-htsget-rs'
+version = '0.1'
+organization_name = 'UMCCR'
+organization_url = 'https://umccr.org/'
+contact_url = 'https://umccr.org/'
+documentation_url = 'https://github.com/umccr/htsget-rs'
+environment = 'public'
 
 [[resolvers]]
-regex = "^(org.umccr.demo.sbeacon-data)/CINECA_UK1/(?P<key>.*)$"
-substitution_string = "CINECA_UK1/$key"
-storage = "S3"
+regex = '^(org.umccr.demo.sbeacon-data)/CINECA_UK1/(?P<key>.*)$'
+substitution_string = 'CINECA_UK1/$key'
+storage = 'S3'
 
 [[resolvers]]
-regex = "^(org.umccr.demo.htsget-rs-data)/(?P<type>bam|cram|vcf|bcf|crypt4gh|mixed)/(?P<key>.*)$"
-substitution_string = "$type/$key"
-storage = "S3"
+regex = '^(org.umccr.demo.htsget-rs-data)/(?P<type>bam|cram|vcf|bcf|crypt4gh|mixed)/(?P<key>.*)$'
+substitution_string = '$type/$key'
+storage = 'S3'

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,8 +1,0 @@
-version: "3.1"
-
-services:
-  htsget-rs:
-    container_name: htsget-rs
-    image: ghcr.io/umccr/htsget-rs:dev-latest
-    ports:
-      - "127.0.0.1:8080-8081:8080-8081"

--- a/deploy/examples/local_storage/README.md
+++ b/deploy/examples/local_storage/README.md
@@ -1,0 +1,15 @@
+# LocalStorage deployment
+
+A simple [`LocalStorage`][local] deployment using default settings is available under the [`compose.yml`][compose] file in this directory.
+
+To run, use:
+
+```
+docker compose up
+```
+
+This launches a `LocalStorage` htsget-actix server serving data from the [`data`][data] directory.
+
+[local]: ../../../htsget-config/README.md#resolvers
+[compose]: compose.yml
+[data]: ../../../data

--- a/deploy/examples/local_storage/README.md
+++ b/deploy/examples/local_storage/README.md
@@ -10,6 +10,35 @@ docker compose up
 
 This launches a `LocalStorage` htsget-actix server serving data from the [`data`][data] directory.
 
+The htsget-rs server can then be queried:
+
+```sh
+curl http://127.0.0.1:8080/reads/data/bam/htsnexus_test_NA12878
+```
+
+Which outputs:
+```sh
+{
+  "htsget": {
+    "format": "BAM",
+    "urls": [
+      {
+        "url": "http://0.0.0.0:8081/data/bam/htsnexus_test_NA12878.bam",
+        "headers": {
+          "Range": "bytes=0-2596770"
+        }
+      },
+      {
+        "url": "data:;base64,H4sIBAAAAAAA/wYAQkMCABsAAwAAAAAAAAAAAA=="
+      }
+    ]
+  }
+}
+```
+
+The volumes of the [`compose.yml`][compose] can be changed to any directory to serve data from it using
+default settings, and `curl http://127.0.0.1:8080/reads/data/<id>`, noting the extra `data` prefix.
+
 [local]: ../../../htsget-config/README.md#resolvers
 [compose]: compose.yml
 [data]: ../../../data

--- a/deploy/examples/local_storage/compose.yml
+++ b/deploy/examples/local_storage/compose.yml
@@ -2,11 +2,9 @@ version: "3"
 
 services:
   htsget-rs:
-    build:
-      context: ../
-      dockerfile: deploy/Dockerfile
+    image: ghcr.io/umccr/htsget-rs:latest
     ports:
       - "8080:8080"
       - "8081:8081"
     volumes:
-      - ./../data:/data
+      - ./../../../data:/data

--- a/deploy/examples/local_storage/compose.yml
+++ b/deploy/examples/local_storage/compose.yml
@@ -7,4 +7,5 @@ services:
       - "8080:8080"
       - "8081:8081"
     volumes:
+      # Change this to any data location to serve files using default settings.
       - ./../../../data:/data

--- a/deploy/examples/minio/README.md
+++ b/deploy/examples/minio/README.md
@@ -1,0 +1,66 @@
+# MinIO deployment
+
+[MinIO][minio] can be used with htsget-rs by configuring the [storage type][storage] as `S3` and setting the `endpoint` to the MinIO server.
+There are a few specific configuration options that need to be considered to use MinIO with htsget-rs, and those include:
+
+* The standard [AWS environment variables][env-variables] for connecting to AWS services must be set, and configured to match those
+used by MinIO.
+    * This means that htsget-rs expects an `AWS_DEFAULT_REGION` to be set, which must match the region used by MinIO (by default us-east-1).
+    * It also means that the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` must be set to match the credentials used by MinIO.
+* If using virtual-hosted style [addressing][virtual-addressing] instead of path style [addressing][path-addressing], `MINIO_DOMAIN` must be
+set on the MinIO server and DNS resolution must allow accessing the MinIO server using `bucket.<MINIO_DOMAIN>`.
+    * Path style addressing can be used instead by setting `path_style = true` under the htsget-rs resolvers storage type.
+
+## Deployment using Docker
+
+The above configuration can be applied using docker-compose to set the relevant environment variables. Additionally, if using
+docker compose and virtual-hosted style addressing, a network alias which allows accessing the MinIO service under `bucket.<MINIO_DOMAIN>`
+must be present.
+
+An example [`compose.yml`][compose] is available which shows htsget-rs configured to use MinIO, serving data from the [data] directory.
+
+After running the compose file, requests can be fetched using htsget:
+
+```sh
+docker compose up
+```
+
+Then:
+
+```sh
+curl http://127.0.0.1:8080/reads/bam/htsnexus_test_NA12878
+```
+
+Outputs:
+```sh
+{
+  "htsget": {
+    "format": "BAM",
+    "urls": [
+      {
+        "url": "http://data.minio:9000/bam/htsnexus_test_NA12878.bam?x-id=GetObject&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=user%2F20240320%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240320T014007Z&X-Amz-Expires=1000&X-Amz-SignedHeaders=host%3Brange&X-Amz-Signature=33a75bd6363ccbfd5ce8edf7e102a5edff8ca7cee17e3c654db01a880e98072d",
+        "headers": {
+          "Range": "bytes=0-2596770"
+        }
+      },
+      {
+        "url": "data:;base64,H4sIBAAAAAAA/wYAQkMCABsAAwAAAAAAAAAAAA=="
+      }
+    ]
+  }
+}
+```
+
+The url tickets can then be fetched within the compose network context:
+
+```sh
+docker exec -it minio curl -H "Range: bytes=0-2596770" "http://data.minio:9000/bam/htsnexus_test_NA12878.bam?x-id=GetObject&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=user%2F20240320%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240320T014007Z&X-Amz-Expires=1000&X-Amz-SignedHeaders=host%3Brange&X-Amz-Signature=33a75bd6363ccbfd5ce8edf7e102a5edff8ca7cee17e3c654db01a880e98072d"
+```
+
+[storage]: ../../../htsget-config/README.md#resolvers
+[minio]: https://min.io/
+[env-variables]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+[virtual-addressing]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#virtual-hosted-style-access
+[path-addressing]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access
+[compose]: compose.yml
+[data]: ../../../data

--- a/deploy/examples/minio/README.md
+++ b/deploy/examples/minio/README.md
@@ -11,6 +11,10 @@ used by MinIO.
 set on the MinIO server and DNS resolution must allow accessing the MinIO server using `bucket.<MINIO_DOMAIN>`.
     * Path style addressing can be used instead by setting `path_style = true` under the htsget-rs resolvers storage type.
 
+The caveats around the addressing style occur because there are two different addressing styles for S3 buckets, path style, e.g.
+`http://minio:9000/bucket`, and virtual-hosted style, e.g. `http://bucket.minio:9000`. AWS has declared path style addressing
+as [deprecated][path-style-deprecated], so this example sets up virtual-hosted style addressing as the default. 
+
 ## Deployment using Docker
 
 The above configuration can be applied using docker-compose to set the relevant environment variables. Additionally, if using
@@ -57,6 +61,7 @@ The url tickets can then be fetched within the compose network context:
 docker exec -it minio curl -H "Range: bytes=0-2596770" "http://data.minio:9000/bam/htsnexus_test_NA12878.bam?x-id=GetObject&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=user%2F20240320%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240320T014007Z&X-Amz-Expires=1000&X-Amz-SignedHeaders=host%3Brange&X-Amz-Signature=33a75bd6363ccbfd5ce8edf7e102a5edff8ca7cee17e3c654db01a880e98072d"
 ```
 
+[path-style-deprecated]: https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
 [storage]: ../../../htsget-config/README.md#resolvers
 [minio]: https://min.io/
 [env-variables]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html

--- a/deploy/examples/minio/compose.yml
+++ b/deploy/examples/minio/compose.yml
@@ -1,0 +1,56 @@
+version: "3"
+
+services:
+  minio:
+    image: docker.io/bitnami/minio:latest
+    container_name: minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      - MINIO_ROOT_USER=user
+      - MINIO_ROOT_PASSWORD=password
+      # Create a bucket called `data`.
+      - MINIO_DEFAULT_BUCKETS=data
+      # This is required to enable virtual-hosted style S3 addressing.
+      - MINIO_DOMAIN=minio
+    networks:
+      default:
+        aliases:
+          # A network alias to the bucket is required if using virtual-hosted style addressing.
+          - data.minio
+    # This specifies the data which will be copied into the MinIO bucket.
+    volumes:
+      - ./../../../data:/tmp/data
+    # An example script to copy over data for testing.
+    command: >
+      /bin/bash -c "
+      /opt/bitnami/scripts/minio/run.sh &
+      until $(curl -s -f http://localhost:9000/minio/health/live); do
+          sleep 1
+      done && 
+      mc alias set minio http://minio:9000 user password;
+      mc mirror /tmp/data minio/data;
+      tail -f /dev/null
+      "
+
+  htsget-rs:
+    image: ghcr.io/umccr/htsget-rs:latest
+    container_name: htsget-rs
+    depends_on:
+      - minio
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+    volumes:
+      - ./:/config
+    environment:
+      # Used to enable more log messages.
+      - RUST_LOG=debug
+      # Point to the config file that has the MinIO endpoint set.
+      - HTSGET_CONFIG=/config/config.toml
+      # The AWS sdk must have the same region set as the minio server.
+      - AWS_REGION=us-east-1
+      # The AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must also match the minio user and password.
+      - AWS_ACCESS_KEY_ID=user
+      - AWS_SECRET_ACCESS_KEY=password

--- a/deploy/examples/minio/config.toml
+++ b/deploy/examples/minio/config.toml
@@ -1,0 +1,12 @@
+data_server_enabled = false
+
+[[resolvers]]
+regex = '.*'
+substitution_string = '$0'
+
+[resolvers.storage]
+bucket = 'data'
+# The minio endpoint is set as the minio service within docker compose.
+endpoint = 'http://minio:9000'
+# Optionally, force path style addressing.
+#path_style = true

--- a/htsget-config/README.md
+++ b/htsget-config/README.md
@@ -435,9 +435,9 @@ endpoint = 'http://127.0.0.1:9000'
 path_style = true
 ```
 
-Care must be taken to ensure that the correct `AWS_REGION`, `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY` is set to allow
-the AWS sdk to reach the endpoint. Additional configuration of the MinIO server is required to use virtual-hosted style
-addressing by setting the `MINIO_DOMAIN` environment variable. Path style addressing can be forced using `path_style = true`.
+Care must be taken to ensure that the [correct][env-variables] `AWS_DEFAULT_REGION`, `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY` is set to allow
+the AWS sdk to reach the endpoint. Additional configuration of the MinIO server is required to use [virtual-hosted][virtual-addressing] style
+addressing by setting the `MINIO_DOMAIN` environment variable. [Path][path-addressing] style addressing can be forced using `path_style = true`.
 
 See the MinIO deployment [example][minio-deployment] for more information on how to configure htsget-rs and MinIO.
 
@@ -459,6 +459,9 @@ This crate has the following features:
 
 This project is licensed under the [MIT license][license].
 
+[path-addressing]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access
+[env-variables]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+[virtual-addressing]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#virtual-hosted-style-access
 [minio-deployment]: ../deploy/examples/minio/README.md
 [license]: LICENSE
 [minio]: https://min.io/

--- a/htsget-config/README.md
+++ b/htsget-config/README.md
@@ -422,34 +422,24 @@ export HTSGET_DATA_SERVER_ENABLED=false
 
 ### MinIO
 
-Operating a local object storage like [MinIO][minio] can be easily achieved by leveraging the `endpoint` directive as shown below:
+Operating a local object storage like [MinIO][minio] can be achieved by leveraging the `endpoint` directive as shown below:
 
 ```toml
 [[resolvers]]
-regex = ".*"
-substitution_string = "$0"
+regex = '.*'
+substitution_string = '$0'
 
 [resolvers.storage]
 bucket = 'bucket'
-endpoint = "http://127.0.0.1:9000"
+endpoint = 'http://127.0.0.1:9000'
+path_style = true
 ```
 
-This will have htsget-rs behaving like the native AWS CLI, i.e:
+Care must be taken to ensure that the correct `AWS_REGION`, `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY` is set to allow
+the AWS sdk to reach the endpoint. Additional configuration of the MinIO server is required to use virtual-hosted style
+addressing by setting the `MINIO_DOMAIN` environment variable. Path style addressing can be forced using `path_style = true`.
 
-```
-mkdir /tmp/test
-minio server /tmp/test
-export AWS_ACCESS_KEY_ID=minioadmin
-export AWS_SECRET_ACCESS_KEY=minioadmin
-aws s3 mb --endpoint-url=http://localhost:9000 s3://bucket/
-aws s3 cp --recursive --endpoint-url=http://localhost:9000 htsget-rs/data/bam s3://bucket/
-cargo run -p htsget-actix -- --config ~/.htsget-rs/config.toml
-
-# On another session/terminal
-curl http://localhost:8080/reads/htsnexus_test_NA12878
-```
-
-Please don't run the example above as-is in production systems ;)
+See the MinIO deployment [example][minio-deployment] for more information on how to configure htsget-rs and MinIO.
 
 ### As a library
 
@@ -469,5 +459,6 @@ This crate has the following features:
 
 This project is licensed under the [MIT license][license].
 
+[minio-deployment]: ../deploy/examples/minio/README.md
 [license]: LICENSE
 [minio]: https://min.io/

--- a/htsget-config/examples/config-files/s3_storage.toml
+++ b/htsget-config/examples/config-files/s3_storage.toml
@@ -12,3 +12,7 @@ data_server_enabled = false
 regex = '^(bucket)/(?P<key>.*)$'
 substitution_string = '$key'
 storage = 'S3'
+
+# Or, set the bucket manually
+#[resolvers.storage]
+#bucket = 'bucket'

--- a/htsget-config/examples/config-files/s3_storage.toml
+++ b/htsget-config/examples/config-files/s3_storage.toml
@@ -11,3 +11,4 @@ data_server_enabled = false
 [[resolvers]]
 regex = '^(bucket)/(?P<key>.*)$'
 substitution_string = '$key'
+storage = 'S3'

--- a/htsget-config/src/storage/mod.rs
+++ b/htsget-config/src/storage/mod.rs
@@ -25,14 +25,8 @@ pub enum TaggedStorageTypes {
 
 /// If s3-storage is enabled, then the default is `S3`, otherwise it is `Local`.
 impl Default for TaggedStorageTypes {
-  #[cfg(not(feature = "s3-storage"))]
   fn default() -> Self {
     Self::Local
-  }
-
-  #[cfg(feature = "s3-storage")]
-  fn default() -> Self {
-    Self::S3
   }
 }
 
@@ -160,13 +154,6 @@ pub(crate) mod tests {
     });
   }
 
-  #[cfg(feature = "s3-storage")]
-  #[test]
-  fn default_tagged_storage_type_s3() {
-    assert_eq!(TaggedStorageTypes::default(), TaggedStorageTypes::S3);
-  }
-
-  #[cfg(not(feature = "s3-storage"))]
   #[test]
   fn default_tagged_storage_type_local() {
     assert_eq!(TaggedStorageTypes::default(), TaggedStorageTypes::Local);


### PR DESCRIPTION
Fixes #231 

### Changes
* Add complete MinIO example with a docker compose showing specific configuration considerations.
* Minimise docker image by using `gcr.io/distroless/cc-debian12`.
* Rearrange examples and some README instructions.
* Remove differing behaviour of the default storage type when compiling with and without the `s3-storage` feature flag.