### PR TITLE
feat: pre-build htsget-lambda

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -14,18 +14,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: [stable]
         os: [ubuntu-latest]
     steps:
       - name: Cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - name: Check out
         uses: actions/checkout@v6
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        id: toolchain
-        with:
-          toolchain: ${{ matrix.rust }}
       - name: Install binstall
         uses: cargo-bins/cargo-binstall@main
       - name: Install cargo-criterion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,56 @@ jobs:
       id-token: write
     name: Release-plz
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release-plz.outputs.releases_created }}
+      releases: ${{ steps.release-plz.outputs.releases }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
       - name: Run release-plz
+        id: release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  # Build the htsget-lambda deployment artifact whenever release-plz publishes `htsget-lambda`
+  lambda-artifact:
+    name: Publish htsget-lambda
+    needs: release
+    # Run only when this release actually included htsget-lambda.
+    if: ${{ needs.release.outputs.releases_created == 'true' && contains(fromJSON(needs.release.outputs.releases).*.package_name, 'htsget-lambda') }}
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install cargo-lambda and Zig
+        run: pip3 install cargo-lambda ziglang
+
+      - name: Build htsget-lambda (arm64)
+        env:
+          RUSTFLAGS: "-C target-cpu=neoverse-n1"
+          CARGO_PROFILE_RELEASE_LTO: "true"
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
+        run: |
+          cargo lambda build \
+            --release \
+            --arm64 \
+            --package htsget-lambda \
+            --features aws,url,experimental \
+            --output-format zip
+
+      - name: Attach artifact to the GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASES: ${{ needs.release.outputs.releases }}
+        run: |
+          tag=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "htsget-lambda") | .tag')
+          gh release upload "$tag" target/lambda/htsget-lambda/bootstrap.zip --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,23 @@ jobs:
 
   # Build the htsget-lambda deployment artifact whenever release-plz publishes `htsget-lambda`
   lambda-artifact:
-    name: Publish htsget-lambda
+    name: Publish htsget-lambda (${{ matrix.arch }})
     needs: release
     # Run only when this release actually included htsget-lambda.
     if: ${{ needs.release.outputs.releases_created == 'true' && contains(fromJSON(needs.release.outputs.releases).*.package_name, 'htsget-lambda') }}
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            build-flag: --arm64
+            target-cpu: neoverse-n1
+          - arch: x86_64
+            build-flag: --x86-64
+            target-cpu: x86-64-v3
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -46,23 +56,26 @@ jobs:
       - name: Install cargo-lambda and Zig
         run: pip3 install cargo-lambda ziglang
 
-      - name: Build htsget-lambda (arm64)
+      - name: Build htsget-lambda for ${{ matrix.arch }}
         env:
-          RUSTFLAGS: "-C target-cpu=neoverse-n1"
+          RUSTFLAGS: "-C target-cpu=${{ matrix.target-cpu }}"
           CARGO_PROFILE_RELEASE_LTO: "true"
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
+          CARGO_PROFILE_RELEASE_STRIP: "symbols"
         run: |
           cargo lambda build \
             --release \
-            --arm64 \
+            ${{ matrix.build-flag }} \
             --package htsget-lambda \
-            --features aws,url,experimental \
+            --all-features \
             --output-format zip
 
       - name: Attach artifact to the GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASES: ${{ needs.release.outputs.releases }}
+          ARCH: ${{ matrix.arch }}
         run: |
           tag=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "htsget-lambda") | .tag')
-          gh release upload "$tag" target/lambda/htsget-lambda/bootstrap.zip --clobber
+          mv target/lambda/htsget-lambda/bootstrap.zip "$tag-$ARCH.zip"
+          gh release upload "$tag" "$tag-$ARCH.zip" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,4 +78,4 @@ jobs:
         run: |
           tag=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "htsget-lambda") | .tag')
           mv target/lambda/htsget-lambda/bootstrap.zip "$tag-$ARCH.zip"
-          gh release upload "$tag" "$tag-$ARCH.zip" --clobber
+          gh release upload "$tag" "$tag-$ARCH.zip"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,19 +19,12 @@ jobs:
       RUSTC_WRAPPER: "sccache"
     strategy:
       matrix:
