### PR TITLE
fix(config): auth environment variable deserialization

### DIFF
--- a/htsget-config/src/config/parser.rs
+++ b/htsget-config/src/config/parser.rs
@@ -42,6 +42,7 @@ impl Parser<'_> {
               .replace("data_server_", "data_server.")
               .replace("cors_", "cors.")
               .replace("tls_", "tls.")
+              .replace("auth_", "auth.")
               .into()
           }),
       )


### PR DESCRIPTION
### Changes
* The 'auth' field need to be listed when deserializing environment variables to correctly separate '.' and '_'.