### PR TITLE
build: upgrade docker rust version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.84-slim AS builder
+FROM rust:1.88-slim AS builder
 
 LABEL org.opencontainers.image.source=https://github.com/umccr/htsget-rs
 LABEL org.opencontainers.image.url=https://github.com/umccr/htsget-rs/pkgs/container/htsget-rs


### PR DESCRIPTION
Related to #309 

### Changes
* Update rust version to 1.88 in Dockerfile