### PR TITLE
Fix failing tests and `BytesPosition`/`BytesRange` checks

### DIFF
--- a/htsget-axum/src/server/data.rs
+++ b/htsget-axum/src/server/data.rs
@@ -114,8 +114,7 @@ mod tests {
   use reqwest::{Client, ClientBuilder, RequestBuilder};
   use rustls::crypto::aws_lc_rs;
   use tempfile::{TempDir, tempdir};
-  use tokio::fs::{File, create_dir};
-  use tokio::io::AsyncWriteExt;
+  use tokio::fs::{create_dir, write};
 
   use htsget_config::config::Config;
   use htsget_config::http::TlsServerConfig;
@@ -360,19 +359,11 @@ mod tests {
     let value1 = b"value1";
     let key2 = "key2";
     let value2 = b"value2";
-    File::create(base_path.path().join(key1))
-      .await
-      .unwrap()
-      .write_all(value1)
-      .await
-      .unwrap();
+    write(base_path.path().join(key1), value1).await.unwrap();
     create_dir(base_path.path().join(folder_name))
       .await
       .unwrap();
-    File::create(base_path.path().join(folder_name).join(key2))
-      .await
-      .unwrap()
-      .write_all(value2)
+    write(base_path.path().join(folder_name).join(key2), value2)
       .await
       .unwrap();
 

--- a/htsget-search/src/bam_search.rs
+++ b/htsget-search/src/bam_search.rs
@@ -51,10 +51,11 @@ impl BgzfSearch<LinearIndex, AsyncReader, Header> for BamSearch {
     };
 
     Ok(vec![
-      BytesPosition::default()
-        .with_start(start.compressed())?
-        .with_end(self.position_at_eof(query).await?)?
-        .with_class(Body),
+      BytesPosition::builder()
+        .with_start(start.compressed())
+        .with_end(self.position_at_eof(query).await?)
+        .with_class(Body)
+        .build()?,
     ])
   }
 

--- a/htsget-search/src/bam_search.rs
+++ b/htsget-search/src/bam_search.rs
@@ -651,6 +651,17 @@ pub(crate) mod tests {
     .await;
   }
 
+  #[tokio::test]
+  async fn get_eof_byte_positions_smaller_than_marker() {
+    with_local_storage(|storage| async move {
+      let search = BamSearch::new(storage);
+      let result = search.get_eof_byte_positions(10);
+      assert!(matches!(result, Some(Err(_))));
+      None
+    })
+    .await;
+  }
+
   pub(crate) async fn with_local_storage<F, Fut>(test: F)
   where
     F: FnOnce(Storage) -> Fut,

--- a/htsget-search/src/bam_search.rs
+++ b/htsget-search/src/bam_search.rs
@@ -52,8 +52,8 @@ impl BgzfSearch<LinearIndex, AsyncReader, Header> for BamSearch {
 
     Ok(vec![
       BytesPosition::default()
-        .with_start(start.compressed())
-        .with_end(self.position_at_eof(query).await?)
+        .with_start(start.compressed())?
+        .with_end(self.position_at_eof(query).await?)?
         .with_class(Body),
     ])
   }

--- a/htsget-search/src/cram_search.rs
+++ b/htsget-search/src/cram_search.rs
@@ -648,6 +648,17 @@ mod tests {
     .await;
   }
 
+  #[tokio::test]
+  async fn get_eof_byte_positions_smaller_than_marker() {
+    with_local_storage(|storage| async move {
+      let search = CramSearch::new(storage);
+      let result = search.get_eof_byte_positions(10);
+      assert!(matches!(result, Some(Err(_))));
+      None
+    })
+    .await;
+  }
+
   async fn with_local_storage<F, Fut>(test: F)
   where
     F: FnOnce(Storage) -> Fut,

--- a/htsget-search/src/cram_search.rs
+++ b/htsget-search/src/cram_search.rs
@@ -45,7 +45,9 @@ impl SearchAll<PhantomData<Self>, Index, AsyncReader, Header> for CramSearch {
   #[instrument(level = "trace", skip_all, ret)]
   async fn get_byte_ranges_for_all(&self, query: &Query) -> Result<Vec<BytesPosition>> {
     Ok(vec![
-      BytesPosition::default().with_end(self.position_at_eof(query).await?)?,
+      BytesPosition::builder()
+        .with_end(self.position_at_eof(query).await?)
+        .build()?,
     ])
   }
 
@@ -71,9 +73,10 @@ impl SearchAll<PhantomData<Self>, Index, AsyncReader, Header> for CramSearch {
     _query: &Query,
   ) -> Result<BytesPosition> {
     Ok(
-      BytesPosition::default()
-        .with_end(self.get_header_end_offset(index).await?)?
-        .with_class(HtsGetHeader),
+      BytesPosition::builder()
+        .with_end(self.get_header_end_offset(index).await?)
+        .with_class(HtsGetHeader)
+        .build()?,
     )
   }
 
@@ -251,10 +254,11 @@ impl CramSearch {
 
     if seq_start <= record_end && seq_end >= record_start {
       Ok(Some(
-        BytesPosition::default()
-          .with_start(record.offset())?
-          .with_end(next)?
-          .with_class(Body),
+        BytesPosition::builder()
+          .with_start(record.offset())
+          .with_end(next)
+          .with_class(Body)
+          .build()?,
       ))
     } else {
       Ok(None)

--- a/htsget-search/src/cram_search.rs
+++ b/htsget-search/src/cram_search.rs
@@ -45,7 +45,7 @@ impl SearchAll<PhantomData<Self>, Index, AsyncReader, Header> for CramSearch {
   #[instrument(level = "trace", skip_all, ret)]
   async fn get_byte_ranges_for_all(&self, query: &Query) -> Result<Vec<BytesPosition>> {
     Ok(vec![
-      BytesPosition::default().with_end(self.position_at_eof(query).await?),
+      BytesPosition::default().with_end(self.position_at_eof(query).await?)?,
     ])
   }
 
@@ -72,7 +72,7 @@ impl SearchAll<PhantomData<Self>, Index, AsyncReader, Header> for CramSearch {
   ) -> Result<BytesPosition> {
     Ok(
       BytesPosition::default()
-        .with_end(self.get_header_end_offset(index).await?)
+        .with_end(self.get_header_end_offset(index).await?)?
         .with_class(HtsGetHeader),
     )
   }
@@ -252,8 +252,8 @@ impl CramSearch {
     if seq_start <= record_end && seq_end >= record_start {
       Ok(Some(
         BytesPosition::default()
-          .with_start(record.offset())
-          .with_end(next)
+          .with_start(record.offset())?
+          .with_end(next)?
           .with_class(Body),
       ))
     } else {

--- a/htsget-search/src/search.rs
+++ b/htsget-search/src/search.rs
@@ -96,23 +96,28 @@ where
   /// Get the eof bytes positions converting from a data block.
   fn get_eof_byte_positions(&self, file_size: u64) -> Option<Result<BytesPosition>> {
     if let Some(DataBlock::Data(data, class)) = self.get_eof_data_block() {
-      let data_len =
-        u64::try_from(data.len()).map_err(|err| HtsGetError::InvalidInput(err.to_string()));
-
-      return match data_len {
-        Ok(data_len) => {
-          let bytes_position = BytesPosition::default()
-            .with_start(file_size - data_len)
-            .with_end(file_size);
-          let bytes_position = bytes_position.set_class(class);
-
-          Some(Ok(bytes_position))
-        }
-        Err(err) => Some(Err(err)),
-      };
+      return Some(Self::eof_position(file_size, &data, class));
     }
 
     None
+  }
+
+  /// Compute the bytes position of the eof data block.
+  fn eof_position(file_size: u64, data: &[u8], class: Option<Class>) -> Result<BytesPosition> {
+    let data_len =
+      u64::try_from(data.len()).map_err(|err| HtsGetError::InvalidInput(err.to_string()))?;
+    let start = file_size.checked_sub(data_len).ok_or_else(|| {
+      HtsGetError::io_error(format!(
+        "file size `{file_size}` is smaller than file length"
+      ))
+    })?;
+
+    Ok(
+      BytesPosition::default()
+        .with_start(start)?
+        .with_end(file_size)?
+        .set_class(class),
+    )
   }
 }
 
@@ -225,11 +230,14 @@ where
   #[instrument(level = "trace", skip(self), ret)]
   async fn position_at_eof(&self, query: &Query) -> Result<u64> {
     let file_size = self.file_size(query).await?;
-    Ok(
-      file_size
-        - u64::try_from(self.get_eof_marker().len())
-          .map_err(|err| HtsGetError::InvalidInput(err.to_string()))?,
-    )
+    let eof_len = u64::try_from(self.get_eof_marker().len())
+      .map_err(|err| HtsGetError::InvalidInput(err.to_string()))?;
+
+    file_size.checked_sub(eof_len).ok_or_else(|| {
+      HtsGetError::io_error(format!(
+        "file size `{file_size}` is smaller than the eof marker"
+      ))
+    })
   }
 
   /// Read the index from the key.
@@ -353,7 +361,7 @@ where
         .preprocess(
           key,
           GetOptions::new(
-            BytesPosition::default().set_end(end),
+            BytesPosition::default().set_end(end)?,
             query.request().headers(),
           ),
         )
@@ -379,6 +387,12 @@ where
     trace!("building response");
     let mut urls = vec![];
     let storage = self.get_storage();
+
+    // Blocks with no bytes cannot have a range header.
+    let byte_ranges = byte_ranges
+      .into_iter()
+      .filter(|block| !block.is_empty())
+      .collect();
 
     for block in DataBlock::update_classes(byte_ranges) {
       match block {
@@ -410,7 +424,7 @@ where
   async fn get_header(&self, query: &Query, offset: u64) -> Result<(Header, Reader)> {
     trace!("getting header");
     let get_options = GetOptions::new(
-      BytesPosition::default().with_end(offset),
+      BytesPosition::default().with_end(offset)?,
       query.request().headers(),
     );
 
@@ -562,19 +576,21 @@ where
     let mut bytes_positions = Vec::new();
     let mut maybe_end: Option<u64> = None;
 
-    let mut append_position = |chunk: Chunk, end: u64| {
+    let mut append_position = |chunk: Chunk, end: u64| -> Result<()> {
       bytes_positions.push(
         BytesPosition::default()
-          .with_start(chunk.start().compressed())
-          .with_end(end)
+          .with_start(chunk.start().compressed())?
+          .with_end(end)?
           .with_class(Body),
       );
+
+      Ok(())
     };
 
     for chunk in chunks {
       match maybe_end {
         Some(pos) if pos > chunk.end().compressed() => {
-          append_position(chunk, pos);
+          append_position(chunk, pos)?;
           continue;
         }
         _ => {}
@@ -594,7 +610,7 @@ where
         Some(pos) => pos,
       };
 
-      append_position(chunk, end);
+      append_position(chunk, end)?;
     }
 
     Ok(bytes_positions)
@@ -627,7 +643,7 @@ where
   #[instrument(level = "debug", skip(self), ret)]
   async fn get_byte_ranges_for_all(&self, query: &Query) -> Result<Vec<BytesPosition>> {
     Ok(vec![
-      BytesPosition::default().with_end(self.position_at_eof(query).await?),
+      BytesPosition::default().with_end(self.position_at_eof(query).await?)?,
     ])
   }
 
@@ -689,8 +705,8 @@ where
 
     Ok(
       BytesPosition::default()
-        .with_start(0)
-        .with_end(next_block_index)
+        .with_start(0)?
+        .with_end(next_block_index)?
         .with_class(Header),
     )
   }

--- a/htsget-search/src/search.rs
+++ b/htsget-search/src/search.rs
@@ -113,10 +113,11 @@ where
     })?;
 
     Ok(
-      BytesPosition::default()
-        .with_start(start)?
-        .with_end(file_size)?
-        .set_class(class),
+      BytesPosition::builder()
+        .with_start(start)
+        .with_end(file_size)
+        .set_class(class)
+        .build()?,
     )
   }
 }
@@ -361,7 +362,7 @@ where
         .preprocess(
           key,
           GetOptions::new(
-            BytesPosition::default().set_end(end)?,
+            BytesPosition::builder().set_end(end).build()?,
             query.request().headers(),
           ),
         )
@@ -424,7 +425,7 @@ where
   async fn get_header(&self, query: &Query, offset: u64) -> Result<(Header, Reader)> {
     trace!("getting header");
     let get_options = GetOptions::new(
-      BytesPosition::default().with_end(offset)?,
+      BytesPosition::builder().with_end(offset).build()?,
       query.request().headers(),
     );
 
@@ -578,10 +579,11 @@ where
 
     let mut append_position = |chunk: Chunk, end: u64| -> Result<()> {
       bytes_positions.push(
-        BytesPosition::default()
-          .with_start(chunk.start().compressed())?
-          .with_end(end)?
-          .with_class(Body),
+        BytesPosition::builder()
+          .with_start(chunk.start().compressed())
+          .with_end(end)
+          .with_class(Body)
+          .build()?,
       );
 
       Ok(())
@@ -643,7 +645,9 @@ where
   #[instrument(level = "debug", skip(self), ret)]
   async fn get_byte_ranges_for_all(&self, query: &Query) -> Result<Vec<BytesPosition>> {
     Ok(vec![
-      BytesPosition::default().with_end(self.position_at_eof(query).await?)?,
+      BytesPosition::builder()
+        .with_end(self.position_at_eof(query).await?)
+        .build()?,
     ])
   }
 
@@ -704,10 +708,11 @@ where
     };
 
     Ok(
-      BytesPosition::default()
-        .with_start(0)?
-        .with_end(next_block_index)?
-        .with_class(Header),
+      BytesPosition::builder()
+        .with_start(0)
+        .with_end(next_block_index)
+        .with_class(Header)
+        .build()?,
     )
   }
 

--- a/htsget-storage/src/c4gh/storage.rs
+++ b/htsget-storage/src/c4gh/storage.rs
@@ -162,12 +162,11 @@ impl C4GHStorage {
     let encrypted_file_size = if Format::is_index(key) {
       match self.inner.head(&c4gh_key, (&options).into()).await {
         Ok(encrypted_file_size) => {
-          // Always get the full index file. A zero file size fetches the whole file rather than
-          // using an empty range.
-          c4gh_header_options.range = c4gh_header_options
-            .range()
-            .clone()
-            .set_end((encrypted_file_size > 0).then_some(encrypted_file_size))?;
+          // Always get the full index file from the start. A zero file size fetches the whole file
+          // rather than using an empty range.
+          c4gh_header_options.range = BytesPosition::builder()
+            .set_end((encrypted_file_size > 0).then_some(encrypted_file_size))
+            .build()?;
           encrypted_file_size
         }
         // Otherwise, fallback on the non-encrypted index.
@@ -176,12 +175,12 @@ impl C4GHStorage {
     } else {
       // Get the file size.
       let encrypted_file_size = self.inner.head(&c4gh_key, (&options).into()).await?;
-      // A zero header end fetches the whole file rather than using an empty range.
+      // Fetch the header region from the start. A zero header end fetches the whole file rather
+      // than using an empty range.
       let header_end = min(MAX_C4GH_HEADER_SIZE, encrypted_file_size);
-      c4gh_header_options.range = c4gh_header_options
-        .range()
-        .clone()
-        .set_end((header_end > 0).then_some(header_end))?;
+      c4gh_header_options.range = BytesPosition::builder()
+        .set_end((header_end > 0).then_some(header_end))
+        .build()?;
       encrypted_file_size
     };
 
@@ -217,9 +216,10 @@ impl C4GHStorage {
       } else {
         Some(min(end, encrypted_file_size))
       };
-      options.range = BytesPosition::default()
-        .with_start(MAX_C4GH_HEADER_SIZE)?
-        .set_end(range_end)?;
+      options.range = BytesPosition::builder()
+        .with_start(MAX_C4GH_HEADER_SIZE)
+        .set_end(range_end)
+        .build()?;
 
       // A range selecting no bytes means there is nothing remaining to fetch.
       // This could occur if encrypted_file_size == MAX_C4GH_HEADER_SIZE which would
@@ -277,7 +277,11 @@ impl C4GHStorage {
       let end = default_end(&pos);
       let class = pos.get_class();
 
-      let pos = BytesPosition::new(Some(start), Some(end), class)?;
+      let pos = BytesPosition::builder()
+        .with_start(start)
+        .with_end(end)
+        .set_class(class)
+        .build()?;
       // Positions selecting no bytes do nothing in terms of the data blocks or edit lists, and
       // should be removed before they are processed.
       if pos.is_empty() {
@@ -286,29 +290,33 @@ impl C4GHStorage {
 
       unencrypted_positions.push(pos);
 
-      clamped_positions.push(BytesPosition::new(
-        Some(unencrypted_clamp(start, header_size, encrypted_file_size)),
-        Some(unencrypted_clamp_next(
-          end,
-          header_size,
-          encrypted_file_size,
-        )),
-        class,
-      )?);
+      clamped_positions.push(
+        BytesPosition::builder()
+          .with_start(unencrypted_clamp(start, header_size, encrypted_file_size))
+          .with_end(unencrypted_clamp_next(
+            end,
+            header_size,
+            encrypted_file_size,
+          ))
+          .set_class(class)
+          .build()?,
+      );
 
-      encrypted_positions.push(BytesPosition::new(
-        Some(unencrypted_to_data_block(
-          start,
-          header_size,
-          encrypted_file_size,
-        )),
-        Some(unencrypted_to_next_data_block(
-          end,
-          header_size,
-          encrypted_file_size,
-        )),
-        class,
-      )?);
+      encrypted_positions.push(
+        BytesPosition::builder()
+          .with_start(unencrypted_to_data_block(
+            start,
+            header_size,
+            encrypted_file_size,
+          ))
+          .with_end(unencrypted_to_next_data_block(
+            end,
+            header_size,
+            encrypted_file_size,
+          ))
+          .set_class(class)
+          .build()?,
+      );
     }
 
     let unencrypted_positions = BytesPosition::merge_all(unencrypted_positions)
@@ -334,9 +342,10 @@ impl C4GHStorage {
     let mut blocks = vec![
       DataBlock::Data(header_info, Some(Class::Header)),
       DataBlock::Range(
-        BytesPosition::default()
-          .with_start(header_info_size)?
-          .with_end(current_header_size)?,
+        BytesPosition::builder()
+          .with_start(header_info_size)
+          .with_end(current_header_size)
+          .build()?,
       ),
       DataBlock::Data(
         [edit_list_packet, reencrypted_bytes].concat(),
@@ -456,7 +465,7 @@ mod tests {
     })
     .await;
   }
-  
+
   #[cfg(feature = "aws")]
   #[tokio::test]
   async fn preprocess_zero_size_s3_storage() {
@@ -642,10 +651,10 @@ mod tests {
         key,
         BytesPositionOptions::new(
           vec![
-            BytesPosition::default()
+            BytesPosition::builder()
               .with_start(0)
-              .unwrap()
               .with_end(6)
+              .build()
               .unwrap(),
           ],
           headers,
@@ -663,11 +672,23 @@ mod tests {
     );
     assert_eq!(
       blocks[1],
-      DataBlock::Range(BytesPosition::new(Some(16), Some(124), None).unwrap())
+      DataBlock::Range(
+        BytesPosition::builder()
+          .with_start(16)
+          .with_end(124)
+          .build()
+          .unwrap()
+      )
     );
     assert_eq!(
       blocks[3],
-      DataBlock::Range(BytesPosition::new(Some(124), Some(158), None).unwrap())
+      DataBlock::Range(
+        BytesPosition::builder()
+          .with_start(124)
+          .with_end(158)
+          .build()
+          .unwrap()
+      )
     );
   }
 
@@ -680,10 +701,10 @@ mod tests {
         key,
         BytesPositionOptions::new(
           vec![
-            BytesPosition::default()
+            BytesPosition::builder()
               .with_start(0)
-              .unwrap()
               .with_end(6)
+              .build()
               .unwrap(),
           ],
           headers,
@@ -749,8 +770,8 @@ mod tests {
     );
 
     storage
-        .preprocess(key, GetOptions::new_with_default_range(&Default::default()))
-        .await
+      .preprocess(key, GetOptions::new_with_default_range(&Default::default()))
+      .await
   }
 
   #[cfg(feature = "aws")]

--- a/htsget-storage/src/c4gh/storage.rs
+++ b/htsget-storage/src/c4gh/storage.rs
@@ -392,8 +392,7 @@ mod tests {
   use http::HeaderMap;
   use std::future::Future;
   use std::path::Path;
-  use tokio::fs::{File, read};
-  use tokio::io::AsyncWriteExt;
+  use tokio::fs::{read, write};
 
   #[tokio::test]
   async fn test_preprocess_local_storage() {
@@ -656,10 +655,7 @@ mod tests {
     let data = read(base_path.join("folder/../key1")).await.unwrap();
     let data = encrypt_data(&data);
 
-    File::create(base_path.join("folder/key.c4gh"))
-      .await
-      .unwrap()
-      .write_all(&data)
+    write(base_path.join("folder/key.c4gh"), &data)
       .await
       .unwrap();
   }

--- a/htsget-storage/src/c4gh/storage.rs
+++ b/htsget-storage/src/c4gh/storage.rs
@@ -449,6 +449,25 @@ mod tests {
   }
 
   #[tokio::test]
+  async fn preprocess_zero_size_local_storage() {
+    with_local_storage(|storage, base_path| async move {
+      write(base_path.join("folder/key.c4gh"), b"").await.unwrap();
+      assert!(preprocess_zero_size(storage, "folder/key").await.is_err());
+    })
+    .await;
+  }
+  
+  #[cfg(feature = "aws")]
+  #[tokio::test]
+  async fn preprocess_zero_size_s3_storage() {
+    with_aws_s3_storage(|storage, base_path| async move {
+      write(base_path.join("folder/key.c4gh"), b"").await.unwrap();
+      assert!(preprocess_zero_size(storage, "key").await.is_err());
+    })
+    .await;
+  }
+
+  #[tokio::test]
   async fn test_get_local_storage() {
     with_local_c4gh_storage(|mut storage| async move {
       test_get(&mut storage, "folder/key", &Default::default()).await
@@ -715,6 +734,23 @@ mod tests {
       .await;
     })
     .await;
+  }
+
+  async fn preprocess_zero_size(
+    storage: impl StorageTrait + Send + Sync + 'static,
+    key: &str,
+  ) -> Result<()> {
+    let mut storage = C4GHStorage::new(
+      get_decryption_keys().await,
+      get_encryption_keys().await,
+      storage,
+      true,
+      get_encoded_public_key(),
+    );
+
+    storage
+        .preprocess(key, GetOptions::new_with_default_range(&Default::default()))
+        .await
   }
 
   #[cfg(feature = "aws")]

--- a/htsget-storage/src/c4gh/storage.rs
+++ b/htsget-storage/src/c4gh/storage.rs
@@ -162,8 +162,12 @@ impl C4GHStorage {
     let encrypted_file_size = if Format::is_index(key) {
       match self.inner.head(&c4gh_key, (&options).into()).await {
         Ok(encrypted_file_size) => {
-          // Always get the full index file.
-          c4gh_header_options.range.end = Some(encrypted_file_size);
+          // Always get the full index file. A zero file size fetches the whole file rather than
+          // using an empty range.
+          c4gh_header_options.range = c4gh_header_options
+            .range()
+            .clone()
+            .set_end((encrypted_file_size > 0).then_some(encrypted_file_size))?;
           encrypted_file_size
         }
         // Otherwise, fallback on the non-encrypted index.
@@ -172,7 +176,12 @@ impl C4GHStorage {
     } else {
       // Get the file size.
       let encrypted_file_size = self.inner.head(&c4gh_key, (&options).into()).await?;
-      c4gh_header_options.range.end = Some(min(MAX_C4GH_HEADER_SIZE, encrypted_file_size));
+      // A zero header end fetches the whole file rather than using an empty range.
+      let header_end = min(MAX_C4GH_HEADER_SIZE, encrypted_file_size);
+      c4gh_header_options.range = c4gh_header_options
+        .range()
+        .clone()
+        .set_end((header_end > 0).then_some(header_end))?;
       encrypted_file_size
     };
 
@@ -198,24 +207,31 @@ impl C4GHStorage {
 
     if encrypted_file_size > MAX_C4GH_HEADER_SIZE {
       let end = unencrypted_to_next_data_block(
-        options.range.end.unwrap_or(encrypted_file_size),
+        options.range().get_end().unwrap_or(encrypted_file_size),
         deserialized_header.header_size,
         encrypted_file_size,
       );
-      options.range.start = Some(MAX_C4GH_HEADER_SIZE);
 
-      if end < MAX_C4GH_HEADER_SIZE {
-        options.range.end = None;
+      let range_end = if end < MAX_C4GH_HEADER_SIZE {
+        None
       } else {
-        options.range.end = Some(min(end, encrypted_file_size));
-      }
+        Some(min(end, encrypted_file_size))
+      };
+      options.range = BytesPosition::default()
+        .with_start(MAX_C4GH_HEADER_SIZE)?
+        .set_end(range_end)?;
 
-      self
-        .inner
-        .get(&c4gh_key, options)
-        .await?
-        .read_to_end(&mut remaining)
-        .await?;
+      // A range selecting no bytes means there is nothing remaining to fetch.
+      // This could occur if encrypted_file_size == MAX_C4GH_HEADER_SIZE which would
+      // mean nothing needs to be fetched.
+      if !options.range().is_empty() {
+        self
+          .inner
+          .get(&c4gh_key, options)
+          .await?
+          .read_to_end(&mut remaining)
+          .await?;
+      }
     }
 
     let mut reader = reader.chain(BufReader::new(remaining.as_slice()));
@@ -244,8 +260,8 @@ impl C4GHStorage {
       .get(&Self::format_key(key))
       .ok_or_else(|| InternalError("missing key from state".to_string()))?;
 
-    let default_start = |pos: &BytesPosition| pos.start.unwrap_or_default();
-    let default_end = |pos: &BytesPosition| pos.end.unwrap_or(state.unencrypted_file_size);
+    let default_start = |pos: &BytesPosition| pos.get_start().unwrap_or_default();
+    let default_end = |pos: &BytesPosition| pos.get_end().unwrap_or(state.unencrypted_file_size);
 
     let header_size = state.deserialized_header.header_size;
     let encrypted_file_size = state.encrypted_file_size;
@@ -256,33 +272,43 @@ impl C4GHStorage {
     let mut clamped_positions = vec![];
     // Positions from the reference frame of someone merging bytes from htsget.
     let mut encrypted_positions = vec![];
-    for mut pos in options.positions {
+    for pos in options.positions {
       let start = default_start(&pos);
       let end = default_end(&pos);
+      let class = pos.get_class();
 
-      pos.start = Some(start);
-      pos.end = Some(end);
-      unencrypted_positions.push(pos.clone());
+      let pos = BytesPosition::new(Some(start), Some(end), class)?;
+      // Positions selecting no bytes do nothing in terms of the data blocks or edit lists, and
+      // should be removed before they are processed.
+      if pos.is_empty() {
+        continue;
+      }
 
-      pos.start = Some(unencrypted_clamp(start, header_size, encrypted_file_size));
-      pos.end = Some(unencrypted_clamp_next(
-        end,
-        header_size,
-        encrypted_file_size,
-      ));
-      clamped_positions.push(pos.clone());
+      unencrypted_positions.push(pos);
 
-      pos.start = Some(unencrypted_to_data_block(
-        start,
-        header_size,
-        encrypted_file_size,
-      ));
-      pos.end = Some(unencrypted_to_next_data_block(
-        end,
-        header_size,
-        encrypted_file_size,
-      ));
-      encrypted_positions.push(pos);
+      clamped_positions.push(BytesPosition::new(
+        Some(unencrypted_clamp(start, header_size, encrypted_file_size)),
+        Some(unencrypted_clamp_next(
+          end,
+          header_size,
+          encrypted_file_size,
+        )),
+        class,
+      )?);
+
+      encrypted_positions.push(BytesPosition::new(
+        Some(unencrypted_to_data_block(
+          start,
+          header_size,
+          encrypted_file_size,
+        )),
+        Some(unencrypted_to_next_data_block(
+          end,
+          header_size,
+          encrypted_file_size,
+        )),
+        class,
+      )?);
     }
 
     let unencrypted_positions = BytesPosition::merge_all(unencrypted_positions)
@@ -309,8 +335,8 @@ impl C4GHStorage {
       DataBlock::Data(header_info, Some(Class::Header)),
       DataBlock::Range(
         BytesPosition::default()
-          .with_start(header_info_size)
-          .with_end(current_header_size),
+          .with_start(header_info_size)?
+          .with_end(current_header_size)?,
       ),
       DataBlock::Data(
         [edit_list_packet, reencrypted_bytes].concat(),
@@ -596,7 +622,13 @@ mod tests {
       .postprocess(
         key,
         BytesPositionOptions::new(
-          vec![BytesPosition::default().with_start(0).with_end(6)],
+          vec![
+            BytesPosition::default()
+              .with_start(0)
+              .unwrap()
+              .with_end(6)
+              .unwrap(),
+          ],
           headers,
         ),
       )
@@ -612,11 +644,11 @@ mod tests {
     );
     assert_eq!(
       blocks[1],
-      DataBlock::Range(BytesPosition::new(Some(16), Some(124), None))
+      DataBlock::Range(BytesPosition::new(Some(16), Some(124), None).unwrap())
     );
     assert_eq!(
       blocks[3],
-      DataBlock::Range(BytesPosition::new(Some(124), Some(158), None))
+      DataBlock::Range(BytesPosition::new(Some(124), Some(158), None).unwrap())
     );
   }
 
@@ -628,7 +660,13 @@ mod tests {
       .postprocess(
         key,
         BytesPositionOptions::new(
-          vec![BytesPosition::default().with_start(0).with_end(6)],
+          vec![
+            BytesPosition::default()
+              .with_start(0)
+              .unwrap()
+              .with_end(6)
+              .unwrap(),
+          ],
           headers,
         ),
       )

--- a/htsget-storage/src/lib.rs
+++ b/htsget-storage/src/lib.rs
@@ -342,7 +342,7 @@ pub trait StorageMiddleware {
     positions_options: BytesPositionOptions<'_>,
   ) -> Result<Vec<DataBlock>> {
     Ok(DataBlock::from_bytes_positions(
-      positions_options.merge_all().into_inner(),
+      positions_options.into_inner(),
     ))
   }
 }

--- a/htsget-storage/src/local.rs
+++ b/htsget-storage/src/local.rs
@@ -176,8 +176,7 @@ pub(crate) mod tests {
   use htsget_config::types::Scheme;
   use http::uri::Authority;
   use tempfile::TempDir;
-  use tokio::fs::{File, create_dir};
-  use tokio::io::AsyncWriteExt;
+  use tokio::fs::{create_dir, write};
 
   use super::*;
   use crate::types::BytesPosition;
@@ -354,19 +353,11 @@ pub(crate) mod tests {
     let value1 = b"value1";
     let key2 = "key2";
     let value2 = b"value2";
-    File::create(base_path.path().join(key1))
-      .await
-      .unwrap()
-      .write_all(value1)
-      .await
-      .unwrap();
+    write(base_path.path().join(key1), value1).await.unwrap();
     create_dir(base_path.path().join(folder_name))
       .await
       .unwrap();
-    File::create(base_path.path().join(folder_name).join(key2))
-      .await
-      .unwrap()
-      .write_all(value2)
+    write(base_path.path().join(folder_name).join(key2), value2)
       .await
       .unwrap();
 

--- a/htsget-storage/src/local.rs
+++ b/htsget-storage/src/local.rs
@@ -97,10 +97,10 @@ impl<T: UrlFormatter + Send + Sync + Debug + Clone + 'static> StorageTrait for F
 
     // Need to ensure range options are considered for local files.
     let mut file = self.get(key).await?;
-    let start = options.range.start.unwrap_or(0);
+    let start = options.range().get_start().unwrap_or(0);
     let seek = file.seek(SeekFrom::Start(start)).await?;
 
-    if let Some(end) = options.range.end {
+    if let Some(end) = options.range().get_end() {
       let file = file.take(end.checked_sub(seek).ok_or_else(|| {
         StorageError::InternalError("subtraction overflow in local storage get".to_string())
       })?);
@@ -146,7 +146,7 @@ impl<T: UrlFormatter + Send + Sync + Debug + Clone + 'static> StorageTrait for F
           .map_err(|err: error::Error| StorageError::InvalidInput(err.to_string()))?,
       );
     }
-    let url = options.apply(url);
+    let url = options.apply(url)?;
 
     debug!(calling_from = ?self, key = key, ?url, "getting url with key {:?}", key);
 
@@ -302,7 +302,7 @@ pub(crate) mod tests {
         &storage,
         "folder/../key1",
         RangeUrlOptions::new(
-          BytesPosition::new(Some(7), Some(10), None),
+          BytesPosition::new(Some(7), Some(10), None).unwrap(),
           &Default::default(),
         ),
       )
@@ -320,7 +320,10 @@ pub(crate) mod tests {
       let result = StorageTrait::range_url(
         &storage,
         "folder/../key1",
-        RangeUrlOptions::new(BytesPosition::new(Some(7), None, None), &Default::default()),
+        RangeUrlOptions::new(
+          BytesPosition::new(Some(7), None, None).unwrap(),
+          &Default::default(),
+        ),
       )
       .await;
       let expected = Url::new("http://127.0.0.1:8081/key1")

--- a/htsget-storage/src/local.rs
+++ b/htsget-storage/src/local.rs
@@ -302,7 +302,11 @@ pub(crate) mod tests {
         &storage,
         "folder/../key1",
         RangeUrlOptions::new(
-          BytesPosition::new(Some(7), Some(10), None).unwrap(),
+          BytesPosition::builder()
+            .with_start(7)
+            .with_end(10)
+            .build()
+            .unwrap(),
           &Default::default(),
         ),
       )
@@ -321,7 +325,7 @@ pub(crate) mod tests {
         &storage,
         "folder/../key1",
         RangeUrlOptions::new(
-          BytesPosition::new(Some(7), None, None).unwrap(),
+          BytesPosition::builder().with_start(7).build().unwrap(),
           &Default::default(),
         ),
       )

--- a/htsget-storage/src/s3.rs
+++ b/htsget-storage/src/s3.rs
@@ -83,7 +83,7 @@ impl S3Storage {
       .get_object()
       .bucket(&self.bucket)
       .key(key.as_ref());
-    let response = Self::apply_range(response, range);
+    let response = Self::apply_range(response, range)?;
     Ok(
       response
         .presigned(
@@ -150,12 +150,15 @@ impl S3Storage {
     Delayed(class)
   }
 
-  fn apply_range(builder: GetObjectFluentBuilder, range: &BytesPosition) -> GetObjectFluentBuilder {
-    let range: String = String::from(&BytesRange::from(range));
+  fn apply_range(
+    builder: GetObjectFluentBuilder,
+    range: &BytesPosition,
+  ) -> Result<GetObjectFluentBuilder> {
+    let range: String = String::from(&BytesRange::try_from(range)?);
     if range.is_empty() {
-      builder
+      Ok(builder)
     } else {
-      builder.range(range)
+      Ok(builder.range(range))
     }
   }
 
@@ -177,7 +180,7 @@ impl S3Storage {
       .get_object()
       .bucket(&self.bucket)
       .key(key.as_ref());
-    let response = Self::apply_range(response, options.range());
+    let response = Self::apply_range(response, options.range())?;
     Ok(
       response
         .send()
@@ -260,7 +263,7 @@ impl StorageTrait for S3Storage {
   #[instrument(level = "trace", skip(self))]
   async fn range_url(&self, key: &str, options: RangeUrlOptions<'_>) -> Result<Url> {
     let presigned_url = self.s3_presign_url(key, options.range()).await?;
-    let url = options.apply(Url::new(presigned_url));
+    let url = options.apply(Url::new(presigned_url))?;
 
     debug!(calling_from = ?self, key, ?url, "getting url with key {:?}", key);
     Ok(url)
@@ -375,7 +378,7 @@ pub(crate) mod tests {
         .range_url(
           "key2",
           RangeUrlOptions::new(
-            BytesPosition::new(Some(7), Some(9), None),
+            BytesPosition::new(Some(7), Some(9), None).unwrap(),
             &Default::default(),
           ),
         )
@@ -401,7 +404,10 @@ pub(crate) mod tests {
       let result = storage
         .range_url(
           "key2",
-          RangeUrlOptions::new(BytesPosition::new(Some(7), None, None), &Default::default()),
+          RangeUrlOptions::new(
+            BytesPosition::new(Some(7), None, None).unwrap(),
+            &Default::default(),
+          ),
         )
         .await
         .unwrap();

--- a/htsget-storage/src/s3.rs
+++ b/htsget-storage/src/s3.rs
@@ -378,7 +378,11 @@ pub(crate) mod tests {
         .range_url(
           "key2",
           RangeUrlOptions::new(
-            BytesPosition::new(Some(7), Some(9), None).unwrap(),
+            BytesPosition::builder()
+              .with_start(7)
+              .with_end(9)
+              .build()
+              .unwrap(),
             &Default::default(),
           ),
         )
@@ -405,7 +409,7 @@ pub(crate) mod tests {
         .range_url(
           "key2",
           RangeUrlOptions::new(
-            BytesPosition::new(Some(7), None, None).unwrap(),
+            BytesPosition::builder().with_start(7).build().unwrap(),
             &Default::default(),
           ),
         )

--- a/htsget-storage/src/types.rs
+++ b/htsget-storage/src/types.rs
@@ -110,39 +110,69 @@ impl BytesRange {
   }
 }
 
-impl BytesPosition {
-  /// Create a new bytes position. Returns an error if the end is less than the start.
-  /// An empty `BytesPosition` is allowed by setting the start and end to the same value.
-  pub fn new(start: Option<u64>, end: Option<u64>, class: Option<Class>) -> Result<Self> {
-    Self { start, end, class }.validate()
+/// A builder for [BytesPosition].
+#[derive(Clone, Debug, Default)]
+pub struct BytesPositionBuilder {
+  start: Option<u64>,
+  end: Option<u64>,
+  class: Option<Class>,
+}
+
+impl BytesPositionBuilder {
+  pub fn with_start(mut self, start: u64) -> Self {
+    self.start = Some(start);
+    self
   }
 
-  /// Validate that the end is greater than the start.
-  fn validate(self) -> Result<Self> {
+  pub fn set_start(mut self, start: Option<u64>) -> Self {
+    self.start = start;
+    self
+  }
+
+  pub fn with_end(mut self, end: u64) -> Self {
+    self.end = Some(end);
+    self
+  }
+
+  pub fn set_end(mut self, end: Option<u64>) -> Self {
+    self.end = end;
+    self
+  }
+
+  pub fn with_class(mut self, class: Class) -> Self {
+    self.class = Some(class);
+    self
+  }
+
+  pub fn set_class(mut self, class: Option<Class>) -> Self {
+    self.class = class;
+    self
+  }
+
+  /// Build the bytes position, returning an error if the end is less than the start.
+  pub fn build(self) -> Result<BytesPosition> {
     if self
       .end
       .is_some_and(|end| end < self.start.unwrap_or_default())
     {
       return Err(StorageError::InternalError(format!(
-        "invalid bytes position {self:?}"
+        "invalid bytes position, end `{:?}` is less than start `{:?}`",
+        self.end, self.start
       )));
     }
 
-    Ok(self)
+    Ok(BytesPosition {
+      start: self.start,
+      end: self.end,
+      class: self.class,
+    })
   }
+}
 
-  pub fn with_start(mut self, start: u64) -> Result<Self> {
-    self.start = Some(start);
-    self.validate()
-  }
-
-  pub fn with_end(self, end: u64) -> Result<Self> {
-    self.set_end(Some(end))
-  }
-
-  pub fn set_end(mut self, end: Option<u64>) -> Result<Self> {
-    self.end = end;
-    self.validate()
+impl BytesPosition {
+  /// Create a builder for a bytes position.
+  pub fn builder() -> BytesPositionBuilder {
+    BytesPositionBuilder::default()
   }
 
   pub fn with_class(self, class: Class) -> Self {
@@ -268,9 +298,10 @@ impl<'a> GetOptions<'a> {
   }
 
   pub fn with_max_length(mut self, max_length: u64) -> Result<Self> {
-    self.range = BytesPosition::default()
-      .with_start(0)?
-      .with_end(max_length)?;
+    self.range = BytesPosition::builder()
+      .with_start(0)
+      .with_end(max_length)
+      .build()?;
     Ok(self)
   }
 
@@ -407,194 +438,352 @@ mod tests {
   fn bytes_range_overlapping_and_merge() {
     let test_cases = vec![
       (
-        BytesPosition::new(None, Some(2), None).unwrap(),
-        BytesPosition::new(Some(3), Some(5), None).unwrap(),
+        BytesPosition::builder().with_end(2).build().unwrap(),
+        BytesPosition::builder()
+          .with_start(3)
+          .with_end(5)
+          .build()
+          .unwrap(),
         None,
       ),
       (
-        BytesPosition::new(None, Some(2), None).unwrap(),
-        BytesPosition::new(Some(3), None, None).unwrap(),
+        BytesPosition::builder().with_end(2).build().unwrap(),
+        BytesPosition::builder().with_start(3).build().unwrap(),
         None,
       ),
       (
-        BytesPosition::new(None, Some(2), None).unwrap(),
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        Some(BytesPosition::new(None, Some(4), None).unwrap()),
+        BytesPosition::builder().with_end(2).build().unwrap(),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        Some(BytesPosition::builder().with_end(4).build().unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None).unwrap(),
-        BytesPosition::new(Some(2), None, None).unwrap(),
-        Some(BytesPosition::new(None, None, None).unwrap()),
+        BytesPosition::builder().with_end(2).build().unwrap(),
+        BytesPosition::builder().with_start(2).build().unwrap(),
+        Some(BytesPosition::builder().build().unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None).unwrap(),
-        BytesPosition::new(Some(1), Some(3), None).unwrap(),
-        Some(BytesPosition::new(None, Some(3), None).unwrap()),
+        BytesPosition::builder().with_end(2).build().unwrap(),
+        BytesPosition::builder()
+          .with_start(1)
+          .with_end(3)
+          .build()
+          .unwrap(),
+        Some(BytesPosition::builder().with_end(3).build().unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None).unwrap(),
-        BytesPosition::new(Some(1), None, None).unwrap(),
-        Some(BytesPosition::new(None, None, None).unwrap()),
+        BytesPosition::builder().with_end(2).build().unwrap(),
+        BytesPosition::builder().with_start(1).build().unwrap(),
+        Some(BytesPosition::builder().build().unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None).unwrap(),
-        BytesPosition::new(Some(0), Some(2), None).unwrap(),
-        Some(BytesPosition::new(None, Some(2), None).unwrap()),
+        BytesPosition::builder().with_end(2).build().unwrap(),
+        BytesPosition::builder()
+          .with_start(0)
+          .with_end(2)
+          .build()
+          .unwrap(),
+        Some(BytesPosition::builder().with_end(2).build().unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None).unwrap(),
-        BytesPosition::new(None, Some(2), None).unwrap(),
-        Some(BytesPosition::new(None, Some(2), None).unwrap()),
+        BytesPosition::builder().with_end(2).build().unwrap(),
+        BytesPosition::builder().with_end(2).build().unwrap(),
+        Some(BytesPosition::builder().with_end(2).build().unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None).unwrap(),
-        BytesPosition::new(Some(0), Some(1), None).unwrap(),
-        Some(BytesPosition::new(None, Some(2), None).unwrap()),
+        BytesPosition::builder().with_end(2).build().unwrap(),
+        BytesPosition::builder()
+          .with_start(0)
+          .with_end(1)
+          .build()
+          .unwrap(),
+        Some(BytesPosition::builder().with_end(2).build().unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None).unwrap(),
-        BytesPosition::new(None, Some(1), None).unwrap(),
-        Some(BytesPosition::new(None, Some(2), None).unwrap()),
+        BytesPosition::builder().with_end(2).build().unwrap(),
+        BytesPosition::builder().with_end(1).build().unwrap(),
+        Some(BytesPosition::builder().with_end(2).build().unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None).unwrap(),
-        BytesPosition::new(None, None, None).unwrap(),
-        Some(BytesPosition::new(None, None, None).unwrap()),
+        BytesPosition::builder().with_end(2).build().unwrap(),
+        BytesPosition::builder().build().unwrap(),
+        Some(BytesPosition::builder().build().unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        BytesPosition::new(Some(6), Some(8), None).unwrap(),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        BytesPosition::builder()
+          .with_start(6)
+          .with_end(8)
+          .build()
+          .unwrap(),
         None,
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        BytesPosition::new(Some(6), None, None).unwrap(),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        BytesPosition::builder().with_start(6).build().unwrap(),
         None,
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        BytesPosition::new(Some(4), Some(6), None).unwrap(),
-        Some(BytesPosition::new(Some(2), Some(6), None).unwrap()),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        BytesPosition::builder()
+          .with_start(4)
+          .with_end(6)
+          .build()
+          .unwrap(),
+        Some(
+          BytesPosition::builder()
+            .with_start(2)
+            .with_end(6)
+            .build()
+            .unwrap(),
+        ),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        BytesPosition::new(Some(4), None, None).unwrap(),
-        Some(BytesPosition::new(Some(2), None, None).unwrap()),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        BytesPosition::builder().with_start(4).build().unwrap(),
+        Some(BytesPosition::builder().with_start(2).build().unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        BytesPosition::new(Some(3), Some(5), None).unwrap(),
-        Some(BytesPosition::new(Some(2), Some(5), None).unwrap()),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        BytesPosition::builder()
+          .with_start(3)
+          .with_end(5)
+          .build()
+          .unwrap(),
+        Some(
+          BytesPosition::builder()
+            .with_start(2)
+            .with_end(5)
+            .build()
+            .unwrap(),
+        ),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        BytesPosition::new(Some(3), None, None).unwrap(),
-        Some(BytesPosition::new(Some(2), None, None).unwrap()),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        BytesPosition::builder().with_start(3).build().unwrap(),
+        Some(BytesPosition::builder().with_start(2).build().unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        BytesPosition::new(Some(2), Some(3), None).unwrap(),
-        Some(BytesPosition::new(Some(2), Some(4), None).unwrap()),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(3)
+          .build()
+          .unwrap(),
+        Some(
+          BytesPosition::builder()
+            .with_start(2)
+            .with_end(4)
+            .build()
+            .unwrap(),
+        ),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        BytesPosition::new(None, Some(3), None).unwrap(),
-        Some(BytesPosition::new(None, Some(4), None).unwrap()),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        BytesPosition::builder().with_end(3).build().unwrap(),
+        Some(BytesPosition::builder().with_end(4).build().unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        BytesPosition::new(Some(1), Some(3), None).unwrap(),
-        Some(BytesPosition::new(Some(1), Some(4), None).unwrap()),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        BytesPosition::builder()
+          .with_start(1)
+          .with_end(3)
+          .build()
+          .unwrap(),
+        Some(
+          BytesPosition::builder()
+            .with_start(1)
+            .with_end(4)
+            .build()
+            .unwrap(),
+        ),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        BytesPosition::new(None, Some(3), None).unwrap(),
-        Some(BytesPosition::new(None, Some(4), None).unwrap()),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        BytesPosition::builder().with_end(3).build().unwrap(),
+        Some(BytesPosition::builder().with_end(4).build().unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        BytesPosition::new(Some(0), Some(2), None).unwrap(),
-        Some(BytesPosition::new(Some(0), Some(4), None).unwrap()),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        BytesPosition::builder()
+          .with_start(0)
+          .with_end(2)
+          .build()
+          .unwrap(),
+        Some(
+          BytesPosition::builder()
+            .with_start(0)
+            .with_end(4)
+            .build()
+            .unwrap(),
+        ),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        BytesPosition::new(None, Some(2), None).unwrap(),
-        Some(BytesPosition::new(None, Some(4), None).unwrap()),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        BytesPosition::builder().with_end(2).build().unwrap(),
+        Some(BytesPosition::builder().with_end(4).build().unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        BytesPosition::new(Some(0), Some(1), None).unwrap(),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        BytesPosition::builder()
+          .with_start(0)
+          .with_end(1)
+          .build()
+          .unwrap(),
         None,
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        BytesPosition::new(None, Some(1), None).unwrap(),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        BytesPosition::builder().with_end(1).build().unwrap(),
         None,
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        BytesPosition::new(None, None, None).unwrap(),
-        Some(BytesPosition::new(None, None, None).unwrap()),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        BytesPosition::builder().build().unwrap(),
+        Some(BytesPosition::builder().build().unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None).unwrap(),
-        BytesPosition::new(Some(4), Some(6), None).unwrap(),
-        Some(BytesPosition::new(Some(2), None, None).unwrap()),
+        BytesPosition::builder().with_start(2).build().unwrap(),
+        BytesPosition::builder()
+          .with_start(4)
+          .with_end(6)
+          .build()
+          .unwrap(),
+        Some(BytesPosition::builder().with_start(2).build().unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None).unwrap(),
-        BytesPosition::new(Some(4), None, None).unwrap(),
-        Some(BytesPosition::new(Some(2), None, None).unwrap()),
+        BytesPosition::builder().with_start(2).build().unwrap(),
+        BytesPosition::builder().with_start(4).build().unwrap(),
+        Some(BytesPosition::builder().with_start(2).build().unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None).unwrap(),
-        BytesPosition::new(Some(2), Some(4), None).unwrap(),
-        Some(BytesPosition::new(Some(2), None, None).unwrap()),
+        BytesPosition::builder().with_start(2).build().unwrap(),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(4)
+          .build()
+          .unwrap(),
+        Some(BytesPosition::builder().with_start(2).build().unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None).unwrap(),
-        BytesPosition::new(Some(2), None, None).unwrap(),
-        Some(BytesPosition::new(Some(2), None, None).unwrap()),
+        BytesPosition::builder().with_start(2).build().unwrap(),
+        BytesPosition::builder().with_start(2).build().unwrap(),
+        Some(BytesPosition::builder().with_start(2).build().unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None).unwrap(),
-        BytesPosition::new(Some(1), Some(3), None).unwrap(),
-        Some(BytesPosition::new(Some(1), None, None).unwrap()),
+        BytesPosition::builder().with_start(2).build().unwrap(),
+        BytesPosition::builder()
+          .with_start(1)
+          .with_end(3)
+          .build()
+          .unwrap(),
+        Some(BytesPosition::builder().with_start(1).build().unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None).unwrap(),
-        BytesPosition::new(None, Some(3), None).unwrap(),
-        Some(BytesPosition::new(None, None, None).unwrap()),
+        BytesPosition::builder().with_start(2).build().unwrap(),
+        BytesPosition::builder().with_end(3).build().unwrap(),
+        Some(BytesPosition::builder().build().unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None).unwrap(),
-        BytesPosition::new(Some(0), Some(2), None).unwrap(),
-        Some(BytesPosition::new(Some(0), None, None).unwrap()),
+        BytesPosition::builder().with_start(2).build().unwrap(),
+        BytesPosition::builder()
+          .with_start(0)
+          .with_end(2)
+          .build()
+          .unwrap(),
+        Some(BytesPosition::builder().with_start(0).build().unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None).unwrap(),
-        BytesPosition::new(None, Some(2), None).unwrap(),
-        Some(BytesPosition::new(None, None, None).unwrap()),
+        BytesPosition::builder().with_start(2).build().unwrap(),
+        BytesPosition::builder().with_end(2).build().unwrap(),
+        Some(BytesPosition::builder().build().unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None).unwrap(),
-        BytesPosition::new(Some(0), Some(1), None).unwrap(),
+        BytesPosition::builder().with_start(2).build().unwrap(),
+        BytesPosition::builder()
+          .with_start(0)
+          .with_end(1)
+          .build()
+          .unwrap(),
         None,
       ),
       (
-        BytesPosition::new(Some(2), None, None).unwrap(),
-        BytesPosition::new(None, Some(1), None).unwrap(),
+        BytesPosition::builder().with_start(2).build().unwrap(),
+        BytesPosition::builder().with_end(1).build().unwrap(),
         None,
       ),
       (
-        BytesPosition::new(Some(2), None, None).unwrap(),
-        BytesPosition::new(None, None, None).unwrap(),
-        Some(BytesPosition::new(None, None, None).unwrap()),
+        BytesPosition::builder().with_start(2).build().unwrap(),
+        BytesPosition::builder().build().unwrap(),
+        Some(BytesPosition::builder().build().unwrap()),
       ),
       (
-        BytesPosition::new(None, None, None).unwrap(),
-        BytesPosition::new(None, None, None).unwrap(),
-        Some(BytesPosition::new(None, None, None).unwrap()),
+        BytesPosition::builder().build().unwrap(),
+        BytesPosition::builder().build().unwrap(),
+        Some(BytesPosition::builder().build().unwrap()),
       ),
     ];
 
@@ -621,62 +810,130 @@ mod tests {
   fn bytes_range_merge_all_removes_empty_positions() {
     assert_eq!(
       BytesPosition::merge_all(vec![
-        BytesPosition::new(Some(0), Some(0), None).unwrap(),
-        BytesPosition::new(Some(5), Some(5), None).unwrap(),
-        BytesPosition::new(Some(1), Some(2), None).unwrap(),
+        BytesPosition::builder()
+          .with_start(0)
+          .with_end(0)
+          .build()
+          .unwrap(),
+        BytesPosition::builder()
+          .with_start(5)
+          .with_end(5)
+          .build()
+          .unwrap(),
+        BytesPosition::builder()
+          .with_start(1)
+          .with_end(2)
+          .build()
+          .unwrap(),
       ]),
-      vec![BytesPosition::new(Some(1), Some(2), None).unwrap()]
+      vec![
+        BytesPosition::builder()
+          .with_start(1)
+          .with_end(2)
+          .build()
+          .unwrap()
+      ]
     );
   }
 
   #[test]
   fn bytes_position_is_empty() {
     assert!(
-      BytesPosition::new(Some(0), Some(0), None)
+      BytesPosition::builder()
+        .with_start(0)
+        .with_end(0)
+        .build()
         .unwrap()
         .is_empty()
     );
-    assert!(BytesPosition::new(None, Some(0), None).unwrap().is_empty());
     assert!(
-      !BytesPosition::new(Some(0), Some(1), None)
+      BytesPosition::builder()
+        .with_end(0)
+        .build()
         .unwrap()
         .is_empty()
     );
-    assert!(!BytesPosition::new(Some(1), None, None).unwrap().is_empty());
-    assert!(!BytesPosition::new(None, None, None).unwrap().is_empty());
+    assert!(
+      !BytesPosition::builder()
+        .with_start(0)
+        .with_end(1)
+        .build()
+        .unwrap()
+        .is_empty()
+    );
+    assert!(
+      !BytesPosition::builder()
+        .with_start(1)
+        .build()
+        .unwrap()
+        .is_empty()
+    );
+    assert!(!BytesPosition::builder().build().unwrap().is_empty());
   }
 
   #[test]
   fn bytes_position_end_less_than_start() {
-    assert!(BytesPosition::new(Some(2), Some(1), None).is_err());
-    assert!(BytesPosition::new(None, Some(1), None).is_ok());
     assert!(
-      BytesPosition::default()
+      BytesPosition::builder()
+        .with_start(2)
+        .with_end(1)
+        .build()
+        .is_err()
+    );
+    assert!(BytesPosition::builder().with_end(1).build().is_ok());
+    assert!(
+      BytesPosition::builder()
         .with_end(2)
-        .unwrap()
         .with_start(3)
+        .build()
         .is_err()
     );
     assert!(
-      BytesPosition::default()
+      BytesPosition::builder()
         .with_start(3)
-        .unwrap()
         .with_end(2)
+        .build()
         .is_err()
     );
     assert!(
-      BytesPosition::default()
+      BytesPosition::builder()
         .with_start(3)
-        .unwrap()
         .set_end(Some(2))
+        .build()
         .is_err()
+    );
+  }
+
+  #[test]
+  fn bytes_position_builder() {
+    let result = BytesPosition::builder()
+      .with_end(2)
+      .with_start(5)
+      .with_end(10)
+      .build();
+    assert_eq!(
+      result.unwrap(),
+      BytesPosition::builder()
+        .with_start(5)
+        .with_end(10)
+        .build()
+        .unwrap()
     );
   }
 
   #[test]
   fn bytes_range_try_from_empty_position() {
-    assert!(BytesRange::try_from(&BytesPosition::new(Some(5), Some(5), None).unwrap()).is_err());
-    assert!(BytesRange::try_from(&BytesPosition::new(None, Some(0), None).unwrap()).is_err());
+    assert!(
+      BytesRange::try_from(
+        &BytesPosition::builder()
+          .with_start(5)
+          .with_end(5)
+          .build()
+          .unwrap()
+      )
+      .is_err()
+    );
+    assert!(BytesRange::try_from(&BytesPosition::builder().with_end(0).build().unwrap()).is_err());
   }
 
   #[test]
@@ -691,10 +948,24 @@ mod tests {
   fn bytes_position_merge_class_header() {
     assert_eq!(
       BytesPosition::merge_all(vec![
-        BytesPosition::new(None, Some(1), Some(Class::Header)).unwrap(),
-        BytesPosition::new(None, Some(2), Some(Class::Header)).unwrap()
+        BytesPosition::builder()
+          .with_end(1)
+          .with_class(Class::Header)
+          .build()
+          .unwrap(),
+        BytesPosition::builder()
+          .with_end(2)
+          .with_class(Class::Header)
+          .build()
+          .unwrap()
       ]),
-      vec![BytesPosition::new(None, Some(2), Some(Class::Header)).unwrap()]
+      vec![
+        BytesPosition::builder()
+          .with_end(2)
+          .with_class(Class::Header)
+          .build()
+          .unwrap()
+      ]
     );
   }
 
@@ -702,10 +973,24 @@ mod tests {
   fn bytes_position_merge_class_body() {
     assert_eq!(
       BytesPosition::merge_all(vec![
-        BytesPosition::new(None, Some(1), Some(Class::Body)).unwrap(),
-        BytesPosition::new(None, Some(3), Some(Class::Body)).unwrap()
+        BytesPosition::builder()
+          .with_end(1)
+          .with_class(Class::Body)
+          .build()
+          .unwrap(),
+        BytesPosition::builder()
+          .with_end(3)
+          .with_class(Class::Body)
+          .build()
+          .unwrap()
       ]),
-      vec![BytesPosition::new(None, Some(3), Some(Class::Body)).unwrap()]
+      vec![
+        BytesPosition::builder()
+          .with_end(3)
+          .with_class(Class::Body)
+          .build()
+          .unwrap()
+      ]
     );
   }
 
@@ -713,10 +998,24 @@ mod tests {
   fn bytes_position_merge_class_none() {
     assert_eq!(
       BytesPosition::merge_all(vec![
-        BytesPosition::new(Some(1), Some(2), None).unwrap(),
-        BytesPosition::new(Some(2), Some(3), None).unwrap()
+        BytesPosition::builder()
+          .with_start(1)
+          .with_end(2)
+          .build()
+          .unwrap(),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(3)
+          .build()
+          .unwrap()
       ]),
-      vec![BytesPosition::new(Some(1), Some(3), None).unwrap()]
+      vec![
+        BytesPosition::builder()
+          .with_start(1)
+          .with_end(3)
+          .build()
+          .unwrap()
+      ]
     );
   }
 
@@ -724,43 +1023,135 @@ mod tests {
   fn bytes_position_merge_class_different() {
     assert_eq!(
       BytesPosition::merge_all(vec![
-        BytesPosition::new(Some(1), Some(2), Some(Class::Header)).unwrap(),
-        BytesPosition::new(Some(2), Some(3), Some(Class::Body)).unwrap()
+        BytesPosition::builder()
+          .with_start(1)
+          .with_end(2)
+          .with_class(Class::Header)
+          .build()
+          .unwrap(),
+        BytesPosition::builder()
+          .with_start(2)
+          .with_end(3)
+          .with_class(Class::Body)
+          .build()
+          .unwrap()
       ]),
-      vec![BytesPosition::new(Some(1), Some(3), None).unwrap()]
+      vec![
+        BytesPosition::builder()
+          .with_start(1)
+          .with_end(3)
+          .build()
+          .unwrap()
+      ]
     );
   }
 
   #[test]
   fn bytes_range_merge_all_when_list_has_many_ranges() {
     let ranges = vec![
-      BytesPosition::new(None, Some(1), None).unwrap(),
-      BytesPosition::new(Some(1), Some(2), None).unwrap(),
-      BytesPosition::new(Some(5), Some(6), None).unwrap(),
-      BytesPosition::new(Some(5), Some(8), None).unwrap(),
-      BytesPosition::new(Some(6), Some(7), None).unwrap(),
-      BytesPosition::new(Some(4), Some(5), None).unwrap(),
-      BytesPosition::new(Some(3), Some(6), None).unwrap(),
-      BytesPosition::new(Some(10), Some(12), None).unwrap(),
-      BytesPosition::new(Some(10), Some(12), None).unwrap(),
-      BytesPosition::new(Some(10), Some(14), None).unwrap(),
-      BytesPosition::new(Some(14), Some(15), None).unwrap(),
-      BytesPosition::new(Some(12), Some(16), None).unwrap(),
-      BytesPosition::new(Some(17), Some(19), None).unwrap(),
-      BytesPosition::new(Some(21), Some(23), None).unwrap(),
-      BytesPosition::new(Some(18), Some(22), None).unwrap(),
-      BytesPosition::new(Some(24), None, None).unwrap(),
-      BytesPosition::new(Some(24), Some(30), None).unwrap(),
-      BytesPosition::new(Some(31), Some(33), None).unwrap(),
-      BytesPosition::new(Some(35), None, None).unwrap(),
+      BytesPosition::builder().with_end(1).build().unwrap(),
+      BytesPosition::builder()
+        .with_start(1)
+        .with_end(2)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(5)
+        .with_end(6)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(5)
+        .with_end(8)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(6)
+        .with_end(7)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(4)
+        .with_end(5)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(3)
+        .with_end(6)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(10)
+        .with_end(12)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(10)
+        .with_end(12)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(10)
+        .with_end(14)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(14)
+        .with_end(15)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(12)
+        .with_end(16)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(17)
+        .with_end(19)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(21)
+        .with_end(23)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(18)
+        .with_end(22)
+        .build()
+        .unwrap(),
+      BytesPosition::builder().with_start(24).build().unwrap(),
+      BytesPosition::builder()
+        .with_start(24)
+        .with_end(30)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(31)
+        .with_end(33)
+        .build()
+        .unwrap(),
+      BytesPosition::builder().with_start(35).build().unwrap(),
     ];
 
     let expected_ranges = vec![
-      BytesPosition::new(None, Some(2), None).unwrap(),
-      BytesPosition::new(Some(3), Some(8), None).unwrap(),
-      BytesPosition::new(Some(10), Some(16), None).unwrap(),
-      BytesPosition::new(Some(17), Some(23), None).unwrap(),
-      BytesPosition::new(Some(24), None, None).unwrap(),
+      BytesPosition::builder().with_end(2).build().unwrap(),
+      BytesPosition::builder()
+        .with_start(3)
+        .with_end(8)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(10)
+        .with_end(16)
+        .build()
+        .unwrap(),
+      BytesPosition::builder()
+        .with_start(17)
+        .with_end(23)
+        .build()
+        .unwrap(),
+      BytesPosition::builder().with_start(24).build().unwrap(),
     ];
 
     assert_eq!(BytesPosition::merge_all(ranges), expected_ranges);
@@ -768,7 +1159,12 @@ mod tests {
 
   #[test]
   fn bytes_position_new() {
-    let result = BytesPosition::new(Some(1), Some(2), Some(Class::Header)).unwrap();
+    let result = BytesPosition::builder()
+      .with_start(1)
+      .with_end(2)
+      .with_class(Class::Header)
+      .build()
+      .unwrap();
     assert_eq!(result.start, Some(1));
     assert_eq!(result.end, Some(2));
     assert_eq!(result.class, Some(Class::Header));
@@ -776,13 +1172,13 @@ mod tests {
 
   #[test]
   fn bytes_position_with_start() {
-    let result = BytesPosition::default().with_start(1).unwrap();
+    let result = BytesPosition::builder().with_start(1).build().unwrap();
     assert_eq!(result.start, Some(1));
   }
 
   #[test]
   fn bytes_position_with_end() {
-    let result = BytesPosition::default().with_end(1).unwrap();
+    let result = BytesPosition::builder().with_end(1).build().unwrap();
     assert_eq!(result.end, Some(1));
   }
 
@@ -801,7 +1197,13 @@ mod tests {
   #[test]
   fn data_block_update_classes_all_some() {
     let blocks = DataBlock::update_classes(vec![
-      DataBlock::Range(BytesPosition::new(None, Some(1), Some(Class::Body)).unwrap()),
+      DataBlock::Range(
+        BytesPosition::builder()
+          .with_end(1)
+          .with_class(Class::Body)
+          .build()
+          .unwrap(),
+      ),
       DataBlock::Data(vec![], Some(Class::Header)),
     ]);
     for block in blocks {
@@ -816,7 +1218,13 @@ mod tests {
   #[test]
   fn data_block_update_classes_one_none() {
     let blocks = DataBlock::update_classes(vec![
-      DataBlock::Range(BytesPosition::new(None, Some(1), Some(Class::Body)).unwrap()),
+      DataBlock::Range(
+        BytesPosition::builder()
+          .with_end(1)
+          .with_class(Class::Body)
+          .build()
+          .unwrap(),
+      ),
       DataBlock::Data(vec![], None),
     ]);
     for block in blocks {
@@ -831,36 +1239,69 @@ mod tests {
   #[test]
   fn data_block_from_bytes_positions() {
     let blocks = DataBlock::from_bytes_positions(vec![
-      BytesPosition::new(None, Some(1), None).unwrap(),
-      BytesPosition::new(Some(1), Some(2), None).unwrap(),
+      BytesPosition::builder().with_end(1).build().unwrap(),
+      BytesPosition::builder()
+        .with_start(1)
+        .with_end(2)
+        .build()
+        .unwrap(),
     ]);
     assert_eq!(
       blocks,
       vec![DataBlock::Range(
-        BytesPosition::new(None, Some(2), None).unwrap()
+        BytesPosition::builder().with_end(2).build().unwrap()
       )]
     );
   }
 
   #[test]
   fn data_block_from_empty_bytes_positions() {
-    let blocks =
-      DataBlock::from_bytes_positions(vec![BytesPosition::new(Some(0), Some(0), None).unwrap()]);
+    let blocks = DataBlock::from_bytes_positions(vec![
+      BytesPosition::builder()
+        .with_start(0)
+        .with_end(0)
+        .build()
+        .unwrap(),
+    ]);
     assert_eq!(blocks, vec![]);
   }
 
   #[test]
   fn data_block_is_empty() {
-    assert!(DataBlock::Range(BytesPosition::new(Some(0), Some(0), None).unwrap()).is_empty());
+    assert!(
+      DataBlock::Range(
+        BytesPosition::builder()
+          .with_start(0)
+          .with_end(0)
+          .build()
+          .unwrap()
+      )
+      .is_empty()
+    );
     assert!(DataBlock::Data(vec![], None).is_empty());
-    assert!(!DataBlock::Range(BytesPosition::new(Some(0), Some(1), None).unwrap()).is_empty());
+    assert!(
+      !DataBlock::Range(
+        BytesPosition::builder()
+          .with_start(0)
+          .with_end(1)
+          .build()
+          .unwrap()
+      )
+      .is_empty()
+    );
     assert!(!DataBlock::Data(vec![0], None).is_empty());
   }
 
   #[test]
   fn byte_range_from_byte_position() {
-    let result =
-      BytesRange::try_from(&BytesPosition::new(Some(5), Some(10), None).unwrap()).unwrap();
+    let result = BytesRange::try_from(
+      &BytesPosition::builder()
+        .with_start(5)
+        .with_end(10)
+        .build()
+        .unwrap(),
+    )
+    .unwrap();
     let expected = BytesRange::new(Some(5), Some(9));
     assert_eq!(result, expected);
   }
@@ -873,36 +1314,67 @@ mod tests {
       .unwrap();
     assert_eq!(
       result.range(),
-      &BytesPosition::new(Some(0), Some(1), None).unwrap()
+      &BytesPosition::builder()
+        .with_start(0)
+        .with_end(1)
+        .build()
+        .unwrap()
     );
   }
 
   #[test]
   fn get_options_with_range() {
     let request_headers = Default::default();
-    let result = GetOptions::new_with_default_range(&request_headers)
-      .with_range(BytesPosition::new(Some(5), Some(11), Some(Class::Header)).unwrap());
+    let result = GetOptions::new_with_default_range(&request_headers).with_range(
+      BytesPosition::builder()
+        .with_start(5)
+        .with_end(11)
+        .with_class(Class::Header)
+        .build()
+        .unwrap(),
+    );
     assert_eq!(
       result.range(),
-      &BytesPosition::new(Some(5), Some(11), Some(Class::Header)).unwrap()
+      &BytesPosition::builder()
+        .with_start(5)
+        .with_end(11)
+        .with_class(Class::Header)
+        .build()
+        .unwrap()
     );
   }
 
   #[test]
   fn url_options_with_range() {
     let request_headers = Default::default();
-    let result = RangeUrlOptions::new_with_default_range(&request_headers)
-      .with_range(BytesPosition::new(Some(5), Some(11), Some(Class::Header)).unwrap());
+    let result = RangeUrlOptions::new_with_default_range(&request_headers).with_range(
+      BytesPosition::builder()
+        .with_start(5)
+        .with_end(11)
+        .with_class(Class::Header)
+        .build()
+        .unwrap(),
+    );
     assert_eq!(
       result.range(),
-      &BytesPosition::new(Some(5), Some(11), Some(Class::Header)).unwrap()
+      &BytesPosition::builder()
+        .with_start(5)
+        .with_end(11)
+        .with_class(Class::Header)
+        .build()
+        .unwrap()
     );
   }
 
   #[test]
   fn url_options_apply_with_bytes_range() {
     let result = RangeUrlOptions::new(
-      BytesPosition::new(Some(5), Some(11), Some(Class::Header)).unwrap(),
+      BytesPosition::builder()
+        .with_start(5)
+        .with_end(11)
+        .with_class(Class::Header)
+        .build()
+        .unwrap(),
       &Default::default(),
     )
     .apply(Url::new(""))
@@ -927,7 +1399,12 @@ mod tests {
   #[test]
   fn url_options_apply_with_headers() {
     let result = RangeUrlOptions::new(
-      BytesPosition::new(Some(5), Some(11), Some(Class::Header)).unwrap(),
+      BytesPosition::builder()
+        .with_start(5)
+        .with_end(11)
+        .with_class(Class::Header)
+        .build()
+        .unwrap(),
       &Default::default(),
     )
     .apply(Url::new("").with_headers(Headers::default().with_header("header", "value")))

--- a/htsget-storage/src/types.rs
+++ b/htsget-storage/src/types.rs
@@ -1,3 +1,4 @@
+use crate::error::{Result, StorageError};
 use htsget_config::types::{Class, Headers, Url};
 use http::HeaderMap;
 use std::borrow::Cow;
@@ -20,6 +21,14 @@ impl DataBlock {
       .into_iter()
       .map(DataBlock::Range)
       .collect()
+  }
+
+  /// Check whether this block is empty.
+  pub fn is_empty(&self) -> bool {
+    match self {
+      DataBlock::Range(range) => range.is_empty(),
+      DataBlock::Data(data, _) => data.is_empty(),
+    }
   }
 
   /// Update the classes of all blocks so that they all contain a class, or None. Does not merge
@@ -49,9 +58,9 @@ impl DataBlock {
 /// with a mix of header and body bytes.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BytesPosition {
-  pub(crate) start: Option<u64>,
-  pub(crate) end: Option<u64>,
-  pub(crate) class: Option<Class>,
+  start: Option<u64>,
+  end: Option<u64>,
+  class: Option<Class>,
 }
 
 /// A bytes range has an inclusive start and end value. This is analogous to http bytes ranges.
@@ -81,9 +90,17 @@ impl Display for BytesRange {
   }
 }
 
-impl From<&BytesPosition> for BytesRange {
-  fn from(pos: &BytesPosition) -> Self {
-    Self::new(pos.start, pos.end.map(|value| value - 1))
+impl TryFrom<&BytesPosition> for BytesRange {
+  type Error = StorageError;
+
+  fn try_from(pos: &BytesPosition) -> Result<Self> {
+    if pos.is_empty() {
+      return Err(StorageError::InternalError(format!(
+        "cannot convert a bytes position with no bytes to a bytes range: {pos:?}"
+      )));
+    }
+
+    Ok(Self::new(pos.start, pos.end.map(|value| value - 1)))
   }
 }
 
@@ -94,22 +111,38 @@ impl BytesRange {
 }
 
 impl BytesPosition {
-  pub fn new(start: Option<u64>, end: Option<u64>, class: Option<Class>) -> Self {
-    Self { start, end, class }
+  /// Create a new bytes position. Returns an error if the end is less than the start.
+  /// An empty `BytesPosition` is allowed by setting the start and end to the same value.
+  pub fn new(start: Option<u64>, end: Option<u64>, class: Option<Class>) -> Result<Self> {
+    Self { start, end, class }.validate()
   }
 
-  pub fn with_start(mut self, start: u64) -> Self {
+  /// Validate that the end is greater than the start.
+  fn validate(self) -> Result<Self> {
+    if self
+      .end
+      .is_some_and(|end| end < self.start.unwrap_or_default())
+    {
+      return Err(StorageError::InternalError(format!(
+        "invalid bytes position {self:?}"
+      )));
+    }
+
+    Ok(self)
+  }
+
+  pub fn with_start(mut self, start: u64) -> Result<Self> {
     self.start = Some(start);
-    self
+    self.validate()
   }
 
-  pub fn with_end(self, end: u64) -> Self {
+  pub fn with_end(self, end: u64) -> Result<Self> {
     self.set_end(Some(end))
   }
 
-  pub fn set_end(mut self, end: Option<u64>) -> Self {
+  pub fn set_end(mut self, end: Option<u64>) -> Result<Self> {
     self.end = end;
-    self
+    self.validate()
   }
 
   pub fn with_class(self, class: Class) -> Self {
@@ -127,6 +160,17 @@ impl BytesPosition {
 
   pub fn get_end(&self) -> Option<u64> {
     self.end
+  }
+
+  pub fn get_class(&self) -> Option<Class> {
+    self.class
+  }
+
+  /// Check whether this position selects no bytes, i.e. the end == start.
+  pub fn is_empty(&self) -> bool {
+    self
+      .end
+      .is_some_and(|end| end == self.start.unwrap_or_default())
   }
 
   pub fn overlaps(&self, range: &BytesPosition) -> bool {
@@ -167,6 +211,8 @@ impl BytesPosition {
   /// Merge ranges, assuming ending byte ranges are exclusive.
   #[instrument(level = "trace", ret)]
   pub fn merge_all(mut ranges: Vec<BytesPosition>) -> Vec<BytesPosition> {
+    ranges.retain(|range| !range.is_empty());
+
     if ranges.len() < 2 {
       ranges
     } else {
@@ -221,9 +267,11 @@ impl<'a> GetOptions<'a> {
     Self::new(Default::default(), request_headers)
   }
 
-  pub fn with_max_length(mut self, max_length: u64) -> Self {
-    self.range = BytesPosition::default().with_start(0).with_end(max_length);
-    self
+  pub fn with_max_length(mut self, max_length: u64) -> Result<Self> {
+    self.range = BytesPosition::default()
+      .with_start(0)?
+      .with_end(max_length)?;
+    Ok(self)
   }
 
   pub fn with_range(mut self, range: BytesPosition) -> Self {
@@ -302,8 +350,8 @@ impl<'a> RangeUrlOptions<'a> {
     self
   }
 
-  pub fn apply(self, url: Url) -> Url {
-    let range: String = String::from(&BytesRange::from(self.range()));
+  pub fn apply(self, url: Url) -> Result<Url> {
+    let range: String = String::from(&BytesRange::try_from(self.range())?);
 
     let url = if range.is_empty() {
       url
@@ -311,7 +359,7 @@ impl<'a> RangeUrlOptions<'a> {
       url.add_headers(Headers::default().with_header("Range", range))
     };
 
-    url.set_class(self.range().class)
+    Ok(url.set_class(self.range().class))
   }
 
   /// Get the range.
@@ -359,194 +407,194 @@ mod tests {
   fn bytes_range_overlapping_and_merge() {
     let test_cases = vec![
       (
-        BytesPosition::new(None, Some(2), None),
-        BytesPosition::new(Some(3), Some(5), None),
+        BytesPosition::new(None, Some(2), None).unwrap(),
+        BytesPosition::new(Some(3), Some(5), None).unwrap(),
         None,
       ),
       (
-        BytesPosition::new(None, Some(2), None),
-        BytesPosition::new(Some(3), None, None),
+        BytesPosition::new(None, Some(2), None).unwrap(),
+        BytesPosition::new(Some(3), None, None).unwrap(),
         None,
       ),
       (
-        BytesPosition::new(None, Some(2), None),
-        BytesPosition::new(Some(2), Some(4), None),
-        Some(BytesPosition::new(None, Some(4), None)),
+        BytesPosition::new(None, Some(2), None).unwrap(),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        Some(BytesPosition::new(None, Some(4), None).unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None),
-        BytesPosition::new(Some(2), None, None),
-        Some(BytesPosition::new(None, None, None)),
+        BytesPosition::new(None, Some(2), None).unwrap(),
+        BytesPosition::new(Some(2), None, None).unwrap(),
+        Some(BytesPosition::new(None, None, None).unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None),
-        BytesPosition::new(Some(1), Some(3), None),
-        Some(BytesPosition::new(None, Some(3), None)),
+        BytesPosition::new(None, Some(2), None).unwrap(),
+        BytesPosition::new(Some(1), Some(3), None).unwrap(),
+        Some(BytesPosition::new(None, Some(3), None).unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None),
-        BytesPosition::new(Some(1), None, None),
-        Some(BytesPosition::new(None, None, None)),
+        BytesPosition::new(None, Some(2), None).unwrap(),
+        BytesPosition::new(Some(1), None, None).unwrap(),
+        Some(BytesPosition::new(None, None, None).unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None),
-        BytesPosition::new(Some(0), Some(2), None),
-        Some(BytesPosition::new(None, Some(2), None)),
+        BytesPosition::new(None, Some(2), None).unwrap(),
+        BytesPosition::new(Some(0), Some(2), None).unwrap(),
+        Some(BytesPosition::new(None, Some(2), None).unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None),
-        BytesPosition::new(None, Some(2), None),
-        Some(BytesPosition::new(None, Some(2), None)),
+        BytesPosition::new(None, Some(2), None).unwrap(),
+        BytesPosition::new(None, Some(2), None).unwrap(),
+        Some(BytesPosition::new(None, Some(2), None).unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None),
-        BytesPosition::new(Some(0), Some(1), None),
-        Some(BytesPosition::new(None, Some(2), None)),
+        BytesPosition::new(None, Some(2), None).unwrap(),
+        BytesPosition::new(Some(0), Some(1), None).unwrap(),
+        Some(BytesPosition::new(None, Some(2), None).unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None),
-        BytesPosition::new(None, Some(1), None),
-        Some(BytesPosition::new(None, Some(2), None)),
+        BytesPosition::new(None, Some(2), None).unwrap(),
+        BytesPosition::new(None, Some(1), None).unwrap(),
+        Some(BytesPosition::new(None, Some(2), None).unwrap()),
       ),
       (
-        BytesPosition::new(None, Some(2), None),
-        BytesPosition::new(None, None, None),
-        Some(BytesPosition::new(None, None, None)),
+        BytesPosition::new(None, Some(2), None).unwrap(),
+        BytesPosition::new(None, None, None).unwrap(),
+        Some(BytesPosition::new(None, None, None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None),
-        BytesPosition::new(Some(6), Some(8), None),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        BytesPosition::new(Some(6), Some(8), None).unwrap(),
         None,
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None),
-        BytesPosition::new(Some(6), None, None),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        BytesPosition::new(Some(6), None, None).unwrap(),
         None,
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None),
-        BytesPosition::new(Some(4), Some(6), None),
-        Some(BytesPosition::new(Some(2), Some(6), None)),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        BytesPosition::new(Some(4), Some(6), None).unwrap(),
+        Some(BytesPosition::new(Some(2), Some(6), None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None),
-        BytesPosition::new(Some(4), None, None),
-        Some(BytesPosition::new(Some(2), None, None)),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        BytesPosition::new(Some(4), None, None).unwrap(),
+        Some(BytesPosition::new(Some(2), None, None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None),
-        BytesPosition::new(Some(3), Some(5), None),
-        Some(BytesPosition::new(Some(2), Some(5), None)),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        BytesPosition::new(Some(3), Some(5), None).unwrap(),
+        Some(BytesPosition::new(Some(2), Some(5), None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None),
-        BytesPosition::new(Some(3), None, None),
-        Some(BytesPosition::new(Some(2), None, None)),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        BytesPosition::new(Some(3), None, None).unwrap(),
+        Some(BytesPosition::new(Some(2), None, None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None),
-        BytesPosition::new(Some(2), Some(3), None),
-        Some(BytesPosition::new(Some(2), Some(4), None)),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        BytesPosition::new(Some(2), Some(3), None).unwrap(),
+        Some(BytesPosition::new(Some(2), Some(4), None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None),
-        BytesPosition::new(None, Some(3), None),
-        Some(BytesPosition::new(None, Some(4), None)),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        BytesPosition::new(None, Some(3), None).unwrap(),
+        Some(BytesPosition::new(None, Some(4), None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None),
-        BytesPosition::new(Some(1), Some(3), None),
-        Some(BytesPosition::new(Some(1), Some(4), None)),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        BytesPosition::new(Some(1), Some(3), None).unwrap(),
+        Some(BytesPosition::new(Some(1), Some(4), None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None),
-        BytesPosition::new(None, Some(3), None),
-        Some(BytesPosition::new(None, Some(4), None)),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        BytesPosition::new(None, Some(3), None).unwrap(),
+        Some(BytesPosition::new(None, Some(4), None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None),
-        BytesPosition::new(Some(0), Some(2), None),
-        Some(BytesPosition::new(Some(0), Some(4), None)),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        BytesPosition::new(Some(0), Some(2), None).unwrap(),
+        Some(BytesPosition::new(Some(0), Some(4), None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None),
-        BytesPosition::new(None, Some(2), None),
-        Some(BytesPosition::new(None, Some(4), None)),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        BytesPosition::new(None, Some(2), None).unwrap(),
+        Some(BytesPosition::new(None, Some(4), None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None),
-        BytesPosition::new(Some(0), Some(1), None),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        BytesPosition::new(Some(0), Some(1), None).unwrap(),
         None,
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None),
-        BytesPosition::new(None, Some(1), None),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        BytesPosition::new(None, Some(1), None).unwrap(),
         None,
       ),
       (
-        BytesPosition::new(Some(2), Some(4), None),
-        BytesPosition::new(None, None, None),
-        Some(BytesPosition::new(None, None, None)),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        BytesPosition::new(None, None, None).unwrap(),
+        Some(BytesPosition::new(None, None, None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None),
-        BytesPosition::new(Some(4), Some(6), None),
-        Some(BytesPosition::new(Some(2), None, None)),
+        BytesPosition::new(Some(2), None, None).unwrap(),
+        BytesPosition::new(Some(4), Some(6), None).unwrap(),
+        Some(BytesPosition::new(Some(2), None, None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None),
-        BytesPosition::new(Some(4), None, None),
-        Some(BytesPosition::new(Some(2), None, None)),
+        BytesPosition::new(Some(2), None, None).unwrap(),
+        BytesPosition::new(Some(4), None, None).unwrap(),
+        Some(BytesPosition::new(Some(2), None, None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None),
-        BytesPosition::new(Some(2), Some(4), None),
-        Some(BytesPosition::new(Some(2), None, None)),
+        BytesPosition::new(Some(2), None, None).unwrap(),
+        BytesPosition::new(Some(2), Some(4), None).unwrap(),
+        Some(BytesPosition::new(Some(2), None, None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None),
-        BytesPosition::new(Some(2), None, None),
-        Some(BytesPosition::new(Some(2), None, None)),
+        BytesPosition::new(Some(2), None, None).unwrap(),
+        BytesPosition::new(Some(2), None, None).unwrap(),
+        Some(BytesPosition::new(Some(2), None, None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None),
-        BytesPosition::new(Some(1), Some(3), None),
-        Some(BytesPosition::new(Some(1), None, None)),
+        BytesPosition::new(Some(2), None, None).unwrap(),
+        BytesPosition::new(Some(1), Some(3), None).unwrap(),
+        Some(BytesPosition::new(Some(1), None, None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None),
-        BytesPosition::new(None, Some(3), None),
-        Some(BytesPosition::new(None, None, None)),
+        BytesPosition::new(Some(2), None, None).unwrap(),
+        BytesPosition::new(None, Some(3), None).unwrap(),
+        Some(BytesPosition::new(None, None, None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None),
-        BytesPosition::new(Some(0), Some(2), None),
-        Some(BytesPosition::new(Some(0), None, None)),
+        BytesPosition::new(Some(2), None, None).unwrap(),
+        BytesPosition::new(Some(0), Some(2), None).unwrap(),
+        Some(BytesPosition::new(Some(0), None, None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None),
-        BytesPosition::new(None, Some(2), None),
-        Some(BytesPosition::new(None, None, None)),
+        BytesPosition::new(Some(2), None, None).unwrap(),
+        BytesPosition::new(None, Some(2), None).unwrap(),
+        Some(BytesPosition::new(None, None, None).unwrap()),
       ),
       (
-        BytesPosition::new(Some(2), None, None),
-        BytesPosition::new(Some(0), Some(1), None),
+        BytesPosition::new(Some(2), None, None).unwrap(),
+        BytesPosition::new(Some(0), Some(1), None).unwrap(),
         None,
       ),
       (
-        BytesPosition::new(Some(2), None, None),
-        BytesPosition::new(None, Some(1), None),
+        BytesPosition::new(Some(2), None, None).unwrap(),
+        BytesPosition::new(None, Some(1), None).unwrap(),
         None,
       ),
       (
-        BytesPosition::new(Some(2), None, None),
-        BytesPosition::new(None, None, None),
-        Some(BytesPosition::new(None, None, None)),
+        BytesPosition::new(Some(2), None, None).unwrap(),
+        BytesPosition::new(None, None, None).unwrap(),
+        Some(BytesPosition::new(None, None, None).unwrap()),
       ),
       (
-        BytesPosition::new(None, None, None),
-        BytesPosition::new(None, None, None),
-        Some(BytesPosition::new(None, None, None)),
+        BytesPosition::new(None, None, None).unwrap(),
+        BytesPosition::new(None, None, None).unwrap(),
+        Some(BytesPosition::new(None, None, None).unwrap()),
       ),
     ];
 
@@ -570,6 +618,68 @@ mod tests {
   }
 
   #[test]
+  fn bytes_range_merge_all_removes_empty_positions() {
+    assert_eq!(
+      BytesPosition::merge_all(vec![
+        BytesPosition::new(Some(0), Some(0), None).unwrap(),
+        BytesPosition::new(Some(5), Some(5), None).unwrap(),
+        BytesPosition::new(Some(1), Some(2), None).unwrap(),
+      ]),
+      vec![BytesPosition::new(Some(1), Some(2), None).unwrap()]
+    );
+  }
+
+  #[test]
+  fn bytes_position_is_empty() {
+    assert!(
+      BytesPosition::new(Some(0), Some(0), None)
+        .unwrap()
+        .is_empty()
+    );
+    assert!(BytesPosition::new(None, Some(0), None).unwrap().is_empty());
+    assert!(
+      !BytesPosition::new(Some(0), Some(1), None)
+        .unwrap()
+        .is_empty()
+    );
+    assert!(!BytesPosition::new(Some(1), None, None).unwrap().is_empty());
+    assert!(!BytesPosition::new(None, None, None).unwrap().is_empty());
+  }
+
+  #[test]
+  fn bytes_position_end_less_than_start() {
+    assert!(BytesPosition::new(Some(2), Some(1), None).is_err());
+    assert!(BytesPosition::new(None, Some(1), None).is_ok());
+    assert!(
+      BytesPosition::default()
+        .with_end(2)
+        .unwrap()
+        .with_start(3)
+        .is_err()
+    );
+    assert!(
+      BytesPosition::default()
+        .with_start(3)
+        .unwrap()
+        .with_end(2)
+        .is_err()
+    );
+    assert!(
+      BytesPosition::default()
+        .with_start(3)
+        .unwrap()
+        .set_end(Some(2))
+        .is_err()
+    );
+  }
+
+  #[test]
+  fn bytes_range_try_from_empty_position() {
+    assert!(BytesRange::try_from(&BytesPosition::new(Some(5), Some(5), None).unwrap()).is_err());
+    assert!(BytesRange::try_from(&BytesPosition::new(None, Some(0), None).unwrap()).is_err());
+  }
+
+  #[test]
   fn bytes_range_merge_all_when_list_has_one_range() {
     assert_eq!(
       BytesPosition::merge_all(vec![BytesPosition::default()]),
@@ -581,10 +691,10 @@ mod tests {
   fn bytes_position_merge_class_header() {
     assert_eq!(
       BytesPosition::merge_all(vec![
-        BytesPosition::new(None, Some(1), Some(Class::Header)),
-        BytesPosition::new(None, Some(2), Some(Class::Header))
+        BytesPosition::new(None, Some(1), Some(Class::Header)).unwrap(),
+        BytesPosition::new(None, Some(2), Some(Class::Header)).unwrap()
       ]),
-      vec![BytesPosition::new(None, Some(2), Some(Class::Header))]
+      vec![BytesPosition::new(None, Some(2), Some(Class::Header)).unwrap()]
     );
   }
 
@@ -592,10 +702,10 @@ mod tests {
   fn bytes_position_merge_class_body() {
     assert_eq!(
       BytesPosition::merge_all(vec![
-        BytesPosition::new(None, Some(1), Some(Class::Body)),
-        BytesPosition::new(None, Some(3), Some(Class::Body))
+        BytesPosition::new(None, Some(1), Some(Class::Body)).unwrap(),
+        BytesPosition::new(None, Some(3), Some(Class::Body)).unwrap()
       ]),
-      vec![BytesPosition::new(None, Some(3), Some(Class::Body))]
+      vec![BytesPosition::new(None, Some(3), Some(Class::Body)).unwrap()]
     );
   }
 
@@ -603,10 +713,10 @@ mod tests {
   fn bytes_position_merge_class_none() {
     assert_eq!(
       BytesPosition::merge_all(vec![
-        BytesPosition::new(Some(1), Some(2), None),
-        BytesPosition::new(Some(2), Some(3), None)
+        BytesPosition::new(Some(1), Some(2), None).unwrap(),
+        BytesPosition::new(Some(2), Some(3), None).unwrap()
       ]),
-      vec![BytesPosition::new(Some(1), Some(3), None)]
+      vec![BytesPosition::new(Some(1), Some(3), None).unwrap()]
     );
   }
 
@@ -614,43 +724,43 @@ mod tests {
   fn bytes_position_merge_class_different() {
     assert_eq!(
       BytesPosition::merge_all(vec![
-        BytesPosition::new(Some(1), Some(2), Some(Class::Header)),
-        BytesPosition::new(Some(2), Some(3), Some(Class::Body))
+        BytesPosition::new(Some(1), Some(2), Some(Class::Header)).unwrap(),
+        BytesPosition::new(Some(2), Some(3), Some(Class::Body)).unwrap()
       ]),
-      vec![BytesPosition::new(Some(1), Some(3), None)]
+      vec![BytesPosition::new(Some(1), Some(3), None).unwrap()]
     );
   }
 
   #[test]
   fn bytes_range_merge_all_when_list_has_many_ranges() {
     let ranges = vec![
-      BytesPosition::new(None, Some(1), None),
-      BytesPosition::new(Some(1), Some(2), None),
-      BytesPosition::new(Some(5), Some(6), None),
-      BytesPosition::new(Some(5), Some(8), None),
-      BytesPosition::new(Some(6), Some(7), None),
-      BytesPosition::new(Some(4), Some(5), None),
-      BytesPosition::new(Some(3), Some(6), None),
-      BytesPosition::new(Some(10), Some(12), None),
-      BytesPosition::new(Some(10), Some(12), None),
-      BytesPosition::new(Some(10), Some(14), None),
-      BytesPosition::new(Some(14), Some(15), None),
-      BytesPosition::new(Some(12), Some(16), None),
-      BytesPosition::new(Some(17), Some(19), None),
-      BytesPosition::new(Some(21), Some(23), None),
-      BytesPosition::new(Some(18), Some(22), None),
-      BytesPosition::new(Some(24), None, None),
-      BytesPosition::new(Some(24), Some(30), None),
-      BytesPosition::new(Some(31), Some(33), None),
-      BytesPosition::new(Some(35), None, None),
+      BytesPosition::new(None, Some(1), None).unwrap(),
+      BytesPosition::new(Some(1), Some(2), None).unwrap(),
+      BytesPosition::new(Some(5), Some(6), None).unwrap(),
+      BytesPosition::new(Some(5), Some(8), None).unwrap(),
+      BytesPosition::new(Some(6), Some(7), None).unwrap(),
+      BytesPosition::new(Some(4), Some(5), None).unwrap(),
+      BytesPosition::new(Some(3), Some(6), None).unwrap(),
+      BytesPosition::new(Some(10), Some(12), None).unwrap(),
+      BytesPosition::new(Some(10), Some(12), None).unwrap(),
+      BytesPosition::new(Some(10), Some(14), None).unwrap(),
+      BytesPosition::new(Some(14), Some(15), None).unwrap(),
+      BytesPosition::new(Some(12), Some(16), None).unwrap(),
+      BytesPosition::new(Some(17), Some(19), None).unwrap(),
+      BytesPosition::new(Some(21), Some(23), None).unwrap(),
+      BytesPosition::new(Some(18), Some(22), None).unwrap(),
+      BytesPosition::new(Some(24), None, None).unwrap(),
+      BytesPosition::new(Some(24), Some(30), None).unwrap(),
+      BytesPosition::new(Some(31), Some(33), None).unwrap(),
+      BytesPosition::new(Some(35), None, None).unwrap(),
     ];
 
     let expected_ranges = vec![
-      BytesPosition::new(None, Some(2), None),
-      BytesPosition::new(Some(3), Some(8), None),
-      BytesPosition::new(Some(10), Some(16), None),
-      BytesPosition::new(Some(17), Some(23), None),
-      BytesPosition::new(Some(24), None, None),
+      BytesPosition::new(None, Some(2), None).unwrap(),
+      BytesPosition::new(Some(3), Some(8), None).unwrap(),
+      BytesPosition::new(Some(10), Some(16), None).unwrap(),
+      BytesPosition::new(Some(17), Some(23), None).unwrap(),
+      BytesPosition::new(Some(24), None, None).unwrap(),
     ];
 
     assert_eq!(BytesPosition::merge_all(ranges), expected_ranges);
@@ -658,7 +768,7 @@ mod tests {
 
   #[test]
   fn bytes_position_new() {
-    let result = BytesPosition::new(Some(1), Some(2), Some(Class::Header));
+    let result = BytesPosition::new(Some(1), Some(2), Some(Class::Header)).unwrap();
     assert_eq!(result.start, Some(1));
     assert_eq!(result.end, Some(2));
     assert_eq!(result.class, Some(Class::Header));
@@ -666,13 +776,13 @@ mod tests {
 
   #[test]
   fn bytes_position_with_start() {
-    let result = BytesPosition::default().with_start(1);
+    let result = BytesPosition::default().with_start(1).unwrap();
     assert_eq!(result.start, Some(1));
   }
 
   #[test]
   fn bytes_position_with_end() {
-    let result = BytesPosition::default().with_end(1);
+    let result = BytesPosition::default().with_end(1).unwrap();
     assert_eq!(result.end, Some(1));
   }
 
@@ -691,7 +801,7 @@ mod tests {
   #[test]
   fn data_block_update_classes_all_some() {
     let blocks = DataBlock::update_classes(vec![
-      DataBlock::Range(BytesPosition::new(None, Some(1), Some(Class::Body))),
+      DataBlock::Range(BytesPosition::new(None, Some(1), Some(Class::Body)).unwrap()),
       DataBlock::Data(vec![], Some(Class::Header)),
     ]);
     for block in blocks {
@@ -706,7 +816,7 @@ mod tests {
   #[test]
   fn data_block_update_classes_one_none() {
     let blocks = DataBlock::update_classes(vec![
-      DataBlock::Range(BytesPosition::new(None, Some(1), Some(Class::Body))),
+      DataBlock::Range(BytesPosition::new(None, Some(1), Some(Class::Body)).unwrap()),
       DataBlock::Data(vec![], None),
     ]);
     for block in blocks {
@@ -721,18 +831,36 @@ mod tests {
   #[test]
   fn data_block_from_bytes_positions() {
     let blocks = DataBlock::from_bytes_positions(vec![
-      BytesPosition::new(None, Some(1), None),
-      BytesPosition::new(Some(1), Some(2), None),
+      BytesPosition::new(None, Some(1), None).unwrap(),
+      BytesPosition::new(Some(1), Some(2), None).unwrap(),
     ]);
     assert_eq!(
       blocks,
-      vec![DataBlock::Range(BytesPosition::new(None, Some(2), None))]
+      vec![DataBlock::Range(
+        BytesPosition::new(None, Some(2), None).unwrap()
+      )]
     );
   }
 
   #[test]
+  fn data_block_from_empty_bytes_positions() {
+    let blocks =
+      DataBlock::from_bytes_positions(vec![BytesPosition::new(Some(0), Some(0), None).unwrap()]);
+    assert_eq!(blocks, vec![]);
+  }
+
+  #[test]
+  fn data_block_is_empty() {
+    assert!(DataBlock::Range(BytesPosition::new(Some(0), Some(0), None).unwrap()).is_empty());
+    assert!(DataBlock::Data(vec![], None).is_empty());
+    assert!(!DataBlock::Range(BytesPosition::new(Some(0), Some(1), None).unwrap()).is_empty());
+    assert!(!DataBlock::Data(vec![0], None).is_empty());
+  }
+
+  #[test]
   fn byte_range_from_byte_position() {
-    let result: BytesRange = BytesRange::from(&BytesPosition::default().with_start(5).with_end(10));
+    let result =
+      BytesRange::try_from(&BytesPosition::new(Some(5), Some(10), None).unwrap()).unwrap();
     let expected = BytesRange::new(Some(5), Some(9));
     assert_eq!(result, expected);
   }
@@ -740,10 +868,12 @@ mod tests {
   #[test]
   fn get_options_with_max_length() {
     let request_headers = Default::default();
-    let result = GetOptions::new_with_default_range(&request_headers).with_max_length(1);
+    let result = GetOptions::new_with_default_range(&request_headers)
+      .with_max_length(1)
+      .unwrap();
     assert_eq!(
       result.range(),
-      &BytesPosition::default().with_start(0).with_end(1)
+      &BytesPosition::new(Some(0), Some(1), None).unwrap()
     );
   }
 
@@ -751,10 +881,10 @@ mod tests {
   fn get_options_with_range() {
     let request_headers = Default::default();
     let result = GetOptions::new_with_default_range(&request_headers)
-      .with_range(BytesPosition::new(Some(5), Some(11), Some(Class::Header)));
+      .with_range(BytesPosition::new(Some(5), Some(11), Some(Class::Header)).unwrap());
     assert_eq!(
       result.range(),
-      &BytesPosition::new(Some(5), Some(11), Some(Class::Header))
+      &BytesPosition::new(Some(5), Some(11), Some(Class::Header)).unwrap()
     );
   }
 
@@ -762,20 +892,21 @@ mod tests {
   fn url_options_with_range() {
     let request_headers = Default::default();
     let result = RangeUrlOptions::new_with_default_range(&request_headers)
-      .with_range(BytesPosition::new(Some(5), Some(11), Some(Class::Header)));
+      .with_range(BytesPosition::new(Some(5), Some(11), Some(Class::Header)).unwrap());
     assert_eq!(
       result.range(),
-      &BytesPosition::new(Some(5), Some(11), Some(Class::Header))
+      &BytesPosition::new(Some(5), Some(11), Some(Class::Header)).unwrap()
     );
   }
 
   #[test]
   fn url_options_apply_with_bytes_range() {
     let result = RangeUrlOptions::new(
-      BytesPosition::new(Some(5), Some(11), Some(Class::Header)),
+      BytesPosition::new(Some(5), Some(11), Some(Class::Header)).unwrap(),
       &Default::default(),
     )
-    .apply(Url::new(""));
+    .apply(Url::new(""))
+    .unwrap();
     println!("{result:?}");
     assert_eq!(
       result,
@@ -787,17 +918,20 @@ mod tests {
 
   #[test]
   fn url_options_apply_no_bytes_range() {
-    let result = RangeUrlOptions::new_with_default_range(&Default::default()).apply(Url::new(""));
+    let result = RangeUrlOptions::new_with_default_range(&Default::default())
+      .apply(Url::new(""))
+      .unwrap();
     assert_eq!(result, Url::new(""));
   }
 
   #[test]
   fn url_options_apply_with_headers() {
     let result = RangeUrlOptions::new(
-      BytesPosition::new(Some(5), Some(11), Some(Class::Header)),
+      BytesPosition::new(Some(5), Some(11), Some(Class::Header)).unwrap(),
       &Default::default(),
     )
-    .apply(Url::new("").with_headers(Headers::default().with_header("header", "value")));
+    .apply(Url::new("").with_headers(Headers::default().with_header("header", "value")))
+    .unwrap();
     println!("{result:?}");
 
     assert_eq!(

--- a/htsget-storage/src/url.rs
+++ b/htsget-storage/src/url.rs
@@ -120,7 +120,7 @@ impl UrlClient {
     let request_headers = self.filter_forward_headers(headers);
     let request = Request::builder().method(method).uri(&request_url);
 
-    let range = BytesRange::from(&position).to_string();
+    let range = BytesRange::try_from(&position)?.to_string();
     let request = request_headers
       .iter()
       .fold(request, |acc, (key, value)| acc.header(key, value));
@@ -171,7 +171,7 @@ impl UrlClient {
       )
     }
 
-    Ok(options.apply(url))
+    options.apply(url)
   }
 
   /// Extract the object size from a response.


### PR DESCRIPTION
Closes #363 

### Tests
* The tests were failing sometimes due to a race condition with `File::create` and `write_all`. This is now fixed.

### Fixes
I've also added a few checks to ensure that no invalid bytes can be produced.

Specifically:
* `BytesPosition` and `BytesRange` cannot have `end < start` in the constructor. `BytesPosition` is allowed to have end == start, which represents an empty range.
* This is now filtered out in multiple spots as empty ranges mean nothing should be fetched.
* `search.rs` uses `checked_sub` to avoid overflow errors
* C4GH `storage.rs` now checks if there are empty edit lists or file get/head requests, and it avoids processing invalid data.

I don't think any of these would have occurred in practice as it relies on invalid files as input, but I think it's good to have as a check because it means that htsget-rs holds its invariants more clearly. 