-        rust: [stable]
         os: [ubuntu-latest]
     steps:
       - name: Cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - name: Check out
         uses: actions/checkout@v6
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        id: toolchain
-        with:
-          toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
       - name: Install pre-commit
         run: pip3 install pre-commit
       - name: Run pre-commit

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Htsget-rs is configured using environment variables or config files, see [htsget
 ### Cloud
 
 Cloud-based htsget-rs uses [htsget-lambda]. For an example deployment of this crate using CDK see [htsget-deploy].
+Pre-built Lambda deployment packages for `arm64` and `x86_64` are attached to each `htsget-lambda` [release][releases].
+
+[releases]: https://github.com/umccr/htsget-rs/releases
 
 ## Protocol
 

--- a/htsget-lambda/README.md
+++ b/htsget-lambda/README.md
@@ -23,19 +23,38 @@ This crate is used for running a cloud-based instance of htsget-rs. It:
 
 ## Usage
 
-This crate can be deployed to AWS as a Lambda function, or interacted with locally using [cargo-lambda]. See the [htsget-deploy] 
-for more details. Note, this crate does not use any configuration relating to the local data server. CORS configuration
-uses values from the ticket server config. See [htsget-config] for more information about configuration.
+This crate is intended to be deployed to AWS as a Lambda function. It is configured in the same
+way as [htsget-axum], by using the [htsget-config]. However, given that it is a Lambda function, environment
+based config is recommended over TOML files.
 
 Pre-built Lambda deployment packages are attached to each `htsget-lambda` [release][releases] as
 `htsget-lambda-v<version>-<arch>.zip` files for `arm64` and `x86_64`.
 
 See [htsget-search] for details on how to structure files.
 
+#### Development
+
+This crate can be locally compiled and tested using [cargo-lambda]. For example, run the function
+locally:
+
+```sh
+cargo lambda watch -p htsget-lambda
+```
+
+Then query it through the local URL:
+
+```sh
+curl localhost:9000/lambda-url/htsget-lambda/reads/service-info
+```
+
+Environment variables can be set when using [cargo-lambda]. `cargo lambda invoke`
+can be used to send raw Lambda events such as API Gateway requests to the function.
+
 [cargo-lambda]: https://github.com/cargo-lambda/cargo-lambda
 [htsget-deploy]: https://github.com/umccr/htsget-deploy
 [htsget-search]: ../htsget-search
 [htsget-config]: ../htsget-config
+[htsget-axum]: ../htsget-axum
 [releases]: https://github.com/umccr/htsget-rs/releases
 
 ### As a library

--- a/htsget-lambda/README.md
+++ b/htsget-lambda/README.md
@@ -27,12 +27,16 @@ This crate can be deployed to AWS as a Lambda function, or interacted with local
 for more details. Note, this crate does not use any configuration relating to the local data server. CORS configuration
 uses values from the ticket server config. See [htsget-config] for more information about configuration.
 
+Pre-built Lambda deployment packages are attached to each `htsget-lambda` [release][releases] as
+`htsget-lambda-v<version>-<arch>.zip` files for `arm64` and `x86_64`.
+
 See [htsget-search] for details on how to structure files.
 
 [cargo-lambda]: https://github.com/cargo-lambda/cargo-lambda
 [htsget-deploy]: https://github.com/umccr/htsget-deploy
 [htsget-search]: ../htsget-search
 [htsget-config]: ../htsget-config
+[releases]: https://github.com/umccr/htsget-rs/releases
 
 ### As a library
 
@@ -42,7 +46,7 @@ library code, and it instead uses `htsget-axum`. Please use that crate for funct
 #### Feature flags
 
 This crate has the following features:
-* `s3`: used to enable `S3` location functionality and any other AWS features.
+* `aws`: used to enable `S3` location functionality and any other AWS features.
 * `url`: used to enable `Url` location functionality.
 * `experimental`: used to enable experimental features that aren't necessarily part of the htsget spec, such as Crypt4GH support through `C4GHStorage`.
 

--- a/htsget-lambda/src/lib.rs
+++ b/htsget-lambda/src/lib.rs
@@ -6,7 +6,8 @@ use futures::TryFuture;
 use htsget_axum::server::ticket::TicketServer;
 use htsget_config::config::Config;
 use htsget_config::package_info;
-use lambda_http::request::LambdaRequest;
+use lambda_http::http::Uri;
+use lambda_http::request::{LambdaRequest, RequestContext};
 use lambda_http::{
   Error, IntoResponse, LambdaEvent, Request, RequestExt, Service, TransformResponse, lambda_runtime,
 };
@@ -58,6 +59,8 @@ where
     let request_origin = lambda_request.request_origin();
     let mut event: Request = lambda_request.into();
 
+    strip_stage_from_path(&mut event);
+
     // After creating the request event, add the original request as an extension.
     debug!(original_request = ?original_request, "original_request");
     event.extensions_mut().insert(original_request);
@@ -65,6 +68,37 @@ where
     let fut = Box::pin(self.service.call(event.with_lambda_context(req.context)));
     TransformResponse::Request(request_origin, fut)
   }
