### PR TITLE
Packages must be writable from the workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      packages: write
     name: docker
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Sould fix https://github.com/umccr/htsget-rs/actions/runs/16981443346 CI permissions error.

The newly introduced workflow permissions by #317 broke this (I guess?)... @mmalenic, caution, there might be similar side effects for the issues we're recently experiencing with release-plz?