### PR TITLE
refactor: simplify default resolvers and local storage data

### DIFF
--- a/htsget-config/README.md
+++ b/htsget-config/README.md
@@ -59,8 +59,8 @@ To configure the data server, set the following options:
 | Option                                                                                    | Description                                                                                                                                                                                              | Type                                      | Default                     |
 |-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|-----------------------------|
 | <span id="data_server_addr">`data_server_addr`</span>                                     | The address for the data server.                                                                                                                                                                         | Socket address                            | `'127.0.0.1:8081'`          | 
-| <span id="data_server_local_path">`data_server_local_path`</span>                         | The local path which the data server can access to serve files.                                                                                                                                          | Filesystem path                           | `'data'`                    |
-| <span id="data_server_serve_at">`data_server_serve_at`</span>                             | The path which the data server will prefix to all response URLs for tickets.                                                                                                                             | URL path                                  | `'/data'`                   |
+| <span id="data_server_local_path">`data_server_local_path`</span>                         | The local path which the data server can access to serve files.                                                                                                                                          | Filesystem path                           | `'./'`                      |
+| <span id="data_server_serve_at">`data_server_serve_at`</span>                             | The path which the data server will prefix to all response URLs for tickets.                                                                                                                             | URL path                                  | `''`                        |
 | <span id="data_server_tls">`data_server_tls`</span>                                       | Enable TLS for the data server. See [TLS](#tls) for more details.                                                                                                                                        | TOML table                                | Not enabled                 |
 | <span id="data_server_cors_allow_credentials">`data_server_cors_allow_credentials`</span> | Controls the CORS Access-Control-Allow-Credentials for the data server.                                                                                                                                  | Boolean                                   | `false`                     |
 | <span id="data_server_cors_allow_origins">`data_server_cors_allow_origins`</span>         | Set the CORS Access-Control-Allow-Origin returned by the data server, this can be set to `All` to send a wildcard, `Mirror` to echo back the request sent by the client, or a specific array of origins. | `'All'`, `'Mirror'` or a array of origins | `['http://localhost:8080']` |
@@ -72,8 +72,8 @@ To configure the data server, set the following options:
 TLS is supported by setting the `data_server_key` and `data_server_cert` options.  An example of config for the data server:
 ```toml
 data_server_addr = '127.0.0.1:8081'
-data_server_local_path = 'data'
-data_server_serve_at = '/data'
+data_server_local_path = './'
+data_server_serve_at = ''
 data_server_key = 'key.pem'
 data_server_cert = 'cert.pem'
 data_server_cors_allow_credentials = false
@@ -134,8 +134,8 @@ To create a resolver, add a `[[resolvers]]` array of tables, and set the followi
 
 | Option                | Description                                                                                                             | Type                                  | Default |
 |-----------------------|-------------------------------------------------------------------------------------------------------------------------|---------------------------------------|---------|
-| `regex`               | A regular expression which can match a query ID.                                                                        | Regex                                 | '.*'    | 
-| `substitution_string` | The replacement expression used to map the matched query ID. This has access to the match groups in the `regex` option. | String with access to capture groups  | '$0'    |
+| `regex`               | A regular expression which can match a query ID.                                                                        | Regex                                 | `'.*'`  | 
+| `substitution_string` | The replacement expression used to map the matched query ID. This has access to the match groups in the `regex` option. | String with access to capture groups  | `'$0'`  |
 
 For example, below is a `regex` option which matches a `/` between two groups, and inserts an additional `data`
 inbetween the groups with the `substitution_string`.
@@ -157,8 +157,8 @@ To use `LocalStorage`, set `storage = 'Local'`. This will derive the values for 
 |---------------------|-------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|------------------------------|--------------------|
 | `scheme`            | The scheme present on URL tickets.                                                                                                  | Derived from `data_server_key` and `data_server_cert`. If no key and cert are present, then uses `Http`, otherwise uses `Https`. | Either `'Http'` or `'Https'` | `'Http'`           |
 | `authority`         | The authority present on URL tickets. This should likely match the `data_server_addr`.                                              | Same as `data_server_addr`.                                                                                                      | URL authority                | `'127.0.0.1:8081'` |
-| `local_path`        | The local filesystem path which the data server uses to respond to tickets.  This should likely match the `data_server_local_path`. | Same as `data_server_local_path`.                                                                                                | Filesystem path              | `'data'`           |
-| `path_prefix`       | The path prefix which the URL tickets will have. This should likely match the `data_server_serve_at` path.                          | Same as `data_server_serve_at`.                                                                                                  | URL path                     | `'/data'`          |
+| `local_path`        | The local filesystem path which the data server uses to respond to tickets.  This should likely match the `data_server_local_path`. | Same as `data_server_local_path`.                                                                                                | Filesystem path              | `'./'`             |
+| `path_prefix`       | The path prefix which the URL tickets will have. This should likely match the `data_server_serve_at` path.                          | Same as `data_server_serve_at`.                                                                                                  | URL path                     | `''`               |
 
 To use `S3Storage`, build htsget-rs with the `s3-storage` feature enabled, and set `storage = 'S3'`. This will derive the value for `bucket` from the `regex` component of the `resolvers`:
 
@@ -206,8 +206,8 @@ substitution_string = '$0'
 [resolvers.storage]
 scheme = 'Http'
 authority = '127.0.0.1:8081'
-local_path = 'data'
-path_prefix = '/data'
+local_path = './'
+path_prefix = ''
 ```
 
 or, to manually set the config for `S3Storage`:

--- a/htsget-config/examples/config-files/default.toml
+++ b/htsget-config/examples/config-files/default.toml
@@ -10,8 +10,8 @@ ticket_server_cors_max_age = 86400
 ticket_server_cors_expose_headers = []
 data_server_enabled = true
 data_server_addr = "127.0.0.1:8081"
-data_server_local_path = "data"
-data_server_serve_at = "/data"
+data_server_local_path = "./"
+data_server_serve_at = ""
 data_server_cors_allow_credentials = false
 data_server_cors_allow_origins = ["http://localhost:8080"]
 data_server_cors_allow_headers = "All"
@@ -20,8 +20,8 @@ data_server_cors_max_age = 86400
 data_server_cors_expose_headers = []
 
 [[resolvers]]
-regex = "(data)/(.*)"
-substitution_string = "$2"
+regex = ".*"
+substitution_string = "$0"
 storage = "Local"
 
 [resolvers.allow_guard]

--- a/htsget-config/src/config/mod.rs
+++ b/htsget-config/src/config/mod.rs
@@ -42,11 +42,7 @@ fn default_server_origin() -> &'static str {
 }
 
 pub(crate) fn default_path() -> &'static str {