+}
+
+/// Strip the API Gateway stage from the start of the request path so that routing works correctly.
+fn strip_stage_from_path(event: &mut Request) {
+  let stage = match event.request_context_ref() {
+    Some(RequestContext::ApiGatewayV1(context)) => context.stage.as_deref(),
+    Some(RequestContext::ApiGatewayV2(context)) => context.stage.as_deref(),
+    _ => None,
+  };
+
+  let Some(stage) = stage.filter(|stage| *stage != "$default") else {
+    return;
+  };
+
+  let stripped = match event.uri().path().strip_prefix(&format!("/{stage}")) {
+    Some("") => "/",
+    Some(rest) if rest.starts_with('/') => rest,
+    _ => return,
+  };
+
+  let path_and_query = match event.uri().query() {
+    Some(query) => format!("{stripped}?{query}"),
+    None => stripped.to_string(),
+  };
+
+  let mut parts = event.uri().clone().into_parts();
+  let path_and_query = path_and_query
+    .parse()
+    .expect("expected valid path and query from a valid uri");
+  parts.path_and_query = Some(path_and_query);
+  *event.uri_mut() = Uri::from_parts(parts).expect("expected valid parts from a valid uri");
 }
 
 /// Run the Lambda handler using the config file contained at the path.
@@ -88,4 +122,64 @@ pub async fn run_handler(path: &Path) -> Result<(), Error> {
   )?;
 
   lambda_runtime::run(Adapter::from(router)).await
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use aws_lambda_events::apigw::{ApiGatewayProxyRequestContext, ApiGatewayV2httpRequestContext};
+  use lambda_http::Body;
+
+  fn v1_request(uri: &str, stage: Option<&str>) -> Request {
+    let mut context = ApiGatewayProxyRequestContext::default();
+    context.stage = stage.map(|stage| stage.to_string());
+    request(uri).with_request_context(RequestContext::ApiGatewayV1(context))
+  }
+
+  fn v2_request(uri: &str, stage: Option<&str>) -> Request {
+    let mut context = ApiGatewayV2httpRequestContext::default();
+    context.stage = stage.map(|stage| stage.to_string());
+    request(uri).with_request_context(RequestContext::ApiGatewayV2(context))
+  }
+
+  fn request(uri: &str) -> Request {
+    lambda_http::http::Request::builder()
+      .uri(uri)
+      .body(Body::Empty)
+      .unwrap()
+  }
+
+  fn strip(mut event: Request) -> String {
+    strip_stage_from_path(&mut event);
+    event.uri().to_string()
+  }
+
+  #[test]
+  fn strip_stage() {
+    assert_eq!(
+      strip(v1_request("/prod/reads/id", Some("prod"))),
+      "/reads/id"
+    );
+    assert_eq!(
+      strip(v2_request("/prod/reads/id", Some("prod"))),
+      "/reads/id"
+    );
+
+    assert_eq!(
+      strip(v1_request("/prod/reads/id?format=BAM", Some("prod"))),
+      "/reads/id?format=BAM"
+    );
+    assert_eq!(strip(v1_request("/prod", Some("prod"))), "/");
+    assert_eq!(strip(request("/prod/reads/id")), "/prod/reads/id");
+    assert_eq!(
+      strip(v1_request("/reads/id", Some("$default"))),
+      "/reads/id"
+    );
+    assert_eq!(strip(v1_request("/reads/id", None)), "/reads/id");
+    assert_eq!(
+      strip(v1_request("/production/reads/id", Some("prod"))),
+      "/production/reads/id"
+    );
+    assert_eq!(strip(v1_request("/reads/id", Some("prod"))), "/reads/id");
+  }
 }


### PR DESCRIPTION
Closes #361 

### Changes
* Adds a build step that uploads the Lambda zip file to the github release, when release-plz runs. This should be called `htsget-lambda-<version>-<arch>.zip`, with both arm64 and x86_64 being uploaded.
* I've also added a function to htsget-lambda which strips the ApiGateway stage, e.g. `/prod/` or `/dev/`. Previously this was relying on `AWS_LAMBDA_HTTP_IGNORE_STAGE_IN_PATH`, which a consumer would have to set when deploying the function. I think this is the right call because this behaviour is required for htsget-lambda to work correctly, and it shouldn't require a consumer setting the correct env variable. Eventually, this might belong in the AWS Lambda runtime.