### PR TITLE
fix: authorization JSON structure and user-agent

### DIFF
--- a/htsget-actix/src/handlers/get.rs
+++ b/htsget-actix/src/handlers/get.rs
@@ -34,6 +34,7 @@ pub async fn reads<H: HtsGet + Clone + Send + Sync + 'static>(
       request,
       Endpoint::Reads,
       app_state.auth.clone(),
+      app_state.package_info.as_ref(),
       extension.map(|extension| extension.into_inner()),
     )
     .await,
@@ -59,6 +60,7 @@ pub async fn variants<H: HtsGet + Clone + Send + Sync + 'static>(
       request,
       Endpoint::Variants,
       app_state.auth.clone(),
+      app_state.package_info.as_ref(),
       extension.map(|extension| extension.into_inner()),
     )
     .await,

--- a/htsget-actix/src/handlers/post.rs
+++ b/htsget-actix/src/handlers/post.rs
@@ -35,6 +35,7 @@ pub async fn reads<H: HtsGet + Clone + Send + Sync + 'static>(
       request,
       Endpoint::Reads,
       app_state.auth.clone(),
+      app_state.package_info.as_ref(),
       extension.map(|extension| extension.into_inner()),
     )
     .await,
@@ -62,6 +63,7 @@ pub async fn variants<H: HtsGet + Clone + Send + Sync + 'static>(
       request,
       Endpoint::Variants,
       app_state.auth.clone(),
+      app_state.package_info.as_ref(),
       extension.map(|extension| extension.into_inner()),
     )
     .await,

--- a/htsget-actix/src/main.rs
+++ b/htsget-actix/src/main.rs
@@ -27,20 +27,29 @@ async fn main() -> io::Result<()> {
 
       let ticket_server_config = config.ticket_server().clone();
       let service_info = config.service_info().clone();
+      let package_info = config.package_info().clone();
 
       select! {
         local_server = local_server => Ok(local_server??),
         actix_server = run_server(
           config.into_locations(),
           ticket_server_config,
-          service_info
+          service_info,
+          package_info,
         )? => actix_server
       }
     } else {
       let ticket_server_config = config.ticket_server().clone();
       let service_info = config.service_info().clone();
+      let package_info = config.package_info().clone();
 
-      run_server(config.into_locations(), ticket_server_config, service_info)?.await
+      run_server(
+        config.into_locations(),
+        ticket_server_config,
+        service_info,
+        package_info,
+      )?
+      .await
     }
   } else {
     Ok(())

--- a/htsget-actix/src/main.rs
+++ b/htsget-actix/src/main.rs
@@ -17,11 +17,8 @@ async fn main() -> io::Result<()> {
 
   if let Some(path) = Config::parse_args_with_command(command!())? {
     let mut config = Config::from_path(&path)?;
-
+    config.set_package_info(package_info!())?;
     config.setup_tracing()?;
-
-    let service_info = config.service_info_mut();
-    service_info.set_from_package_info(package_info!())?;
 
     debug!(config = ?config, "config parsed");
 

--- a/htsget-axum/src/handlers/get.rs
+++ b/htsget-axum/src/handlers/get.rs
@@ -26,6 +26,7 @@ pub async fn reads<H: HtsGet + Send + Sync + 'static>(
       request,
       Endpoint::Reads,
       app_state.auth_middleware,
+      app_state.package_info.as_ref(),
       extension.map(|extension| extension.0),
     )
     .await,
@@ -48,6 +49,7 @@ pub async fn variants<H: HtsGet + Send + Sync + 'static>(
       request,
       Endpoint::Variants,
       app_state.auth_middleware,
+      app_state.package_info.as_ref(),
       extension.map(|extension| extension.0),
     )
     .await,

--- a/htsget-axum/src/handlers/post.rs
+++ b/htsget-axum/src/handlers/post.rs
@@ -28,6 +28,7 @@ pub async fn reads<H: HtsGet + Clone + Send + Sync + 'static>(
       request,
       Endpoint::Reads,
       app_state.auth_middleware,
+      app_state.package_info.as_ref(),
       extension.map(|extension| extension.0),
     )
     .await,
@@ -52,6 +53,7 @@ pub async fn variants<H: HtsGet + Clone + Send + Sync + 'static>(
       request,
       Endpoint::Variants,
       app_state.auth_middleware,
+      app_state.package_info.as_ref(),
       extension.map(|extension| extension.0),
     )
     .await,

--- a/htsget-axum/src/main.rs
+++ b/htsget-axum/src/main.rs
@@ -18,11 +18,8 @@ async fn main() -> io::Result<()> {
     Config::parse_args_with_command(command!()).expect("expected valid command parsing")
   {
     let mut config = Config::from_path(&path)?;
-
+    config.set_package_info(package_info!())?;
     config.setup_tracing()?;
-
-    let service_info = config.service_info_mut();
-    service_info.set_from_package_info(package_info!())?;
 
     debug!(config = ?config, "config parsed");
 

--- a/htsget-axum/src/server/data.rs
+++ b/htsget-axum/src/server/data.rs
@@ -83,8 +83,8 @@ impl From<DataServerConfig> for BindServer {
     let auth = config.auth().cloned();
 
     match config.into_tls() {
-      None => Self::new(addr, cors, auth),
-      Some(tls) => Self::new_with_tls(addr, cors, auth, tls),
+      None => Self::new(addr, cors, auth, None),
+      Some(tls) => Self::new_with_tls(addr, cors, auth, tls, None),
     }
   }
 }
@@ -251,6 +251,7 @@ mod tests {
       "127.0.0.1:8080".parse().unwrap(),
       CorsConfig::default(),
       None,
+      None,
     );
     assert_eq!(formatter.get_scheme(), &Scheme::Http);
   }
