### PR TITLE
feat: allow no prefix on locations config

### DIFF
--- a/htsget-config/docs/schemas/auth.schema.json
+++ b/htsget-config/docs/schemas/auth.schema.json
@@ -73,27 +73,32 @@
         }
       },
       "unevaluatedProperties": false,
-      "oneOf": [
+      "anyOf": [
         {
-          "description": "Use prefix matching logic, where the requested id should start with the prefix.",
-          "type": "object",
-          "properties": {
-            "prefix": {
-              "type": "string"
+          "oneOf": [
+            {
+              "description": "Use prefix matching logic, where the requested id should start with the prefix.",
+              "type": "object",
+              "properties": {
+                "prefix": {
+                  "type": "string"
+                }
+              },
+              "required": ["prefix"]
+            },
+            {
+              "description": "Use exact id matching logic, where the requested id should be equal to this id.",
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              },
+              "required": ["id"]
             }
-          },
-          "required": ["prefix"]
+          ]
         },
-        {
-          "description": "Use exact id matching logic, where the requested id should be equal to this id.",
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string"
-            }
-          },
-          "required": ["id"]
-        }
+        {}
       ]
     },
     "RegexLocation": {

--- a/htsget-config/src/config/location.rs
+++ b/htsget-config/src/config/location.rs
@@ -250,7 +250,7 @@ struct StringLocation {
   location: Option<String>,
   /// The prefix or id match configuration.
   #[serde(flatten)]
-  prefix_or_id: PrefixOrId,
+  prefix_or_id: Option<PrefixOrId>,
 }
 
 /// Deserialize the location from a map with regular field and values.
@@ -312,7 +312,7 @@ impl TryFrom<LocationWrapper> for SimpleLocation {
         Ok(SimpleLocation::new(
           backend.0,
           backend.1,
-          Some(wrapper.prefix_or_id),
+          wrapper.prefix_or_id,
         ))
       }
       LocationWrapper::Map(wrapper) => Ok(SimpleLocation::new(
@@ -325,10 +325,10 @@ impl TryFrom<LocationWrapper> for SimpleLocation {
           if #[cfg(feature = "experimental")] {
             let mut backend: BackendWithAppend = wrapper.location.location.unwrap_or_default().try_into()?;
             backend.0.set_keys(wrapper.keys);
-            Ok(SimpleLocation::new(backend.0, backend.1, Some(wrapper.location.prefix_or_id)))
+            Ok(SimpleLocation::new(backend.0, backend.1, wrapper.location.prefix_or_id))
           } else {
             let backend: BackendWithAppend = wrapper.location.location.unwrap_or_default().try_into()?;
-            Ok(SimpleLocation::new(backend.0, backend.1, Some(wrapper.location.prefix_or_id)))
+            Ok(SimpleLocation::new(backend.0, backend.1, wrapper.location.prefix_or_id))
           }
         }
       }
@@ -461,6 +461,17 @@ mod tests {
     test_serialize_and_deserialize(
       r#"
       locations = "file://path/"
+      "#,
+      ("path".to_string(), "".to_string(), None),
+      |result: Config| assert_file_location(result),
+    );
+  }
+
+  #[test]
+  fn location_map_no_prefix() {
+    test_serialize_and_deserialize(
+      r#"
+      locations = [ { location = "file://path" } ]
       "#,
       ("path".to_string(), "".to_string(), None),
       |result: Config| assert_file_location(result),
@@ -680,6 +691,33 @@ mod tests {
               .as_prefix()
               .unwrap()
               .to_string(),
+          );
+        }
+
+        panic!();
+      },
+    );
+  }
+
+  #[cfg(feature = "aws")]
+  #[test]
+  fn location_s3_map_no_prefix() {
+    test_serialize_and_deserialize(
+      r#"
+      locations = [ { location = "s3://bucket" } ]
+      "#,
+      ("bucket".to_string(), None),
+      |result: Config| {
+        let result = result.locations.0;
+        assert_eq!(result.len(), 1);
+        if let Location::Simple(location) = result.first().unwrap()
+          && let Backend::S3(s3) = location.backend()
+        {
+          return (
+            s3.bucket().to_string(),
+            location
+              .prefix_or_id()
+              .and_then(|prefix| prefix.as_prefix().map(|prefix| prefix.to_string())),
           );
         }
 

--- a/htsget-config/src/config/mod.rs
+++ b/htsget-config/src/config/mod.rs
@@ -783,6 +783,22 @@ pub(crate) mod tests {
     );
   }
 
+  #[cfg(feature = "aws")]
+  #[test]
+  fn simple_locations_s3_env() {
+    test_config_from_env(
+      vec![("HTSGET_LOCATIONS", "[{location=s3://bucket}]")],
+      |config| {
+        assert_eq!(config.locations().len(), 1);
+        let config = config.locations.into_inner();
+        let location = config[0].as_simple().unwrap();
+        assert_eq!(location.prefix_or_id(), None);
+        assert!(matches!(location.backend(),
+            Backend::S3(s3) if s3.bucket() == "bucket"));
+      },
+    );
+  }
+
   #[cfg(feature = "url")]
   #[test]
   fn simple_locations_url() {


### PR DESCRIPTION
Closes #366 

### Changes
* Make the `prefix_or_id` optional on locations config.