### PR TITLE
fix(http): allow encryption scheme to be uppercase

### DIFF
--- a/htsget-http/src/query_builder.rs
+++ b/htsget-http/src/query_builder.rs
@@ -172,7 +172,7 @@ impl QueryBuilder {
     encryption_scheme: Option<impl Into<String>>,
   ) -> Result<Self> {
     if let Some(scheme) = encryption_scheme {
-      let scheme = match scheme.into().as_str() {
+      let scheme = match scheme.into().to_lowercase().as_str() {
         "c4gh" => Ok(EncryptionScheme::C4GH),
         scheme => Err(HtsGetError::UnsupportedFormat(format!(
           "invalid encryption scheme `{scheme}`"


### PR DESCRIPTION
Related to #297

### Changes
* Allows encryption scheme to be any case.