@@ -262,8 +263,12 @@ mod tests {
 
   #[tokio::test]
   async fn get_addr_local_addr() {
-    let mut formatter =
-      BindServer::new("127.0.0.1:0".parse().unwrap(), CorsConfig::default(), None);
+    let mut formatter = BindServer::new(
+      "127.0.0.1:0".parse().unwrap(),
+      CorsConfig::default(),
+      None,
+      None,
+    );
     let server = formatter.bind_server().await.unwrap();
     assert_eq!(formatter.get_addr(), server.local_addr().unwrap());
   }
@@ -312,6 +317,7 @@ mod tests {
       CorsConfig::default(),
       None,
       server_config,
+      None,
     )
   }
 

--- a/htsget-axum/src/server/mod.rs
+++ b/htsget-axum/src/server/mod.rs
@@ -16,7 +16,7 @@ use axum::Router;
 use axum::extract::Request;
 use htsget_config::config::advanced::auth::AuthConfig;
 use htsget_config::config::advanced::cors::CorsConfig;
-use htsget_config::config::service_info::ServiceInfo;
+use htsget_config::config::service_info::{PackageInfo, ServiceInfo};
 use htsget_config::http::TlsServerConfig;
 use htsget_config::types::Scheme;
 use htsget_http::middleware::auth::Auth;
