### PR TITLE
feat: ticket origin and misc fixes

### DIFF
--- a/htsget-actix/src/lib.rs
+++ b/htsget-actix/src/lib.rs
@@ -204,6 +204,7 @@ mod tests {
 
   use crate::Config;
   use htsget_axum::server::BindServer;
+  use htsget_config::storage::file::default_path;
   use htsget_config::types::JsonResponse;
   use htsget_http::middleware::auth::AuthBuilder;
   use htsget_test::http::auth::MockAuthServer;
@@ -276,7 +277,10 @@ mod tests {
         .as_data_server_config()
         .unwrap();
 
-      let path = data_server.local_path().to_path_buf();
+      let path = data_server
+        .local_path()
+        .unwrap_or_else(|| default_path().as_ref())
+        .to_path_buf();
       let mut bind_data_server = BindServer::from(data_server.clone());
       let server = bind_data_server.bind_data_server().await.unwrap();
       let addr = server.local_addr();

--- a/htsget-axum/src/server/data.rs
+++ b/htsget-axum/src/server/data.rs
@@ -8,6 +8,7 @@ use axum::Router;
 use htsget_config::config::advanced::auth::AuthConfig;
 use htsget_config::config::advanced::cors::CorsConfig;
 use htsget_config::config::data_server::DataServerConfig;
+use htsget_config::storage::file::default_path;
 use htsget_http::middleware::auth::AuthBuilder;
 use std::net::SocketAddr;
 use std::path::Path;
@@ -81,7 +82,10 @@ impl From<DataServerConfig> for BindServer {
 
 /// Spawn a task to run the data server.
 pub async fn join_handle(config: DataServerConfig) -> Result<JoinHandle<Result<()>>> {
-  let local_path = config.local_path().to_path_buf();
+  let local_path = config
+    .local_path()
+    .unwrap_or_else(|| default_path().as_ref())
+    .to_path_buf();
   let data_server = BindServer::from(config.clone()).bind_data_server().await?;
 
   info!(address = ?data_server.local_addr()?, "data server address bound to");

--- a/htsget-axum/src/server/ticket.rs
+++ b/htsget-axum/src/server/ticket.rs
@@ -150,6 +150,7 @@ mod tests {
   use axum::body::{Body, to_bytes};
   use axum::response::Response;
   use htsget_config::config::Config;
+  use htsget_config::storage::file::default_path;
   use htsget_config::types::JsonResponse;
   use htsget_test::http::auth::{MockAuthServer, create_test_auth_config};
   use htsget_test::http::server::expected_url_path;
@@ -216,7 +217,10 @@ mod tests {
         .as_data_server_config()
         .unwrap();
 
-      let path = data_server.local_path().to_path_buf();
+      let path = data_server
+        .local_path()
+        .unwrap_or_else(|| default_path().as_ref())
+        .to_path_buf();
       let mut bind_data_server = BindServer::from(data_server.clone());
       let server = bind_data_server.bind_data_server().await.unwrap();
       let addr = server.local_addr();

--- a/htsget-config/README.md
+++ b/htsget-config/README.md
@@ -79,6 +79,23 @@ data_server = "None"
 
 This is automatically applied if no file locations are configured.
 
+By default, file locations specified via `file://<dir>` will use the data server scheme and
+address for ticket responses. This means that tickets will be served as `<scheme>://<addr>/reads/<id>`,
+pointing to the data server `<scheme>` and `<addr>` automatically. For example, a default `file://data`
+location will have tickets that look like `http://127.0.0.1:8081/reads/<id>`.
+
+The scheme and address can be overridden for any file-based responses by setting `data_server.ticket_origin`:
+
+```toml
+# Ensure that the scheme is set for the origin.
+data_server.ticket_origin = "https://example.com/"
+## The url can also have a path set, which appears in the tickets.
+#data_server.ticket_origin = "https://example.com/path"
+```
+
+In this example, the tickets will appear as `https://example.com/<id>`. This is useful to arbitrarily route tickets to
+DNS-resolvable requests, for example, inside a docker container.
+
 > [!NOTE]  
 > For S3 locations, the bucket is not included in the request to htsget-rs. To include the bucket as well, 
 > see deriving the bucket from the first capture group in [advanced config](#bucket).
@@ -183,11 +200,11 @@ locations. These are called `File`, `S3`, and `Url` respectively.
 
 To manually configure `File` locations, set `backend.kind = "File"`, and specify any additional options from below the `backend` table:
 
-| Option                   | Description                                                                                                                        | Type                         | Default            |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------|------------------------------|--------------------|
-| `scheme`                 | The scheme present on URL tickets.                                                                                                 | Either `'Http'` or `'Https'` | `'Http'`           |
-| `authority`              | The authority present on URL tickets. This should likely match the `data_server.addr`.                                             | URL authority                | `'127.0.0.1:8081'` |
-| `local_path`             | The local filesystem path which the data server uses to respond to tickets. This should likely match the `data_server.local_path`. | Filesystem path              | `'./'`             |
+| Option                   | Description                                                                                                               | Type                         | Default            |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------|------------------------------|--------------------|
+| `scheme`                 | The scheme present on URL tickets.                                                                                        | Either `'Http'` or `'Https'` | `'Http'`           |
+| `authority`              | The authority present on URL tickets. This should likely match the `data_server.addr`.                                    | URL authority                | `'127.0.0.1:8081'` |
+| `local_path`             | The local filesystem path which the data server uses to respond to tickets. This must match the `data_server.local_path`. | Filesystem path              | `'./'`             |
 
 For example:
 

--- a/htsget-config/README.md
+++ b/htsget-config/README.md
@@ -65,10 +65,20 @@ Locations can be mixed, and don't all need to have the same directory or resourc
 locations = [ "file://data/bam", "file://data/cram", "s3://bucket/vcf" ]
 ```
 
+For all types of locations, the second path segment represents the prefix which the request is expected
+to contain, in order to use that location. With the above example, if the request is `/variants/vcf/<id>`, then
+the S3 location is used, and if it is `/reads/bam/<id>` or `/reads/cram/<id>`, then the file locations are used.
+
+For each of the location types, the first component represents the storage location:
+
+```toml
+locations = [ "file://<directory>/<prefix>", "s3://<bucket>/<prefix>", "https://<endpoint>/<prefix>" ]
+```
+
 htsget-rs spawns a separate server process to respond to htsget tickets for file locations.
-This server's path can be set by using `data_server.local_path`. When using `file://<dir>` locations,
+This server's path can be set by using `data_server.local_path`. When using `file://<directory>` locations,
 the directory component must be the same as the local path so that the server has access to it. 
-It is also not possible to have different directories components when using multiple `file://<dir>`
+It is also not possible to have different directories components when using multiple `file://<directory>`
 locations.
 
 The data server process can be disabled by setting it to `None` if no file locations are being used:

--- a/htsget-config/README.md
+++ b/htsget-config/README.md
@@ -62,19 +62,22 @@ curl 'http://localhost:8080/reads/cram/htsnexus_test_NA12878?format=CRAM'
 Locations can be mixed, and don't all need to have the same directory or resource:
 
 ```toml
-data_server.local_path = "root"
-locations = [ "file://dir_two/bam", "file://dir_one/cram", "s3://bucket/vcf" ]
+locations = [ "file://data/bam", "file://data/cram", "s3://bucket/vcf" ]
 ```
 
-htsget-rs spawns a separate server process to respond to htsget tickets for file locations,
-so setting `data_server.local_path` to the root directory which contains all subdirectories is
-required to give this server access to the local directory.
+htsget-rs spawns a separate server process to respond to htsget tickets for file locations.
+This server's path can be set by using `data_server.local_path`. When using `file://<dir>` locations,
+the directory component must be the same as the local path so that the server has access to it. 
+It is also not possible to have different directories components when using multiple `file://<dir>`
+locations.
 
 The data server process can be disabled by setting it to `None` if no file locations are being used:
 
 ```toml
 data_server = "None"
 ```
+
+This is automatically applied if no file locations are configured.
 
 > [!NOTE]  
 > For S3 locations, the bucket is not included in the request to htsget-rs. To include the bucket as well, 

--- a/htsget-config/docs/examples/default.toml
+++ b/htsget-config/docs/examples/default.toml
@@ -13,7 +13,6 @@ expose_headers = "All"
 
 [data_server]
 addr = "127.0.0.1:8081"
-local_path = "./"
 
 [data_server.cors]
 allow_credentials = false

--- a/htsget-config/src/config/advanced/auth/mod.rs
+++ b/htsget-config/src/config/advanced/auth/mod.rs
@@ -114,6 +114,11 @@ impl AuthConfig {
   pub fn http_client(&self) -> &reqwest::Client {
     &self.http_client.0
   }
+  
+  /// Set the authentication only flag.
+  pub(crate) fn set_authentication_only(&mut self, authentication_only: bool) {
+    self.authentication_only = authentication_only;
+  }
 }
 
 /// Builder for `AuthConfig`.

--- a/htsget-config/src/config/advanced/auth/mod.rs
+++ b/htsget-config/src/config/advanced/auth/mod.rs
@@ -114,7 +114,7 @@ impl AuthConfig {
   pub fn http_client(&self) -> &reqwest::Client {
     &self.http_client.0
   }
-  
+
   /// Set the authentication only flag.
   pub(crate) fn set_authentication_only(&mut self, authentication_only: bool) {
     self.authentication_only = authentication_only;

--- a/htsget-config/src/config/advanced/regex_location.rs
+++ b/htsget-config/src/config/advanced/regex_location.rs
@@ -49,6 +49,11 @@ impl RegexLocation {
     &self.backend
   }
 
+  /// Get the storage backend as a mutable reference.
+  pub fn backend_mut(&mut self) -> &mut Backend {
+    &mut self.backend
+  }
+
   /// Get the allow guard.
   pub fn guard(&self) -> Option<&AllowGuard> {
     self.guard.as_ref()

--- a/htsget-config/src/config/data_server.rs
+++ b/htsget-config/src/config/data_server.rs
@@ -49,6 +49,7 @@ pub struct DataServerConfig {
   cors: CorsConfig,
   #[serde(skip_serializing)]
   auth: Option<AuthConfig>,
+  ticket_origin: Option<String>,
 }
 
 impl DataServerConfig {
@@ -59,6 +60,7 @@ impl DataServerConfig {
     tls: Option<TlsServerConfig>,
     cors: CorsConfig,
     auth: Option<AuthConfig>,
+    ticket_origin: Option<String>,
   ) -> Self {
     Self {
       addr,
@@ -66,6 +68,7 @@ impl DataServerConfig {
       tls,
       cors,
       auth,
+      ticket_origin,
     }
   }
 
@@ -99,6 +102,11 @@ impl DataServerConfig {
     self.auth.as_ref()
   }
 
+  /// Get the ticket origin.
+  pub fn ticket_origin(&self) -> Option<String> {
+    self.ticket_origin.clone()
+  }
+
   /// Set the auth config.
   pub fn set_auth(&mut self, auth: Option<AuthConfig>) {
     self.auth = auth;
@@ -120,6 +128,7 @@ impl Default for DataServerConfig {
       tls: Default::default(),
       cors: Default::default(),
       auth: None,
+      ticket_origin: None,
     }
   }
 }
@@ -136,13 +145,20 @@ mod tests {
       addr = "127.0.0.1:8083"
       local_path = "path"
       cors.max_age = 1
+      ticket_origin = "http://example.com"
       "#,
-      ("127.0.0.1:8083".to_string(), "path".to_string(), 1),
+      (
+        "127.0.0.1:8083".to_string(),
+        "path".to_string(),
+        1,
+        "http://example.com".to_string(),
+      ),
       |result: DataServerConfig| {
         (
           result.addr().to_string(),
           result.local_path().unwrap().to_string_lossy().to_string(),
           result.cors.max_age(),
+          result.ticket_origin.unwrap(),
         )
       },
     );

--- a/htsget-config/src/config/location.rs
+++ b/htsget-config/src/config/location.rs
@@ -66,6 +66,14 @@ impl LocationEither {
     }
   }
 
+  /// Get the storage backend as a mutable reference.
+  pub fn backend_mut(&mut self) -> &mut Backend {
+    match self {
+      LocationEither::Simple(location) => location.backend_mut(),
+      LocationEither::Regex(regex_location) => regex_location.backend_mut(),
+    }
+  }
+
   /// Get the simple location variant, returning an error otherwise.
   pub fn as_simple(&self) -> Result<&Location> {
     if let LocationEither::Simple(simple) = self {
@@ -108,6 +116,11 @@ impl Location {
   /// Get the storage backend.
   pub fn backend(&self) -> &Backend {
     &self.backend
+  }
+
+  /// Get the storage backend as a mutable reference
+  pub fn backend_mut(&mut self) -> &mut Backend {
+    &mut self.backend
   }
 
   /// Get the prefix.

--- a/htsget-config/src/config/location.rs
+++ b/htsget-config/src/config/location.rs
@@ -243,12 +243,12 @@ impl<'de> Deserialize<'de> for StringLocation {
 
     if let Some(s) = s.strip_prefix("file://") {
       let (path, prefix) = split(s)?;
+      let mut file = storage::file::File::new(Scheme::Http, default_authority(), path.to_string());
+      // Origin should be updated based on data server config.
+      file.reset_origin = true;
+
       return Ok(StringLocation {
-        backend: Backend::File(storage::file::File::new(
-          Scheme::Http,
-          default_authority(),
-          path.to_string(),
-        )),
+        backend: Backend::File(file),
         prefix,
       });
     }

--- a/htsget-config/src/config/mod.rs
+++ b/htsget-config/src/config/mod.rs
@@ -4,20 +4,22 @@
 use crate::config::advanced::FormattingStyle;
 use crate::config::advanced::auth::{AuthConfig, AuthorizationRestrictions};
 use crate::config::data_server::{DataServerConfig, DataServerEnabled};
-use crate::config::location::{Location, LocationEither, Locations};
+use crate::config::location::{LocationEither, Locations};
 use crate::config::parser::from_path;
 use crate::config::service_info::ServiceInfo;
 use crate::config::ticket_server::TicketServerConfig;
 use crate::error::Error::{ArgParseError, ParseError, TracingError};
 use crate::error::Result;
 use crate::storage::Backend;
-use crate::storage::file::File;
+use crate::tls::KeyPairScheme;
 use clap::{Args as ClapArgs, Command, FromArgMatches, Parser};
 use http::header::AUTHORIZATION;
+use http::uri::Authority;
 use schemars::schema_for;
 use serde::de::Error;
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::HashSet;
 use std::fmt::{Debug, Display};
 use std::io;
 use std::path::{Path, PathBuf};
@@ -187,7 +189,7 @@ impl Config {
           auth.set_authentication_only(true);
           auth
         });
-        
+
         data_server_config.set_auth(auth);
       }
     }
@@ -195,7 +197,7 @@ impl Config {
       config.ticket_server.set_auth(config.auth.clone());
     }
 
-    Ok(config.resolvers_from_data_server_config()?)
+    Ok(config.validate_file_locations()?)
   }
 
   /// Setup tracing, using a global subscriber.
@@ -222,29 +224,68 @@ impl Config {
   }
 
   /// Set the local resolvers from the data server config.
-  pub fn resolvers_from_data_server_config(mut self) -> Result<Self> {
+  pub fn validate_file_locations(mut self) -> Result<Self> {
+    if !self
+      .locations()
+      .iter()
+      .any(|location| location.backend().as_file().is_ok())
+    {
+      return Ok(self);
+    }
+
+    let DataServerEnabled::Some(ref mut config) = self.data_server else {
+      return Err(ParseError(
+        "must enable data server if using file locations".to_string(),
+      ));
+    };
+
+    let mut possible_paths: HashSet<_> =
+      HashSet::from_iter(self.locations.as_slice().iter().map(|location| {
+        location
+          .backend()
+          .as_file()
+          .ok()
+          .map(|file| file.local_path())
+      }));
+    possible_paths.remove(&None);
+
+    if possible_paths.len() > 1 {
+      return Err(ParseError(
+        "cannot have multiple file paths for file storage".to_string(),
+      ));
+    }
+    let local_path = possible_paths
+      .into_iter()
+      .next()
+      .flatten()
+      .ok_or_else(|| ParseError("failed to find local path from locations".to_string()))?
+      .to_string();
+
+    if config
+      .local_path()
+      .is_some_and(|path| path.to_string_lossy() != local_path)
+    {
+      return Err(ParseError(
+        "the data server local path and file storage directories must be the same".to_string(),
+      ));
+    }
+
+    config.set_local_path(Some(PathBuf::from(local_path)));
+
+    let scheme = config.tls().get_scheme();
+    let authority =
+      Authority::from_str(&config.addr().to_string()).map_err(|err| ParseError(err.to_string()))?;
+
     self
       .locations
       .as_mut_slice()
       .iter_mut()
       .map(|location| {
+        // Configure the scheme and authority for simple locations.
         if let LocationEither::Simple(simple) = location {
-          // Fall through only if the backend is File and default
-          let file_location = if let Ok(location) = simple.backend().as_file() {
-            location
-          } else {
-            return Ok(());
-          };
-
-          if let DataServerEnabled::Some(ref data_server) = self.data_server {
-            let prefix = simple.prefix().to_string();
-
-            // Don't update the local path as that comes in from the config.
-            let file: File = data_server.try_into()?;
-            let file = file.set_local_path(file_location.local_path().to_string());
-
-            *location =
-              LocationEither::Simple(Box::new(Location::new(Backend::File(file), prefix)));
+          if let Backend::File(file) = simple.backend_mut() {
+            file.set_scheme(scheme);
+            file.set_authority(authority.clone());
           }
         }
 
@@ -316,7 +357,9 @@ pub(crate) mod tests {
 
   use super::*;
   use crate::config::advanced::auth::AuthMode;
+  use crate::config::location::Location;
   use crate::config::parser::from_str;
+  use crate::storage::Backend;
   use crate::tls::tests::with_test_certificates;
   use crate::types::Scheme;
   use figment::Jail;
@@ -348,13 +391,13 @@ pub(crate) mod tests {
       test_fn(
         from_path::<Config>(path)
           .map_err(|err| err.to_string())?
-          .resolvers_from_data_server_config()
+          .validate_file_locations()
           .map_err(|err| err.to_string())?,
       );
       test_fn(
         from_str::<Config>(contents.unwrap_or(""))
           .map_err(|err| err.to_string())?
-          .resolvers_from_data_server_config()
+          .validate_file_locations()
           .map_err(|err| err.to_string())?,
       );
 
@@ -663,7 +706,7 @@ pub(crate) mod tests {
     test_config_from_file(
       r#"
     data_server.addr = "127.0.0.1:8080"
-    data_server.local_path = "path"
+    data_server.local_path = "data"
     
     locations = "file://data"
     "#,
@@ -732,8 +775,8 @@ pub(crate) mod tests {
     test_config_from_file(
       r#"
     data_server.addr = "127.0.0.1:8080"
-    data_server.local_path = "root"
-    locations = ["file://dir_one/bam", "file://dir_two/cram", "s3://bucket/vcf"]
+    data_server.local_path = "data"
+    locations = ["file://data/bam", "file://data/cram", "s3://bucket/vcf"]
     "#,
       |config| {
         assert_eq!(config.locations().len(), 3);
@@ -741,11 +784,11 @@ pub(crate) mod tests {
 
         let location = config[0].as_simple().unwrap();
         assert_eq!(location.prefix(), "bam");
-        assert_file_location(location, "dir_one");
+        assert_file_location(location, "data");
 
         let location = config[1].as_simple().unwrap();
         assert_eq!(location.prefix(), "cram");
-        assert_file_location(location, "dir_two");
+        assert_file_location(location, "data");
 
         let location = config[2].as_simple().unwrap();
         assert_eq!(location.prefix(), "vcf");
@@ -830,11 +873,13 @@ pub(crate) mod tests {
     );
   }
 
+  #[cfg(feature = "aws")]
   #[test]
   fn no_data_server() {
     test_config_from_file(
       r#"
       data_server = "None"
+      locations = "s3://bucket"
     "#,
       |config| {
         assert!(config.data_server().as_data_server_config().is_err());

--- a/htsget-config/src/config/mod.rs
+++ b/htsget-config/src/config/mod.rs
@@ -281,9 +281,10 @@ impl Config {
       .as_mut_slice()
       .iter_mut()
       .map(|location| {
-        // Configure the scheme and authority for simple locations.
-        if let LocationEither::Simple(simple) = location {
-          if let Backend::File(file) = simple.backend_mut() {
+        // Configure the scheme and authority for file locations that haven't been
+        // explicitly set.
+        if let Backend::File(file) = location.backend_mut() {
+          if file.reset_origin {
             file.set_scheme(scheme);
             file.set_authority(authority.clone());
           }
@@ -683,7 +684,7 @@ pub(crate) mod tests {
         let config = config.locations.into_inner();
         let regex = config[0].as_regex().unwrap();
         assert!(matches!(regex.backend(),
-            Backend::File(file) if file.local_path() == "path" && file.scheme() == Scheme::Http && file.authority() == &Authority::from_static("127.0.0.1:8081")));
+            Backend::File(file) if file.local_path() == "path" && file.scheme() == Scheme::Http && file.authority() == &Authority::from_static("127.0.0.1:8080")));
       },
     );
   }

--- a/htsget-config/src/config/mod.rs
+++ b/htsget-config/src/config/mod.rs
@@ -183,7 +183,12 @@ impl Config {
     // Propagate global config to individual ticket and data servers.
     if let DataServerEnabled::Some(ref mut data_server_config) = config.data_server {
       if data_server_config.auth().is_none() {
-        data_server_config.set_auth(config.auth.clone());
+        let auth = config.auth.clone().map(|mut auth| {
+          auth.set_authentication_only(true);
+          auth
+        });
+        
+        data_server_config.set_auth(auth);
       }
     }
     if config.ticket_server().auth().is_none() {

--- a/htsget-config/src/config/mod.rs
+++ b/htsget-config/src/config/mod.rs
@@ -284,12 +284,18 @@ impl Config {
       .map(|location| {
         // Configure the scheme and authority for file locations that haven't been
         // explicitly set.
-        if let Backend::File(file) = location.backend_mut() {
-          if file.reset_origin {
-            file.set_scheme(scheme);
-            file.set_authority(authority.clone());
-            file.set_ticket_origin(ticket_origin.clone())
+        match location.backend_mut() {
+          Backend::File(file) => {
+            if file.reset_origin {
+              file.set_scheme(scheme);
+              file.set_authority(authority.clone());
+              file.set_ticket_origin(ticket_origin.clone())
+            }
           }
+          #[cfg(feature = "aws")]
+          Backend::S3(_) => {}
+          #[cfg(feature = "url")]
+          Backend::Url(_) => {}
         }
 
         // Ensure authorization header gets forwarded if the data server has authorization set.

--- a/htsget-config/src/config/mod.rs
+++ b/htsget-config/src/config/mod.rs
@@ -275,6 +275,7 @@ impl Config {
     let scheme = config.tls().get_scheme();
     let authority =
       Authority::from_str(&config.addr().to_string()).map_err(|err| ParseError(err.to_string()))?;
+    let ticket_origin = config.ticket_origin();
 
     self
       .locations
@@ -287,6 +288,7 @@ impl Config {
           if file.reset_origin {
             file.set_scheme(scheme);
             file.set_authority(authority.clone());
+            file.set_ticket_origin(ticket_origin.clone())
           }
         }
 

--- a/htsget-config/src/config/mod.rs
+++ b/htsget-config/src/config/mod.rs
@@ -13,6 +13,7 @@ use crate::error::Result;
 use crate::storage::Backend;
 use crate::storage::file::File;
 use clap::{Args as ClapArgs, Command, FromArgMatches, Parser};
+use http::header::AUTHORIZATION;
 use schemars::schema_for;
 use serde::de::Error;
 use serde::ser::SerializeSeq;
@@ -240,6 +241,17 @@ impl Config {
             *location =
               LocationEither::Simple(Box::new(Location::new(Backend::File(file), prefix)));
           }
+        }
+
+        // Ensure authorization header gets forwarded if the data server has authorization set.
+        if self
+          .data_server
+          .as_data_server_config()
+          .is_ok_and(|config| config.auth().is_some())
+        {
+          location
+            .backend_mut()
+            .add_ticket_header(AUTHORIZATION.to_string());
         }
 
         Ok(())

--- a/htsget-config/src/storage/file.rs
+++ b/htsget-config/src/storage/file.rs
@@ -26,6 +26,8 @@ pub struct File {
   #[cfg(feature = "experimental")]
   #[serde(skip_serializing)]
   keys: Option<C4GHKeys>,
+  #[serde(skip)]
+  pub(crate) reset_origin: bool,
 }
 
 impl File {
@@ -38,6 +40,7 @@ impl File {
       ticket_headers: Vec::new(),
       #[cfg(feature = "experimental")]
       keys: None,
+      reset_origin: false,
     }
   }
 
@@ -97,7 +100,9 @@ impl File {
 
 impl Default for File {
   fn default() -> Self {
-    Self::new(Scheme::Http, default_authority(), default_path().into())
+    let mut file = Self::new(Scheme::Http, default_authority(), default_path().into());
+    file.reset_origin = true;
+    file
   }
 }
 

--- a/htsget-config/src/storage/file.rs
+++ b/htsget-config/src/storage/file.rs
@@ -26,6 +26,7 @@ pub struct File {
   #[cfg(feature = "experimental")]
   #[serde(skip_serializing)]
   keys: Option<C4GHKeys>,
+  ticket_origin: Option<String>,
   #[serde(skip)]
   pub(crate) reset_origin: bool,
 }
@@ -40,6 +41,7 @@ impl File {
       ticket_headers: Vec::new(),
       #[cfg(feature = "experimental")]
       keys: None,
+      ticket_origin: None,
       reset_origin: false,
     }
   }
@@ -71,6 +73,11 @@ impl File {
     self.keys.as_ref()
   }
 
+  /// Get the ticket origin.
+  pub fn ticket_origin(&self) -> Option<&str> {
+    self.ticket_origin.as_deref()
+  }
+
   /// Set the local path.
   pub fn set_local_path(mut self, local_path: String) -> Self {
     self.local_path = local_path;
@@ -85,6 +92,11 @@ impl File {
   /// Set the authority.
   pub fn set_authority(&mut self, authority: Authority) {
     self.authority = authority;
+  }
+
+  /// Set the authority.
+  pub fn set_ticket_origin(&mut self, ticket_origin: Option<String>) {
+    self.ticket_origin = ticket_origin;
   }
 
   /// Add a header to add to the ticket.

--- a/htsget-config/src/storage/file.rs
+++ b/htsget-config/src/storage/file.rs
@@ -74,6 +74,16 @@ impl File {
     self
   }
 
+  /// Set the scheme.
+  pub fn set_scheme(&mut self, scheme: Scheme) {
+    self.scheme = scheme;
+  }
+
+  /// Set the authority.
+  pub fn set_authority(&mut self, authority: Authority) {
+    self.authority = authority;
+  }
+
   /// Add a header to add to the ticket.
   pub fn add_ticket_header(&mut self, header: String) {
     self.ticket_headers.push(header);
@@ -98,7 +108,10 @@ impl TryFrom<&DataServerConfig> for File {
     Ok(Self::new(
       config.tls().get_scheme(),
       Authority::from_str(&config.addr().to_string()).map_err(|err| ParseError(err.to_string()))?,
-      config.local_path().to_string_lossy().to_string(),
+      config
+        .local_path()
+        .map(|path| path.to_string_lossy().to_string())
+        .unwrap_or_else(|| default_path().to_string()),
     ))
   }
 }
@@ -111,7 +124,8 @@ pub(crate) fn default_localstorage_addr() -> &'static str {
   "127.0.0.1:8081"
 }
 
-pub(crate) fn default_path() -> &'static str {
+/// The default data server path.
+pub fn default_path() -> &'static str {
   "./"
 }
 

--- a/htsget-config/src/storage/file.rs
+++ b/htsget-config/src/storage/file.rs
@@ -21,6 +21,8 @@ pub struct File {
   #[serde(with = "http_serde::authority")]
   authority: Authority,
   local_path: String,
+  #[serde(skip)]
+  ticket_headers: Vec<String>,
   #[cfg(feature = "experimental")]
   #[serde(skip_serializing)]
   keys: Option<C4GHKeys>,
@@ -33,6 +35,7 @@ impl File {
       scheme,
       authority,
       local_path,
+      ticket_headers: Vec::new(),
       #[cfg(feature = "experimental")]
       keys: None,
     }
@@ -69,6 +72,16 @@ impl File {
   pub fn set_local_path(mut self, local_path: String) -> Self {
     self.local_path = local_path;
     self
+  }
+
+  /// Add a header to add to the ticket.
+  pub fn add_ticket_header(&mut self, header: String) {
+    self.ticket_headers.push(header);
+  }
+
+  /// Get the ticket headers.
+  pub fn ticket_headers(&self) -> &[String] {
+    &self.ticket_headers
   }
 }
 

--- a/htsget-config/src/storage/mod.rs
+++ b/htsget-config/src/storage/mod.rs
@@ -64,6 +64,30 @@ impl Backend {
     }
   }
 
+  /// Add a header to add to the ticket.
+  pub fn add_ticket_header(&mut self, header: String) {
+    match self {
+      Backend::File(file) => {
+        file.add_ticket_header(header);
+      }
+      #[cfg(feature = "aws")]
+      Backend::S3(_) => {}
+      #[cfg(feature = "url")]
+      Backend::Url(_) => {}
+    }
+  }
+
+  /// Get the ticket headers.
+  pub fn ticket_headers(&self) -> Option<&[String]> {
+    match self {
+      Backend::File(file) => Some(file.ticket_headers()),
+      #[cfg(feature = "aws")]
+      Backend::S3(_) => None,
+      #[cfg(feature = "url")]
+      Backend::Url(_) => None,
+    }
+  }
+
   /// Get the file variant and error if it is not `S3`.
   #[cfg(feature = "aws")]
   pub fn as_s3(&self) -> Result<&S3> {

--- a/htsget-http/src/lib.rs
+++ b/htsget-http/src/lib.rs
@@ -288,6 +288,7 @@ mod tests {
           Authority::from_static("127.0.0.1:8081"),
           "data".to_string(),
         ),
+        vec![],
       )
       .unwrap(),
     ))

--- a/htsget-search/src/from_storage.rs
+++ b/htsget-search/src/from_storage.rs
@@ -291,7 +291,7 @@ pub(crate) mod tests {
     with_config_local_storage(
       |base_path, local_storage| async {
         test(Storage::new(
-          FileStorage::new(base_path, local_storage).unwrap(),
+          FileStorage::new(base_path, local_storage, vec![]).unwrap(),
         ))
         .await
       },
@@ -310,7 +310,7 @@ pub(crate) mod tests {
     with_config_local_storage_map(
       |base_path, local_storage| async {
         test(Storage::new(
-          FileStorage::new(base_path, local_storage).unwrap(),
+          FileStorage::new(base_path, local_storage, vec![]).unwrap(),
         ))
         .await
       },

--- a/htsget-storage/src/lib.rs
+++ b/htsget-storage/src/lib.rs
@@ -10,7 +10,6 @@ pub use htsget_config::types::{
 use crate::c4gh::storage::C4GHStorage;
 use crate::error::Result;
 use crate::error::StorageError;
-use crate::error::StorageError::InvalidKey;
 use crate::local::FileStorage;
 #[cfg(feature = "aws")]
 use crate::s3::S3Storage;
@@ -26,12 +25,9 @@ use htsget_config::encryption_scheme::EncryptionScheme;
 use htsget_config::storage;
 #[cfg(feature = "experimental")]
 use htsget_config::storage::c4gh::C4GHKeys;
-use htsget_config::types::Scheme;
-use http::uri;
 use pin_project_lite::pin_project;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
-use std::path::Path;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, ReadBuf};
@@ -289,30 +285,29 @@ pub trait UrlFormatter {
 
 impl UrlFormatter for storage::file::File {
   fn format_url<K: AsRef<str>>(&self, key: K) -> Result<String> {
-    let path = Path::new("/").join(key.as_ref());
-    uri::Builder::new()
-      .scheme(match self.scheme() {
-        Scheme::Http => uri::Scheme::HTTP,
-        Scheme::Https => uri::Scheme::HTTPS,
-      })
-      .authority(self.authority().to_string())
-      .path_and_query(
-        path
-          .to_str()
-          .ok_or_else(|| InvalidKey("constructing url".to_string()))?,
-      )
-      .build()
+    let mut url = if let Some(origin) = self.ticket_origin() {
+      origin.to_string()
+    } else {
+      format!("{}://{}", self.scheme(), self.authority())
+    };
+    if !url.ends_with('/') {
+      url = format!("{url}/");
+    }
+
+    let url = ::url::Url::parse(&url).map_err(|err| StorageError::InvalidUri(err.to_string()))?;
+    url
+      .join(key.as_ref())
       .map_err(|err| StorageError::InvalidUri(err.to_string()))
-      .map(|value| value.to_string())
+      .map(|url| url.to_string())
   }
 }
 
 #[cfg(test)]
 mod tests {
-  use http::uri::Authority;
-
   use crate::local::FileStorage;
+  use htsget_config::types::Scheme;
   use htsget_test::util::default_dir_data;
+  use http::uri::Authority;
 
   use super::*;
 

--- a/htsget-test/src/http/mod.rs
+++ b/htsget-test/src/http/mod.rs
@@ -162,6 +162,7 @@ fn default_test_config_params(
     tls.clone(),
     cors.clone(),
     Default::default(),
+    Default::default(),
   );
 
   Config::new(


### PR DESCRIPTION
Closes #319 

### Changes
* Adds a ticket_origin option that allows changing the ticket response endpoint for local file-based locations.

### Fixes
* The server should forward the JWT on ticket responses if authorisation is being used.
* The data server should only perform authentication (not the custom authorization scheme) if it is confirmed.
* The interaction between `file://` locations and the data server was broken and difficult to configure correctly. I've re-worked it so that only one local directory can be used, and that always corresponds to data served by the data server (otherwise it's a configuration error).
* The data server is automatically disabled if not using `file://` locations, and the server's directory is also automatically matched to any `file://` location