### PR TITLE
ARM docker releases via GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.HTSGET_RS_CRATES_IO_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64/v8
       - name: Login to GHCR.io (GH's Container Registry)
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Should:

* Not significantly increase runtimes by using QEMU, [prefer native machines instead](https://docs.docker.com/build/building/multi-platform/).
* Preferably avoid multiple docker containers, just ship one that is multiplatform.