@@ -39,15 +39,22 @@ pub struct AppState<H: HtsGet> {
   pub(crate) htsget: H,
   pub(crate) service_info: ServiceInfo,
   pub(crate) auth_middleware: Option<Auth>,
+  pub(crate) package_info: Option<PackageInfo>,
 }
 
 impl<H: HtsGet> AppState<H> {
   /// Create a new app state.
-  pub fn new(htsget: H, service_info: ServiceInfo, auth_middleware: Option<Auth>) -> Self {
+  pub fn new(
+    htsget: H,
+    service_info: ServiceInfo,
+    auth_middleware: Option<Auth>,
+    package_info: Option<PackageInfo>,
+  ) -> Self {
     Self {
       htsget,
       service_info,
       auth_middleware,
+      package_info,
     }
   }
 }
@@ -125,17 +132,24 @@ pub struct BindServer {
   scheme: Scheme,
   cors: CorsConfig,
   auth: Option<AuthConfig>,
+  package_info: Option<PackageInfo>,
 }
 
 impl BindServer {
   /// Create a new bind server instance.
-  pub fn new(addr: SocketAddr, cors: CorsConfig, auth: Option<AuthConfig>) -> Self {
+  pub fn new(
+    addr: SocketAddr,
+    cors: CorsConfig,
+    auth: Option<AuthConfig>,
+    package_info: Option<PackageInfo>,
+  ) -> Self {
     Self {
       addr,
       cert_key_pair: None,
       scheme: Scheme::Http,
       cors,
       auth,
+      package_info,
     }
   }
 
@@ -145,6 +159,7 @@ impl BindServer {
     cors: CorsConfig,
     auth: Option<AuthConfig>,
     tls: TlsServerConfig,
+    package_info: Option<PackageInfo>,
   ) -> Self {
     Self {
       addr,
@@ -152,6 +167,7 @@ impl BindServer {
       scheme: Scheme::Https,
       cors,
       auth,
+      package_info,
     }
   }
 
@@ -197,6 +213,7 @@ impl BindServer {
       service_info,
       self.cors.clone(),
       self.auth.clone(),
+      self.package_info.clone(),
     ))
   }
 

--- a/htsget-config/src/config/advanced/auth/mod.rs
+++ b/htsget-config/src/config/advanced/auth/mod.rs
@@ -50,8 +50,13 @@ impl AuthConfig {
   }
 
   /// Get the http client.
-  pub fn http_client(&self) -> &ClientWithMiddleware {
-    &self.http_client.0
+  pub fn http_client(&mut self) -> Result<&ClientWithMiddleware> {
+    self.http_client.as_inner_built()
+  }
+
+  /// Get a mutable reference to the inner client builder.
+  pub fn inner_client_mut(&mut self) -> &mut HttpClient {
+    &mut self.http_client
   }
 
   /// Get the authorization mode.
@@ -203,7 +208,7 @@ impl AuthConfigBuilder {
       forward_extensions: self.forward_extensions,
       http_client: self
         .http_client
-        .unwrap_or(HttpClient::try_from(HttpClientConfig::default())?),
+        .unwrap_or(HttpClient::from(HttpClientConfig::default())),
       #[cfg(feature = "experimental")]
       suppress_errors: self.suppress_errors,
       #[cfg(feature = "experimental")]

--- a/htsget-config/src/config/advanced/auth/mod.rs
+++ b/htsget-config/src/config/advanced/auth/mod.rs
@@ -7,6 +7,7 @@
 use crate::config::advanced::HttpClient;
 use crate::config::advanced::auth::authorization::{ForwardExtensions, UrlOrStatic};
 use crate::config::advanced::auth::jwt::AuthMode;
+use crate::config::service_info::PackageInfo;
 use crate::error::{Error, Result};
 use crate::http::client::HttpClientConfig;
 use reqwest_middleware::ClientWithMiddleware;
@@ -102,6 +103,15 @@ impl AuthConfig {
   /// Get the extensions to forward.
   pub fn forward_extensions(&self) -> &[ForwardExtensions] {
     self.forward_extensions.as_slice()
+  }
+
+  /// Set the user-agent information from the package info.
+  pub fn set_from_package_info(&mut self, info: &PackageInfo) -> Result<()> {
+    let client = self.inner_client_mut();
+    let builder = client.config()?;
+    client.set_config(builder.with_user_agent(info.id.to_string()));
+
+    Ok(())
   }
 }
 

--- a/htsget-config/src/config/advanced/auth/response.rs
+++ b/htsget-config/src/config/advanced/auth/response.rs
@@ -316,70 +316,76 @@ mod tests {
   use super::*;
   use crate::config::location::{PrefixOrId, SimpleLocation};
   use serde_json;
+  use std::result;
 
   #[test]
   fn test_authorization_response_deserialization() {
     let json_value = serde_json::json!({
       "version": 1,
-      "htsgetAuth": [{
-        "location": {
-          "id": "path/to/file"
-        },
-        "rules": [{
-          "referenceName": "chr1",
-          "start": 1000,
-          "end": 2000,
-          "format": "BAM"
-        }]
-      }]
-    });
-    let response: AuthorizationRestrictions = serde_json::from_value(json_value).unwrap();
-
-    assert_eq!(response.version(), 1);
-    assert_eq!(response.htsget_auth().len(), 1);
-    assert_eq!(
-      response.htsget_auth()[0]
-        .location()
-        .as_simple()
-        .unwrap()
-        .prefix_or_id()
-        .unwrap()
-        .as_id()
-        .unwrap(),
-      "path/to/file"
-    );
-
-    let restrictions = response.htsget_auth()[0].rules().unwrap();
-    assert_eq!(restrictions.len(), 1);
-    assert_eq!(restrictions[0].reference_name(), Some("chr1"));
-    assert_eq!(restrictions[0].interval().start(), Some(1000));
-    assert_eq!(restrictions[0].interval().end(), Some(2000));
-    assert_eq!(restrictions[0].format(), Some(Format::Bam));
-
-    let no_restrictions_value = serde_json::json!({
-      "version": 1,
-      "htsgetAuth": [{
-        "location": {
-          "id": "path/to/file"
+      "htsgetAuth": [
+        {
+          "location": {
+            "id": "HG00096",
+            "backend": "s3://umccr-10g-data-dev/HG00096/HG00096",
+          },
+          "rules": [
+            {
+              "format": "BAM"
+            }
+          ]
         }
-      }]
+      ]
     });
-    let no_restrictions_response: AuthorizationRestrictions =
-      serde_json::from_value(no_restrictions_value).unwrap();
-    assert_eq!(no_restrictions_response.version(), 1);
-    assert_eq!(no_restrictions_response.htsget_auth().len(), 1);
-    assert_eq!(
-      no_restrictions_response.htsget_auth()[0]
-        .location()
-        .as_simple()
-        .unwrap()
-        .prefix_or_id()
-        .unwrap()
-        .as_id()
-        .unwrap(),
-      "path/to/file"
-    );
-    assert!(no_restrictions_response.htsget_auth()[0].rules().is_none());
+    let response: result::Result<AuthorizationRestrictions, _> = serde_json::from_value(json_value);
+
+    println!("{:#?}", response);
+
+    //
+    // assert_eq!(response.version(), 1);
+    // assert_eq!(response.htsget_auth().len(), 1);
+    // assert_eq!(
+    //   response.htsget_auth()[0]
+    //     .location()
+    //     .as_simple()
+    //     .unwrap()
+    //     .prefix_or_id()
+    //     .unwrap()
+    //     .as_id()
+    //     .unwrap(),
+    //   "path/to/file"
+    // );
+    //
+    // let restrictions = response.htsget_auth()[0].rules().unwrap();
+    // assert_eq!(restrictions.len(), 1);
+    // assert_eq!(restrictions[0].reference_name(), Some("chr1"));
+    // assert_eq!(restrictions[0].interval().start(), Some(1000));
+    // assert_eq!(restrictions[0].interval().end(), Some(2000));
+    // assert_eq!(restrictions[0].format(), Some(Format::Bam));
+    //
+    // let no_restrictions_value = serde_json::json!({
+    //   "version": 1,
+    //   "htsgetAuth": [{
+    //     "location": {
+    //       "id": "path/to/file"
+    //     }
+    //   }]
+    // });
+    // let no_restrictions_response: AuthorizationRestrictions =
+    //   serde_json::from_value(no_restrictions_value).unwrap();
+    // assert_eq!(no_restrictions_response.version(), 1);
+    // assert_eq!(no_restrictions_response.htsget_auth().len(), 1);
+    // assert_eq!(
+    //   no_restrictions_response.htsget_auth()[0]
+    //     .location()
+    //     .as_simple()
+    //     .unwrap()
+    //     .prefix_or_id()
+    //     .unwrap()
+    //     .as_id()
+    //     .unwrap(),
+    //   "path/to/file"
+    // );
+    // assert!(no_restrictions_response.htsget_auth()[0].rules().is_none());
   }
 
   #[test]

--- a/htsget-config/src/config/advanced/auth/response.rs
+++ b/htsget-config/src/config/advanced/auth/response.rs
@@ -29,6 +29,7 @@ pub struct AuthorizationRestrictions {
 #[serde(deny_unknown_fields)]
 pub struct AuthorizationRule {
   /// The location that the authorization applies to.
+  #[serde(alias = "backend")]
   location: Location,
   /// The reference name restrictions to apply to this path.
   #[serde(skip_serializing_if = "Option::is_none")]
@@ -182,6 +183,7 @@ impl AuthorizationRestrictionsBuilder {
 #[serde(deny_unknown_fields)]
 pub struct AuthorizationRuleBuilder {
   /// The location that the authorization applies to.
+  #[serde(alias = "backend")]
   location: Option<Location>,
   /// The reference name restrictions to apply to this path.
   #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/htsget-config/src/config/advanced/auth/response.rs
+++ b/htsget-config/src/config/advanced/auth/response.rs
@@ -316,76 +316,70 @@ mod tests {
   use super::*;
   use crate::config::location::{PrefixOrId, SimpleLocation};
   use serde_json;
-  use std::result;
 
   #[test]
   fn test_authorization_response_deserialization() {
     let json_value = serde_json::json!({
       "version": 1,
-      "htsgetAuth": [
-        {
-          "location": {
-            "id": "HG00096",
-            "backend": "s3://umccr-10g-data-dev/HG00096/HG00096",
-          },
-          "rules": [
-            {
-              "format": "BAM"
-            }
-          ]
-        }
-      ]
+      "htsgetAuth": [{
+        "location": {
+          "id": "path/to/file"
+        },
+        "rules": [{
+          "referenceName": "chr1",
+          "start": 1000,
+          "end": 2000,
+          "format": "BAM"
+        }]
+      }]
     });
-    let response: result::Result<AuthorizationRestrictions, _> = serde_json::from_value(json_value);
+    let response: AuthorizationRestrictions = serde_json::from_value(json_value).unwrap();
 
-    println!("{:#?}", response);
+    assert_eq!(response.version(), 1);
+    assert_eq!(response.htsget_auth().len(), 1);
+    assert_eq!(
+      response.htsget_auth()[0]
+        .location()
+        .as_simple()
+        .unwrap()
+        .prefix_or_id()
+        .unwrap()
+        .as_id()
+        .unwrap(),
+      "path/to/file"
+    );
 
-    //
-    // assert_eq!(response.version(), 1);
-    // assert_eq!(response.htsget_auth().len(), 1);
-    // assert_eq!(
-    //   response.htsget_auth()[0]
-    //     .location()
-    //     .as_simple()
-    //     .unwrap()
-    //     .prefix_or_id()
-    //     .unwrap()
-    //     .as_id()
-    //     .unwrap(),
-    //   "path/to/file"
-    // );
-    //
-    // let restrictions = response.htsget_auth()[0].rules().unwrap();
-    // assert_eq!(restrictions.len(), 1);
-    // assert_eq!(restrictions[0].reference_name(), Some("chr1"));
-    // assert_eq!(restrictions[0].interval().start(), Some(1000));
-    // assert_eq!(restrictions[0].interval().end(), Some(2000));
-    // assert_eq!(restrictions[0].format(), Some(Format::Bam));
-    //
-    // let no_restrictions_value = serde_json::json!({
-    //   "version": 1,
-    //   "htsgetAuth": [{
-    //     "location": {
-    //       "id": "path/to/file"
-    //     }
-    //   }]
-    // });
-    // let no_restrictions_response: AuthorizationRestrictions =
-    //   serde_json::from_value(no_restrictions_value).unwrap();
-    // assert_eq!(no_restrictions_response.version(), 1);
-    // assert_eq!(no_restrictions_response.htsget_auth().len(), 1);
-    // assert_eq!(
-    //   no_restrictions_response.htsget_auth()[0]
-    //     .location()
-    //     .as_simple()
-    //     .unwrap()
-    //     .prefix_or_id()
-    //     .unwrap()
-    //     .as_id()
-    //     .unwrap(),
-    //   "path/to/file"
-    // );
-    // assert!(no_restrictions_response.htsget_auth()[0].rules().is_none());
+    let restrictions = response.htsget_auth()[0].rules().unwrap();
+    assert_eq!(restrictions.len(), 1);
+    assert_eq!(restrictions[0].reference_name(), Some("chr1"));
+    assert_eq!(restrictions[0].interval().start(), Some(1000));
+    assert_eq!(restrictions[0].interval().end(), Some(2000));
+    assert_eq!(restrictions[0].format(), Some(Format::Bam));
+
+    let no_restrictions_value = serde_json::json!({
+      "version": 1,
+      "htsgetAuth": [{
+        "location": {
+          "id": "path/to/file"
+        }
+      }]
+    });
+    let no_restrictions_response: AuthorizationRestrictions =
+      serde_json::from_value(no_restrictions_value).unwrap();
+    assert_eq!(no_restrictions_response.version(), 1);
+    assert_eq!(no_restrictions_response.htsget_auth().len(), 1);
+    assert_eq!(
+      no_restrictions_response.htsget_auth()[0]
+        .location()
+        .as_simple()
+        .unwrap()
+        .prefix_or_id()
+        .unwrap()
+        .as_id()
+        .unwrap(),
+      "path/to/file"
+    );
+    assert!(no_restrictions_response.htsget_auth()[0].rules().is_none());
   }
 
   #[test]

--- a/htsget-config/src/config/advanced/url.rs
+++ b/htsget-config/src/config/advanced/url.rs
@@ -95,7 +95,7 @@ impl TryFrom<Url> for storage::url::Url {
   type Error = Error;
 
   fn try_from(storage: Url) -> Result<Self> {
-    let client = HttpClient::try_from(storage.http)?.0;
+    let client = HttpClient::from(storage.http);
 
     let url_storage = Self::new(
       storage.url.clone(),

--- a/htsget-config/src/config/data_server.rs
+++ b/htsget-config/src/config/data_server.rs
@@ -48,7 +48,7 @@ pub struct DataServerConfig {
   tls: Option<TlsServerConfig>,
   cors: CorsConfig,
   #[serde(skip_serializing)]
-  auth: Option<AuthConfig>,
+  pub(crate) auth: Option<AuthConfig>,
   ticket_origin: Option<String>,
 }
 

--- a/htsget-config/src/config/location.rs
+++ b/htsget-config/src/config/location.rs
@@ -206,7 +206,7 @@ impl From<LocationsOneOrMany> for Locations {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(default, deny_unknown_fields)]
 struct ExtendedLocation {
-  #[serde(flatten)]
+  #[serde(flatten, alias = "backend")]
   location: StringLocation,
   #[cfg(feature = "experimental")]
   #[serde(skip_serializing)]
@@ -218,6 +218,7 @@ struct ExtendedLocation {
 #[serde(default, deny_unknown_fields)]
 struct StringLocation {
   /// The location, which should start with `file://`, `s3://`, `http://` or `https://`.
+  #[serde(alias = "backend")]
   location: Option<String>,
   /// The prefix or id match configuration.
   #[serde(flatten)]
@@ -228,6 +229,7 @@ struct StringLocation {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(default, deny_unknown_fields)]
 struct MapLocation {
+  #[serde(alias = "backend")]
   location: Backend,
   append_to: String,
   prefix_or_id: Option<PrefixOrId>,

--- a/htsget-config/src/config/mod.rs
+++ b/htsget-config/src/config/mod.rs
@@ -149,6 +149,14 @@ impl Config {
     if let Some(ref mut auth) = self.auth {
       auth.set_from_package_info(&self.package_info)?;
     };
+    if let Some(ref mut auth) = self.ticket_server.auth {
+      auth.set_from_package_info(&self.package_info)?;
+    }
+    if let DataServerEnabled::Some(ref mut data_server_config) = self.data_server {
+      if let Some(ref mut auth) = data_server_config.auth {
+        auth.set_from_package_info(&self.package_info)?;
+      }
+    }
 
     self.locations.set_from_package_info(&self.package_info)?;
 

--- a/htsget-config/src/config/service_info.rs
+++ b/htsget-config/src/config/service_info.rs
@@ -124,7 +124,7 @@ impl ServiceInfo {
   }
 
   /// Set the fields from the package info if they have not already been set.
-  pub fn set_from_package_info(&mut self, info: PackageInfo) -> Result<()> {
+  pub fn set_from_package_info(&mut self, info: &PackageInfo) -> Result<()> {
     let mut package_info: HashMap<String, Value> = from_value(to_value(info)?)?;
 
     package_info.extend(self.0.drain());
@@ -175,7 +175,7 @@ mod tests {
 
   fn update_service_info(result: &mut Config) {
     let info = result.service_info_mut();
-    info.set_from_package_info(package_info!()).unwrap();
+    info.set_from_package_info(&package_info!()).unwrap();
 
     assert!(result.service_info.0.contains_key("createdAt"));
     assert!(result.service_info.0.contains_key("updatedAt"));

--- a/htsget-config/src/config/service_info.rs
+++ b/htsget-config/src/config/service_info.rs
@@ -27,11 +27,11 @@ macro_rules! package_info {
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, Clone)]
 #[serde(default, rename_all = "camelCase")]
 pub struct PackageInfo {
-  id: String,
-  name: String,
-  version: String,
-  description: String,
-  documentation_url: String,
+  pub(crate) id: String,
+  pub(crate) name: String,
+  pub(crate) version: String,
+  pub(crate) description: String,
+  pub(crate) documentation_url: String,
 }
 
 impl PackageInfo {

--- a/htsget-config/src/config/ticket_server.rs
+++ b/htsget-config/src/config/ticket_server.rs
@@ -16,7 +16,7 @@ pub struct TicketServerConfig {
   tls: Option<TlsServerConfig>,
   cors: CorsConfig,
   #[serde(skip_serializing)]
-  auth: Option<AuthConfig>,
+  pub(crate) auth: Option<AuthConfig>,
 }
 
 impl TicketServerConfig {

--- a/htsget-config/src/http/client.rs
+++ b/htsget-config/src/http/client.rs
@@ -17,6 +17,7 @@ pub struct HttpClientConfig {
   cert: Option<Vec<Certificate>>,
   identity: Option<Identity>,
   use_cache: bool,
+  user_agent: Option<String>,
 }
 
 impl Default for HttpClientConfig {
@@ -25,6 +26,7 @@ impl Default for HttpClientConfig {
       cert: None,
       identity: None,
       use_cache: true,
+      user_agent: None,
     }
   }
 }
@@ -36,12 +38,26 @@ impl HttpClientConfig {
       cert,
       identity,
       use_cache,
+      ..Default::default()
     }
   }
 
   /// Get the inner client config.
-  pub fn into_inner(self) -> (Option<Vec<Certificate>>, Option<Identity>, bool) {
-    (self.cert, self.identity, self.use_cache)
+  pub fn into_inner(
+    self,
+  ) -> (
+    Option<Vec<Certificate>>,
+    Option<Identity>,
+    bool,
+    Option<String>,
+  ) {
+    (self.cert, self.identity, self.use_cache, self.user_agent)
+  }
+
+  /// Set the user agent string.
+  pub fn with_user_agent(mut self, user_agent: String) -> Self {
+    self.user_agent = Some(user_agent);
+    self
   }
 }
 
@@ -93,7 +109,7 @@ pub(crate) mod tests {
   async fn test_tls_client_config() {
     with_test_certificates(|path, _, _| {
       let client_config = client_config_from_path(path);
-      let (certs, identity, _) = client_config.into_inner();
+      let (certs, identity, _, _) = client_config.into_inner();
 
       assert_eq!(certs.unwrap().len(), 1);
       assert!(identity.is_some());

--- a/htsget-config/src/resolver.rs
+++ b/htsget-config/src/resolver.rs
@@ -27,7 +27,7 @@ pub trait ResolveResponse {
 
   /// Convert from `Url`.
   #[cfg(feature = "url")]
-  async fn from_url(url_storage: &storage::url::Url, query: &Query) -> Result<Response>;
+  async fn from_url(url_storage: storage::url::Url, query: &Query) -> Result<Response>;
 }
 
 /// A trait which uses storage to resolve requests into responses.
@@ -152,7 +152,7 @@ impl StorageResolver for Location {
         Some(T::from_s3(s3, query).await)
       }
       #[cfg(feature = "url")]
-      Backend::Url(url_storage) => Some(T::from_url(url_storage, query).await),
+      Backend::Url(url_storage) => Some(T::from_url(url_storage.clone(), query).await),
     }
   }
 }
@@ -210,7 +210,7 @@ mod tests {
   use crate::types::Url;
   use http::uri::Authority;
   #[cfg(feature = "url")]
-  use reqwest::ClientBuilder;
+  use {crate::config::advanced::HttpClient, reqwest::ClientBuilder};
   #[cfg(feature = "aws")]
   use {
     crate::config::advanced::allow_guard::{AllowGuard, ReferenceNames},
@@ -238,7 +238,7 @@ mod tests {
     }
 
     #[cfg(feature = "url")]
-    async fn from_url(url: &storage::url::Url, query: &Query) -> Result<Response> {
+    async fn from_url(url: storage::url::Url, query: &Query) -> Result<Response> {
       Ok(Response::new(
         Bam,
         Self::format_url(url.url().to_string().strip_suffix('/').unwrap(), query.id()),
@@ -333,7 +333,7 @@ mod tests {
       "https://example.com/".parse().unwrap(),
       true,
       vec![],
-      client,
+      HttpClient::new(client),
     );
 
     let regex_location = RegexLocation::new(

--- a/htsget-config/src/resolver.rs
+++ b/htsget-config/src/resolver.rs
@@ -152,7 +152,7 @@ impl StorageResolver for Location {
         Some(T::from_s3(s3, query).await)
       }
       #[cfg(feature = "url")]
-      Backend::Url(url_storage) => Some(T::from_url(url_storage.clone(), query).await),
+      Backend::Url(url_storage) => Some(T::from_url(*url_storage.clone(), query).await),
     }
   }
 }
@@ -339,7 +339,7 @@ mod tests {
     let regex_location = RegexLocation::new(
       "(id)-1".parse().unwrap(),
       "$1-test".to_string(),
-      Backend::Url(url_storage.clone()),
+      Backend::Url(Box::new(url_storage.clone())),
       Default::default(),
     );
     expected_resolved_request(
@@ -349,7 +349,7 @@ mod tests {
     .await;
 
     let location = SimpleLocation::new(
-      Backend::Url(url_storage),
+      Backend::Url(Box::new(url_storage)),
       "".to_string(),
       Some(PrefixOrId::Prefix("".to_string())),
     );

--- a/htsget-config/src/storage/mod.rs
+++ b/htsget-config/src/storage/mod.rs
@@ -120,6 +120,16 @@ impl Backend {
     }
   }
 
+  /// Get the url variant as a mutable reference and error if it is not `Url`.
+  #[cfg(feature = "url")]
+  pub fn as_url_mut(&mut self) -> Result<&mut Url> {
+    if let Backend::Url(url) = self {
+      Ok(url)
+    } else {
+      Err(Error::ParseError("not a `File` variant".to_string()))
+    }
+  }
+
   /// Set the C4GH keys.
   #[cfg(feature = "experimental")]
   pub fn set_keys(&mut self, keys: Option<C4GHKeys>) {

--- a/htsget-config/src/storage/mod.rs
+++ b/htsget-config/src/storage/mod.rs
@@ -50,7 +50,7 @@ pub enum Backend {
   S3(S3),
   #[cfg(feature = "url")]
   #[serde(alias = "url", alias = "URL")]
-  Url(Url),
+  Url(Box<Url>),
 }
 
 impl Backend {

--- a/htsget-http/src/http_core.rs
+++ b/htsget-http/src/http_core.rs
@@ -1,4 +1,4 @@
-use crate::HtsGetError::InvalidInput;
+use crate::HtsGetError::{InternalError, InvalidInput};
 use crate::middleware::auth::Auth;
 use crate::{
   Endpoint, HtsGetError, PostRequest, Result, convert_to_query, match_format_from_query,
@@ -8,6 +8,7 @@ use cfg_if::cfg_if;
 use futures::StreamExt;
 use futures::stream::FuturesOrdered;
 use htsget_config::config::advanced::auth::AuthorizationRestrictions;
+use htsget_config::config::service_info::PackageInfo;
 use htsget_config::types::{JsonResponse, Query, Request, Response};
 use htsget_search::HtsGet;
 use http::HeaderMap;
@@ -66,6 +67,7 @@ pub async fn get(
   request: Request,
   endpoint: Endpoint,
   auth: Option<Auth>,
+  package_info: Option<&PackageInfo>,
   extensions: Option<Value>,
 ) -> Result<JsonResponse> {
   let path = request.path().to_string();
@@ -82,7 +84,12 @@ pub async fn get(
   let query = query.into_iter().next().expect("single element vector");
 
   let response = if let Some(ref rules) = rules {
-    let remote_locations = rules.clone().into_remote_locations();
+    let mut remote_locations = rules.clone().into_remote_locations();
+    if let Some(package_info) = package_info {
+      remote_locations
+        .set_from_package_info(package_info)
+        .map_err(|_| InternalError("invalid remote locations".to_string()))?;
+    }
 
     // If there are remote locations, try them first.
     match remote_locations
@@ -115,6 +122,7 @@ pub async fn post(
   request: Request,
   endpoint: Endpoint,
   auth: Option<Auth>,
+  package_info: Option<&PackageInfo>,
   extensions: Option<Value>,
 ) -> Result<JsonResponse> {
   let path = request.path().to_string();
@@ -136,7 +144,12 @@ pub async fn post(
   let mut futures = FuturesOrdered::new();
   if let Some(ref rules) = rules {
     for query in queries {
-      let remote_locations = rules.clone().into_remote_locations();
+      let mut remote_locations = rules.clone().into_remote_locations();
+      if let Some(package_info) = package_info {
+        remote_locations
+          .set_from_package_info(package_info)
+          .map_err(|_| InternalError("invalid remote locations".to_string()))?;
+      }
       let owned_searcher = searcher.clone();
 
       // If there are remote locations, try them first.

--- a/htsget-http/src/http_core.rs
+++ b/htsget-http/src/http_core.rs
@@ -21,7 +21,7 @@ async fn authenticate(
   headers: &HeaderMap,
   auth: Option<Auth>,
 ) -> Result<Option<(TokenData<Value>, Auth)>> {
-  if let Some(auth) = auth {
+  if let Some(mut auth) = auth {
     if auth.config().auth_mode().is_some() {
       return Ok(Some((auth.validate_jwt(headers).await?, auth)));
     }
@@ -37,7 +37,7 @@ async fn authorize(
   auth: Option<(TokenData<Value>, Auth)>,
   extensions: Option<Value>,
 ) -> Result<Option<AuthorizationRestrictions>> {
-  if let Some((_, auth)) = auth {
+  if let Some((_, mut auth)) = auth {
     let _rules = auth
       .validate_authorization(headers, path, queries, extensions)
       .await?;

--- a/htsget-http/src/lib.rs
+++ b/htsget-http/src/lib.rs
@@ -163,7 +163,7 @@ mod tests {
     );
 
     assert_eq!(
-      get(get_searcher(), request, Endpoint::Reads, None, None).await,
+      get(get_searcher(), request, Endpoint::Reads, None, None, None).await,
       Ok(expected_bam_json_response(expected_response_headers))
     );
   }
@@ -180,7 +180,7 @@ mod tests {
     );
 
     assert!(matches!(
-      get(get_searcher(), request, Endpoint::Reads, None, None).await,
+      get(get_searcher(), request, Endpoint::Reads, None, None, None).await,
       Err(HtsGetError::UnsupportedFormat(_))
     ));
   }
@@ -202,7 +202,15 @@ mod tests {
     );
 
     assert_eq!(
-      get(get_searcher(), request, Endpoint::Variants, None, None).await,
+      get(
+        get_searcher(),
+        request,
+        Endpoint::Variants,
+        None,
+        None,
+        None
+      )
+      .await,
       Ok(expected_vcf_json_response(expected_response_headers))
     );
   }
@@ -224,7 +232,16 @@ mod tests {
     expected_response_headers.insert("Range".to_string(), "bytes=0-2596798".to_string());
 
     assert_eq!(
-      post(get_searcher(), body, request, Endpoint::Reads, None, None).await,
+      post(
+        get_searcher(),
+        body,
+        request,
+        Endpoint::Reads,
+        None,
+        None,
+        None
+      )
+      .await,
       Ok(expected_bam_json_response(expected_response_headers))
     );
   }
@@ -248,6 +265,7 @@ mod tests {
         body,
         request,
         Endpoint::Variants,
+        None,
         None,
         None
       )
@@ -282,6 +300,7 @@ mod tests {
         body,
         request,
         Endpoint::Variants,
+        None,
         None,
         None
       )

--- a/htsget-http/src/middleware/auth.rs
+++ b/htsget-http/src/middleware/auth.rs
@@ -1,7 +1,7 @@
 //! The htsget authorization middleware.
 //!
 
-use crate::{HtsGetError, Htsget};
+use crate::HtsGetError;
 use crate::error::Result as HtsGetResult;
 use crate::middleware::error::Error::AuthBuilderError;
 use crate::middleware::error::Result;
@@ -81,46 +81,28 @@ impl Auth {
 
   /// Fetch JWKS from the authorization server.
   pub async fn fetch_from_url<D: DeserializeOwned>(
-    &self,
+    &mut self,
     url: &str,
-    mut headers: HeaderMap,
+    headers: HeaderMap,
   ) -> HtsGetResult<D> {
-    headers.insert("User-Agent", HeaderValue::from_str("htsget-rs").unwrap());
     trace!("fetching url: {}", url);
     let err = || HtsGetError::InternalError(format!("failed to fetch data from {url}"));
-    println!("HEADERS: {:?}", headers);
     let response = self
       .config
       .http_client()
+      .map_err(|_| err())?
       .get(url)
-      .headers(headers.clone())
+      .headers(headers)
       .send()
       .await
-      .map_err(|_| HtsGetError::InternalError(format!("failed to fetch data from {url}")))?;
-    let test = self
-        .config
-        .http_client()
-        .head("https://www.google.com")
-        .send()
-        .await
-        .map_err(|_| HtsGetError::InternalError(format!("failed to fetch data from {url}")))?;
-    println!("TEST: {:?}", test);
-    println!("ELSA: {:?}", response);
-    println!("ELSA: {:?}", String::from_utf8(response.bytes().await.map_err(|err| HtsGetError::InternalError(err.to_string()))?.to_vec()));
+      .map_err(|_| err())?;
+    trace!("response: {:?}", response);
 
-    let response = self
-        .config
-        .http_client()
-        .get(url)
-        .headers(headers)
-        .send()
-        .await
-        .map_err(|_| HtsGetError::InternalError(format!("failed to fetch data from {url}")))?;
-    response.json().await.map_err(|err| HtsGetError::InternalError(format!("failed to fetch data from {url}: {err}")))
+    response.json().await.map_err(|_| err())
   }
 
   /// Get a decoding key form the JWKS url.
-  pub async fn decode_jwks(&self, jwks_url: &Uri, token: &str) -> HtsGetResult<DecodingKey> {
+  pub async fn decode_jwks(&mut self, jwks_url: &Uri, token: &str) -> HtsGetResult<DecodingKey> {
     // Decode header and get the key id.
     let header = decode_header(token)?;
     let kid = header
@@ -219,7 +201,7 @@ impl Auth {
   /// that the authorization url is trusted in the config settings before calling the
   /// service. The claims are assumed to be valid.
   pub async fn query_authorization_service(
-    &self,
+    &mut self,
     headers: &HeaderMap,
     request_extensions: Option<Value>,
   ) -> HtsGetResult<Option<AuthorizationRestrictions>> {
@@ -345,7 +327,7 @@ impl Auth {
 
   /// Validate only the JWT without looking up restrictions and validating those. Returns the
   /// decoded JWT token.
-  pub async fn validate_jwt(&self, headers: &HeaderMap) -> HtsGetResult<TokenData<Value>> {
+  pub async fn validate_jwt(&mut self, headers: &HeaderMap) -> HtsGetResult<TokenData<Value>> {
     let auth_token = headers
       .values()
       .find_map(|value| Authorization::<Bearer>::decode(&mut [value].into_iter()).ok())
@@ -355,16 +337,22 @@ impl Auth {
 
     let decoding_key = if let Some(ref decoding_key) = self.decoding_key {
       decoding_key
+    } else if matches!(self.config.auth_mode(), Some(AuthMode::Jwks(_))) {
+      let url = if let Some(AuthMode::Jwks(uri)) = self.config.auth_mode() {
+        uri.clone()
+      } else {
+        return Err(HtsGetError::InternalError(
+          "JWT validation not set".to_string(),
+        ));
+      };
+
+      &self.decode_jwks(&url, auth_token.token()).await?
+    } else if let Some(AuthMode::PublicKey(key)) = self.config.auth_mode() {
+      &Self::decode_public_key(key)?
     } else {
-      match self.config.auth_mode() {
-        Some(AuthMode::Jwks(jwks)) => &self.decode_jwks(jwks, auth_token.token()).await?,
-        Some(AuthMode::PublicKey(public_key)) => &Self::decode_public_key(public_key)?,
-        _ => {
-          return Err(HtsGetError::InternalError(
-            "JWT validation not set".to_string(),
-          ));
-        }
-      }
+      return Err(HtsGetError::InternalError(
+        "JWT validation not set".to_string(),
+      ));
     };
 
     // Decode and validate the JWT
@@ -415,7 +403,7 @@ impl Auth {
   /// 3. Queries the authorization service for restrictions based on the config or JWT claims.
   /// 4. Validates the restrictions to determine if the user is authorized.
   pub async fn validate_authorization(
-    &self,
+    &mut self,
     headers: &HeaderMap,
     path: &str,
     queries: &mut [Query],
@@ -1331,7 +1319,7 @@ mod tests {
 
   #[tokio::test]
   async fn validate_authorization_missing_auth_header() {
-    let auth = create_mock_auth_with_restrictions();
+    let mut auth = create_mock_auth_with_restrictions();
     let request = Request::new("sample1".to_string(), HashMap::new(), HeaderMap::new());
 
     let result = auth.validate_jwt(request.headers()).await;
@@ -1344,7 +1332,7 @@ mod tests {
 
   #[tokio::test]
   async fn validate_authorization_invalid_jwt_format() {
-    let auth = create_mock_auth_with_restrictions();
+    let mut auth = create_mock_auth_with_restrictions();
     let request = create_request_with_auth_header("sample1", HashMap::new(), "invalid.jwt.token");
 
     let result = auth.validate_jwt(request.headers()).await;

--- a/htsget-lambda/src/lib.rs
+++ b/htsget-lambda/src/lib.rs
@@ -69,11 +69,8 @@ where
 /// Run the Lambda handler using the config file contained at the path.
 pub async fn run_handler(path: &Path) -> Result<(), Error> {
   let mut config = Config::from_path(path)?;
-
+  config.set_package_info(package_info!())?;
   config.setup_tracing()?;
-
-  let service_info = config.service_info_mut();
-  service_info.set_from_package_info(package_info!())?;
 
   debug!(config = ?config, "config parsed");
 

--- a/htsget-lambda/src/lib.rs
+++ b/htsget-lambda/src/lib.rs
@@ -77,7 +77,14 @@ pub async fn run_handler(path: &Path) -> Result<(), Error> {
   let service_info = config.service_info().clone();
   let cors = config.ticket_server().cors().clone();
   let auth = config.ticket_server().auth().cloned();
-  let router = TicketServer::router(config.into_locations(), service_info, cors, auth)?;
+  let package_info = config.package_info().clone();
+  let router = TicketServer::router(
+    config.into_locations(),
+    service_info,
+    cors,
+    auth,
+    Some(package_info),
+  )?;
 
   lambda_runtime::run(Adapter::from(router)).await
 }

--- a/htsget-search/src/from_storage.rs
+++ b/htsget-search/src/from_storage.rs
@@ -64,7 +64,7 @@ impl ResolveResponse for HtsGetFromStorage {
   }
 
   #[cfg(feature = "url")]
-  async fn from_url(url_storage_config: &storage::url::Url, query: &Query) -> Result<Response> {
+  async fn from_url(url_storage_config: storage::url::Url, query: &Query) -> Result<Response> {
     let storage = Storage::from_url(url_storage_config, query).await;
     let searcher = HtsGetFromStorage::new(storage?);
     searcher.search(query.clone()).await

--- a/htsget-storage/src/lib.rs
+++ b/htsget-storage/src/lib.rs
@@ -193,9 +193,11 @@ impl Storage {
 
   /// Create from url config.
   #[cfg(feature = "url")]
-  pub async fn from_url(url: &storage::url::Url, _query: &Query) -> Result<Storage> {
+  pub async fn from_url(mut url: storage::url::Url, _query: &Query) -> Result<Storage> {
     let storage = Storage::new(UrlStorage::new(
-      url.client_cloned(),
+      url
+        .client_cloned()
+        .map_err(|err| StorageError::InternalError(err.to_string()))?,
       url.url().clone(),
       url.response_url().clone(),
       url.forward_headers(),

--- a/htsget-test/src/http/mod.rs
+++ b/htsget-test/src/http/mod.rs
@@ -178,6 +178,7 @@ fn default_test_config_params(
     Default::default(),
     default_test_resolver(addr, scheme),
     auth_config,
+    Default::default(),
   )
 }
 


### PR DESCRIPTION
### Changes
* Adds the user-agent to all internal request inside htsget-rs as otherwise they can get blocked.
    * The user agent is the package name and version.
    * This took a bit of a refactor of the package info, as I wanted the user-agent to be based on the top-level crate that has htsget-config as a dependency. If `package_info!()` is called inside htsget-config, it will return `"htsget-config/<version>"` rather than `"htsget-lambda/<version>"`.
* Changes the authorization response structure and gives an "backend" as an alias to the location.