### PR TITLE
docs: update deployment README

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -43,7 +43,7 @@ can be found under [`bin/htsget-lambda.ts`][htsget-lambda-bin]. This uses the [`
 1. [aws-cli] should be installed and authenticated in the shell.
 2. Node.js and [npm] should be installed.
 3. [Rust][rust] should be installed.
-4. [Zig][zig] should be installed.
+4. [Zig][zig] should be installed. Zig can be installed by running `cargo lambda build` at least once.
 
 After installing the basic dependencies, complete the following steps:
 
@@ -55,6 +55,9 @@ Below is a summary of commands to run in this directory:
 
 ```sh
 cargo install cargo-lambda
+
+## Install zig if not already installed.
+#cd .. && cargo lambda build && cd deploy
 
 export CDK_DEFAULT_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
 export CDK_DEFAULT_REGION=$(aws configure get region)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -41,39 +41,38 @@ can be found under [`bin/htsget-lambda.ts`][htsget-lambda-bin]. This uses the [`
 ### Prerequisites
 
 1. [aws-cli] should be installed and authenticated in the shell.
-1. Node.js and [npm] should be installed.
-1. [Rust][rust] should be installed.
-1. [Zig][zig] should be installed
+2. Node.js and [npm] should be installed.
+3. [Rust][rust] should be installed.
+4. [Zig][zig] should be installed.
 
 After installing the basic dependencies, complete the following steps:
 
-1. Define CDK\_DEFAULT\_* env variables (if not defined already). You must be authenticated with your AWS cloud to run this step.
-1. Add the arm cross-compilation target to rust.
-1. Install [cargo-lambda], as it is used to compile artifacts that are uploaded to aws lambda.
-1. Define which configuration to use for htsget-rs on `cdk.json` as stated in aforementioned configuration section. 
+1. Login to AWS and define `CDK_DEFAULT_*` env variables (if not defined already). You must be authenticated with your AWS cloud to run this step.
+2. Install [cargo-lambda], as it is used to compile artifacts that are uploaded to aws lambda.
+3. Define which configuration to use for htsget-rs as stated in the configuration section. 
 
 Below is a summary of commands to run in this directory:
 
 ```sh
-``export CDK_DEFAULT_ACCOUNT=`aws sts get-caller-identity --query Account --output text`
-export CDK_DEFAULT_REGION=`aws configure get region```
-rustup target add aarch64-unknown-linux-gnu
 cargo install cargo-lambda
+
+export CDK_DEFAULT_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+export CDK_DEFAULT_REGION=$(aws configure get region)
+
 npm install
 ```
 
 ### Deploy to AWS
 
-CDK should be bootstrapped once, if this hasn't been done before.
+CDK should be bootstrapped once, if this hasn't been done before:
 
 ```sh
 npx cdk bootstrap
 ```
 
-In order to deploy, check that the stack synthesizes correctly and then deploy.
+Then to deploy the stack, run:
 
 ```sh
-npx cdk synth
 npx cdk deploy
 ```
 

--- a/deploy/bin/settings.ts
+++ b/deploy/bin/settings.ts
@@ -15,7 +15,7 @@ export const SETTINGS: HtsgetSettings = {
   jwtAuthorizer: {
     // Set this to true if you want a public instance.
     public: false,
-    jwtAudience: ["audience"],
-    cogUserPoolId: "user-pool-id",
+    // jwtAudience: ["audience"],
+    // cogUserPoolId: "user-pool-id",
   },
 };

--- a/deploy/bin/settings.ts
+++ b/deploy/bin/settings.ts
@@ -15,7 +15,7 @@ export const SETTINGS: HtsgetSettings = {
   jwtAuthorizer: {
     // Set this to true if you want a public instance.
     public: false,
-    // jwtAudience: ["audience"],
-    // cogUserPoolId: "user-pool-id"
+    jwtAudience: ["audience"],
+    cogUserPoolId: "user-pool-id",
   },
 };

--- a/deploy/lib/htsget-lambda-stack.ts
+++ b/deploy/lib/htsget-lambda-stack.ts
@@ -14,14 +14,6 @@ import {
 } from "aws-cdk-lib/aws-iam";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
 import {
-  CorsHttpMethod,
-  HttpMethod,
-  HttpApi,
-  DomainName,
-} from "@aws-cdk/aws-apigatewayv2-alpha";
-import { HttpLambdaIntegration } from "@aws-cdk/aws-apigatewayv2-integrations-alpha";
-import { HttpJwtAuthorizer } from "@aws-cdk/aws-apigatewayv2-authorizers-alpha";
-import {
   Certificate,
   CertificateValidation,
 } from "aws-cdk-lib/aws-certificatemanager";
@@ -29,6 +21,14 @@ import { ARecord, HostedZone, RecordTarget } from "aws-cdk-lib/aws-route53";
 import { ApiGatewayv2DomainProperties } from "aws-cdk-lib/aws-route53-targets";
 import { RustFunction } from "cargo-lambda-cdk";
 import path from "path";
+import { HttpLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations";
+import {
+  CorsHttpMethod,
+  DomainName,
+  HttpApi,
+  HttpMethod,
+} from "aws-cdk-lib/aws-apigatewayv2";
+import { HttpJwtAuthorizer } from "aws-cdk-lib/aws-apigatewayv2-authorizers";
 
 /**
  * Settings related to the htsget lambda stack.

--- a/deploy/lib/htsget-lambda-stack.ts
+++ b/deploy/lib/htsget-lambda-stack.ts
@@ -4,7 +4,6 @@ import { readFileSync } from "fs";
 
 import { Duration, Stack, StackProps, Tags } from "aws-cdk-lib";
 import { Construct } from "constructs";
-import { RustFunction, Settings } from "rust.aws-cdk-lambda";
 
 import { UserPool } from "aws-cdk-lib/aws-cognito";
 import {
@@ -28,6 +27,8 @@ import {
 } from "aws-cdk-lib/aws-certificatemanager";
 import { ARecord, HostedZone, RecordTarget } from "aws-cdk-lib/aws-route53";
 import { ApiGatewayv2DomainProperties } from "aws-cdk-lib/aws-route53-targets";
+import { RustFunction } from "cargo-lambda-cdk";
+import path from "path";
 
 /**
  * Settings related to the htsget lambda stack.
@@ -160,28 +161,23 @@ export class HtsgetLambdaStack extends Stack {
     );
     lambdaRole.addToPolicy(s3BucketPolicy);
 
-    // Set the workspace directory of htsget.
-    Settings.WORKSPACE_DIR = "../";
-    // Don't build htsget packages other than htsget-lambda.
-    Settings.BUILD_INDIVIDUALLY = true;
-
     let htsgetLambda = new RustFunction(this, id + "Function", {
-      // Build htsget-lambda only.
-      package: "htsget-lambda",
-      target: "aarch64-unknown-linux-gnu",
-
+      manifestPath: path.join(__dirname, "..", ".."),
+      binaryName: "htsget-lambda",
+      bundling: {
+        environment: {
+          RUSTFLAGS: "-C target-cpu=neoverse-n1",
+          CARGO_PROFILE_RELEASE_LTO: "true",
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1",
+        },
+        cargoLambdaFlags: ["--features", "s3-storage"],
+      },
       memorySize: 128,
       timeout: Duration.seconds(28),
       environment: {
         ...config.htsgetConfig,
         RUST_LOG:
           "info,htsget_http_lambda=trace,htsget_config=trace,htsget_http_core=trace,htsget_search=trace",
-      },
-      features: ["s3-storage"],
-      buildEnvironment: {
-        RUSTFLAGS: "-C target-cpu=neoverse-n1",
-        CARGO_PROFILE_RELEASE_LTO: "true",
-        CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1",
       },
       architecture: Architecture.ARM_64,
       role: lambdaRole,

--- a/deploy/package-lock.json
+++ b/deploy/package-lock.json
@@ -13,9 +13,9 @@
         "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.96.1-alpha.0",
         "@iarna/toml": "^3.0.0",
         "aws-cdk-lib": "^2.96.1",
+        "cargo-lambda-cdk": "^0.0.22",
         "constructs": "^10.1.148",
         "glob": "^10.3.10",
-        "rust.aws-cdk-lambda": "^1.1.3",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -103,41 +103,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "optional": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "optional": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "optional": true,
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -147,56 +112,11 @@
         "node": ">=14"
       }
     },
-    "node_modules/@types/fs-extra": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
-      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/minimist": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
-      "optional": true
-    },
     "node_modules/@types/node": {
       "version": "18.13.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
       "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
-      "devOptional": true
-    },
-    "node_modules/@types/ps-tree": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/ps-tree/-/ps-tree-1.1.2.tgz",
-      "integrity": "sha512-ZREFYlpUmPQJ0esjxoG1fMvB2HNaD3z+mjqdSosZvd3RalncI9NEur73P8ZJz4YQdL64CmV1w0RuqoRUlhQRBw==",
-      "optional": true
-    },
-    "node_modules/@types/which": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
-      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
-      "optional": true
-    },
-    "node_modules/@ziglang/cli": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@ziglang/cli/-/cli-0.0.11.tgz",
-      "integrity": "sha512-PCeyxchKF1nG9tr4sHUJlJiDjSFP0D+YS7jS0qREaAsa0cjdXYCqGXltFrEEbSMgWWkxJr9KnWviJgnHnnSFeg==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "zx": "^6.0.7"
-      },
-      "bin": {
-        "zig": "bin/zig",
-        "zig-cli": "zig.js",
-        "zig-install": "install.js",
-        "zig-postinstall": "postinstall.js",
-        "zig-reinstall": "reinstall.js",
-        "zig-uninstall": "uninstall.js"
-      }
+      "dev": true
     },
     "node_modules/ansi-regex": {
       "version": "6.0.1",
@@ -600,33 +520,120 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "optional": true,
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
-    "node_modules/chalk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
-      "optional": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+    "node_modules/cargo-lambda-cdk": {
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/cargo-lambda-cdk/-/cargo-lambda-cdk-0.0.22.tgz",
+      "integrity": "sha512-lpRh4TFR03FSWw/Ji6D3ZD18mAJjeWvU8ST5UdS6RwbdSXQT/0TbEjG/ccMCpqNGtrlx+txQ8WYURgtNbnDKcw==",
+      "bundleDependencies": [
+        "js-toml"
+      ],
+      "dependencies": {
+        "js-toml": "^0.1.1"
       },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.63.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/@babel/runtime-corejs3": {
+      "version": "7.23.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.30.2",
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/@chevrotain/cst-dts-gen": {
+      "version": "10.5.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/@chevrotain/gast": {
+      "version": "10.5.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "10.5.0",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/@chevrotain/types": {
+      "version": "10.5.0",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/@chevrotain/utils": {
+      "version": "10.5.0",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/chevrotain": {
+      "version": "10.5.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "10.5.0",
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
+        "@chevrotain/utils": "10.5.0",
+        "lodash": "4.17.21",
+        "regexp-to-ast": "0.5.0"
+      }
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/core-js-pure": {
+      "version": "3.33.2",
+      "hasInstallScript": true,
+      "inBundle": true,
+      "license": "MIT",
       "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/js-toml": {
+      "version": "0.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "chevrotain": "^10.4.1",
+        "xregexp": "^5.1.1"
+      }
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/lodash": {
+      "version": "4.17.21",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/regexp-to-ast": {
+      "version": "0.5.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cargo-lambda-cdk/node_modules/xregexp": {
+      "version": "5.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.16.5"
       }
     },
     "node_modules/color-convert": {
@@ -666,15 +673,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "optional": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/diff": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
@@ -683,24 +681,6 @@
       "engines": {
         "node": ">=0.3.1"
       }
-    },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "optional": true,
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "optional": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -711,81 +691,6 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
-    },
-    "node_modules/event-stream": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
-      "optional": true,
-      "dependencies": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
-      }
-    },
-    "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
-      "optional": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-      "optional": true,
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "optional": true,
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/foreground-child": {
       "version": "3.1.1",
@@ -800,38 +705,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "optional": true,
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
-      "optional": true
-    },
-    "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "optional": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/fsevents": {
@@ -869,88 +742,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "optional": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/globby": {
-      "version": "13.1.3",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
-      "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
-      "optional": true,
-      "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.11",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "optional": true
-    },
-    "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-      "optional": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "optional": true,
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/isexe": {
@@ -975,52 +772,12 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "optional": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
       "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
       "engines": {
         "node": "14 || >=16.14"
-      }
-    },
-    "node_modules/map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
-      "optional": true
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "optional": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "optional": true,
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/minimatch": {
@@ -1037,58 +794,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "optional": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/minipass": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
       "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "optional": true,
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-      "optional": true,
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/path-key": {
@@ -1114,36 +825,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
-      "optional": true,
-      "dependencies": {
-        "through": "~2.3"
-      }
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "optional": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/prettier": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
@@ -1157,94 +838,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/ps-tree": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
-      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
-      "optional": true,
-      "dependencies": {
-        "event-stream": "=3.3.4"
-      },
-      "bin": {
-        "ps-tree": "bin/ps-tree.js"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "optional": true
-    },
-    "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "optional": true,
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/rust.aws-cdk-lambda": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rust.aws-cdk-lambda/-/rust.aws-cdk-lambda-1.2.1.tgz",
-      "integrity": "sha512-BlkV7rVRQUkLVQuwP1A89C8f9yuDA1St7B/+EsckxBu/fUER8KKLydoe/hMfskCt6LQaIIAQqGqZ6HUr1DHjnw==",
-      "dependencies": {
-        "aws-cdk-lib": "^2.*",
-        "constructs": "^10.*",
-        "toml": "~3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.3.0"
-      },
-      "optionalDependencies": {
-        "@ziglang/cli": "^0.0.11"
-      },
-      "peerDependencies": {
-        "aws-cdk-lib": "^2.*",
-        "constructs": "^10.*"
       }
     },
     "node_modules/shebang-command": {
@@ -1277,18 +870,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1304,27 +885,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
-      "optional": true,
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
-      "optional": true,
-      "dependencies": {
-        "duplexer": "~0.1.1"
       }
     },
     "node_modules/string-width": {
@@ -1415,29 +975,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "optional": true
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "optional": true,
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/toml": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
-    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -1449,24 +986,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "optional": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "optional": true,
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/which": {
@@ -1566,49 +1085,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/yaml": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
-      "optional": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/zx": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/zx/-/zx-6.2.5.tgz",
-      "integrity": "sha512-aTEZSL8sp1IhMUhxlXRTPH6MwzcuTBA3G4LLuH68NIj8kENfcaVGV7cn8LQXXHwG1M9LDI6ST6Qcw0EOrhRAVA==",
-      "optional": true,
-      "dependencies": {
-        "@types/fs-extra": "^9.0.13",
-        "@types/minimist": "^1.2.2",
-        "@types/node": "^17.0",
-        "@types/ps-tree": "^1.1.2",
-        "@types/which": "^2.0.1",
-        "chalk": "^5.0.1",
-        "fs-extra": "^10.1.0",
-        "globby": "^13.1.1",
-        "ignore": "^5.2.0",
-        "minimist": "^1.2.6",
-        "node-fetch": "^3.2.5",
-        "ps-tree": "^1.2.0",
-        "which": "^2.0.2",
-        "yaml": "^2.1.1"
-      },
-      "bin": {
-        "zx": "build/cli.js"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      }
-    },
-    "node_modules/zx/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "optional": true
     }
   }
 }

--- a/deploy/package-lock.json
+++ b/deploy/package-lock.json
@@ -8,11 +8,8 @@
       "name": "htsget-lambda",
       "version": "1.0",
       "dependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "^2.96.1-alpha.0",
-        "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "^2.96.1-alpha.0",
-        "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.96.1-alpha.0",
         "@iarna/toml": "^3.0.0",
-        "aws-cdk-lib": "^2.96.1",
+        "aws-cdk-lib": "^2.144.0",
         "cargo-lambda-cdk": "^0.0.22",
         "constructs": "^10.1.148",
         "glob": "^10.3.10",
@@ -23,16 +20,15 @@
       },
       "devDependencies": {
         "@types/node": "^18.11.18",
-        "aws-cdk": "^2.96.1",
-        "aws-cdk-local": "^2.18.0",
+        "aws-cdk": "^2.144.0",
         "prettier": "2.8.3",
         "typescript": "^4.9.4"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.200",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz",
-      "integrity": "sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg=="
+      "version": "2.2.202",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
+      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.2",
@@ -40,47 +36,9 @@
       "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
-      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
-    },
-    "node_modules/@aws-cdk/aws-apigatewayv2-alpha": {
-      "version": "2.96.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.96.1-alpha.0.tgz",
-      "integrity": "sha512-pamzRMhyw0CxvvWBAuIyADWPWy1/zxUd22GncGRTwds+Frtv4FXNLQX5s/cXQR8fMwOUyRI/Zyf7HP6yRm9YGg==",
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "aws-cdk-lib": "2.96.1",
-        "constructs": "^10.0.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-apigatewayv2-authorizers-alpha": {
-      "version": "2.96.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-authorizers-alpha/-/aws-apigatewayv2-authorizers-alpha-2.96.1-alpha.0.tgz",
-      "integrity": "sha512-4HidQ9EVADYBo8tyEllv8q0ttM8QalHOZygmMJ7ZK5jcx5Ya86GCHrkFsbH+iP3HD3EmPx1eLKgpgPcWCZyWEQ==",
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "2.96.1-alpha.0",
-        "aws-cdk-lib": "2.96.1",
-        "constructs": "^10.0.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-apigatewayv2-integrations-alpha": {
-      "version": "2.96.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-integrations-alpha/-/aws-apigatewayv2-integrations-alpha-2.96.1-alpha.0.tgz",
-      "integrity": "sha512-gFF7pa+Nn5dd06Qa4Ywdc+wEu7nE4OkcRSsFRUQX8vSefiIMcmyaDUNNhdpSOn6rIfsmae4OdPAeqcdQmaQv2A==",
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "2.96.1-alpha.0",
-        "aws-cdk-lib": "2.96.1",
-        "constructs": "^10.0.0"
-      }
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
+      "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg=="
     },
     "node_modules/@iarna/toml": {
       "version": "3.0.0",
@@ -141,9 +99,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.96.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.96.1.tgz",
-      "integrity": "sha512-dCMriGZj2w6/B5+bu45knQM9QmPpDoUMiGCzsxALsOJVu/Fr5QwvmHxRBTc48uaVAOlYN2qQsAcG5H6TXtBJhg==",
+      "version": "2.144.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.144.0.tgz",
+      "integrity": "sha512-qsTZGCceKi15oOYbWvWpIZNBHRZa+WTV5IIN20leQV9PVRxzHGN58VCOIAiyT1+CncDYjY9grLXEGAOuKRynFQ==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -156,9 +114,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.96.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.96.1.tgz",
-      "integrity": "sha512-7jo7btYghU0OCx9BUi/CmEL967Udc3PNm45uBxn6P2ipvhuYSLkJj0toNiln8uPmMKdTzZPH2r22kX+7N9NzQw==",
+      "version": "2.144.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.144.0.tgz",
+      "integrity": "sha512-DpyIyTs8NHX6WgAyYM2mGorirIk+eTjWzXGQRfzAe40qkwcqsb5Ax4JEl5gz1OEo9QIJIgWDtmImgWN0tUbILA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -169,21 +127,23 @@
         "punycode",
         "semver",
         "table",
-        "yaml"
+        "yaml",
+        "mime-types"
       ],
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.200",
+        "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.3",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.1.1",
-        "ignore": "^5.2.4",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.1",
         "jsonschema": "^1.4.1",
+        "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
-        "semver": "^7.5.4",
-        "table": "^6.8.1",
+        "punycode": "^2.3.1",
+        "semver": "^7.6.0",
+        "table": "^6.8.2",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -199,14 +159,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.12.0",
+      "version": "8.13.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "uri-js": "^4.4.1"
       },
       "funding": {
         "type": "github",
@@ -297,7 +257,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.1.1",
+      "version": "11.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -315,7 +275,7 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.4",
+      "version": "5.3.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -370,6 +330,25 @@
         "node": ">=10"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
       "version": "3.1.2",
       "inBundle": true,
@@ -382,7 +361,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -398,7 +377,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.5.4",
+      "version": "7.6.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -452,7 +431,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.1",
+      "version": "6.8.2",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -467,7 +446,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -493,18 +472,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/aws-cdk-local": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-local/-/aws-cdk-local-2.18.0.tgz",
-      "integrity": "sha512-ZNQxs4GKHG2MC5y19MJZE/Xf/c0tAdjH6LWbZdouyG4k+1DeuFtBZ+UoYjoUfGPI8dycGpwUiewsLBY1lbtTWg==",
-      "dev": true,
-      "dependencies": {
-        "diff": "^5.0.0"
-      },
-      "bin": {
-        "cdklocal": "bin/cdklocal"
       }
     },
     "node_modules/balanced-match": {
@@ -671,15 +638,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/eastasianwidth": {

--- a/deploy/package.json
+++ b/deploy/package.json
@@ -22,9 +22,9 @@
     "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.96.1-alpha.0",
     "@iarna/toml": "^3.0.0",
     "aws-cdk-lib": "^2.96.1",
+    "cargo-lambda-cdk": "^0.0.22",
     "constructs": "^10.1.148",
     "glob": "^10.3.10",
-    "rust.aws-cdk-lambda": "^1.1.3",
     "source-map-support": "^0.5.21"
   }
 }

--- a/deploy/package.json
+++ b/deploy/package.json
@@ -11,17 +11,13 @@
   },
   "devDependencies": {
     "@types/node": "^18.11.18",
-    "aws-cdk": "^2.96.1",
-    "aws-cdk-local": "^2.18.0",
+    "aws-cdk": "^2.144.0",
     "prettier": "2.8.3",
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigatewayv2-alpha": "^2.96.1-alpha.0",
-    "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "^2.96.1-alpha.0",
-    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.96.1-alpha.0",
     "@iarna/toml": "^3.0.0",
-    "aws-cdk-lib": "^2.96.1",
+    "aws-cdk-lib": "^2.144.0",
     "cargo-lambda-cdk": "^0.0.22",
     "constructs": "^10.1.148",
     "glob": "^10.3.10",

--- a/deploy/tsconfig.json
+++ b/deploy/tsconfig.json
@@ -17,7 +17,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
-    "typeRoots": ["./node_modules/@types"]
+    "typeRoots": ["./node_modules/@types"],
+    "esModuleInterop": true
   },
   "exclude": ["node_modules", "cdk.out"]
 }


### PR DESCRIPTION
Closes #242 

It turns out zig is still required, even though `cargo-lambda` prompts to install it, because the `RustFunction` construct doesn't support interactivity. Could potentially automate this by simulating 'enter' presses to install zig, but I don't think it's a good idea without user input.

### Changes
* Swap out [rust.aws-cdk-lambda](https://github.com/rnag/rust.aws-cdk-lambda) for [cargo-lambda-cdk](https://github.com/cargo-lambda/cargo-lambda-cdk) because of slightly better automation when installing rustup targets and building release.
* Update `package.json` dependencies, including removing `@aws-cdk/aws-apigatewayv2-alpha` as it's no longer alpha.