-  "data"
-}
-
-pub(crate) fn default_serve_at() -> &'static str {
-  "/data"
+  "./"
 }
 
 /// The command line arguments allowed for the htsget-rs executables.
@@ -268,7 +264,7 @@ impl Default for DataServerConfig {
         .parse()
         .expect("expected valid address"),
       local_path: default_path().into(),
-      serve_at: default_serve_at().into(),
+      serve_at: Default::default(),
       tls: None,
       cors: CorsConfig::default(),
     }

--- a/htsget-config/src/resolver.rs
+++ b/htsget-config/src/resolver.rs
@@ -270,13 +270,8 @@ impl QueryAllowed for AllowGuard {
 
 impl Default for Resolver {
   fn default() -> Self {
-    Self::new(
-      Storage::default(),
-      "(data)/(.*)",
-      "$2",
-      AllowGuard::default(),
-    )
-    .expect("expected valid storage")
+    Self::new(Storage::default(), ".*", "$0", AllowGuard::default())
+      .expect("expected valid storage")
   }
 }
 

--- a/htsget-config/src/storage/local.rs
+++ b/htsget-config/src/storage/local.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use http::uri::Authority;
 use serde::{Deserialize, Serialize};
 
-use crate::config::{default_localstorage_addr, default_path, default_serve_at, DataServerConfig};
+use crate::config::{default_localstorage_addr, default_path, DataServerConfig};
 use crate::tls::KeyPairScheme;
 use crate::types::Scheme;
 
@@ -13,10 +13,6 @@ pub(crate) fn default_authority() -> Authority {
 
 fn default_local_path() -> String {
   default_path().into()
-}
-
-fn default_path_prefix() -> String {
-  default_serve_at().into()
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -72,7 +68,7 @@ impl Default for LocalStorage {
       scheme: Scheme::Http,
       authority: default_authority(),
       local_path: default_local_path(),
-      path_prefix: default_path_prefix(),
+      path_prefix: Default::default(),
     }
   }
 }


### PR DESCRIPTION
Closes #239, there's no need for the defaults to be any more complicated than a 1-1 mapping.

### Changes
* Change default resolvers to `.*` and `$0`, and default local storage locations to the current directory.
    * When running with default settings, data can still be fetched from `data/.../<id>`.
    * Docker examples also work with a 1-1 mapping between the mount point and url paths.