### PR TITLE
Tweak docker container labels (was: Docker SOCI support)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64
       - name: Login to GHCR.io (GH's Container Registry)
         uses: docker/login-action@v3
         with:
@@ -36,6 +36,18 @@ jobs:
         with:
           context: .
           file: deploy/Dockerfile
+          platforms: ${{ matrix.platforms }}
           push: true
           tags: |
             ghcr.io/umccr/htsget-rs:latest
+## SOCI (Seekable OCI) support. Only enable when and if docker layers surpass 10MB in the future, see:
+# https://github.com/awslabs/soci-snapshotter/issues/100
+#      - name: Install aws SOCI
+#        uses: iamops-team/aws-soci@v1.0
+#      - name: Pull the image in containerd
+#        run: |
+#          sudo ctr i pull --user ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} ghcr.io/umccr/htsget-rs:latest
+#      - name: Create and push soci index
+#        run: |
+#          sudo soci create ghcr.io/umccr/htsget-rs:latest
+#          sudo soci push --user ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} ghcr.io/umccr/htsget-rs:latest

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,5 +1,11 @@
 FROM rust:1.76-slim AS builder
 
+LABEL org.opencontainers.image.source=https://github.com/umccr/htsget-rs
+LABEL org.opencontainers.image.url=https://github.com/umccr/htsget-rs/pkgs/container/htsget-rs
+LABEL org.opencontainers.image.description="A server implementation of the htsget protocol for bioinformatics in Rust"
+LABEL org.opencontainers.image.licenses=MIT
+LABEL org.opencontainers.image.authors="Roman Valls Guimera <brainstorm@nopcode.org>, Marko Malenic <mmalenic1@gmail.com>"
+
 WORKDIR /build
 
 RUN cargo install cargo-strip


### PR DESCRIPTION
Outcome of this PR w.r.t SOCI is that we don't have layers < 10MB (total docker image size is currently ~50MB), so no `ztocs` indexes are generated and the CI build fails. If and when the layers grow in the future, we can re-evaluate this.

# Docker LABELs

https://github.com/opencontainers/image-spec/blob/main/annotations.md

# SOCI

https://aws.amazon.com/blogs/containers/under-the-hood-lazy-loading-container-images-with-seekable-oci-and-aws-fargate/

https://github.com/awslabs/soci-snapshotter/discussions/949
